### PR TITLE
Add msg handler wrapper for concurrent processing 

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
 )
@@ -49,7 +50,7 @@ type (
 )
 
 // BaseApp reflects the ABCI application implementation.
-type BaseApp struct { // nolint: maligned
+type BaseApp struct { //nolint: maligned
 	// initialized on creation
 	logger            log.Logger
 	name              string               // application name from abci.Info
@@ -771,6 +772,21 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	return gInfo, result, anteEvents, priority, err
 }
 
+// Waits for all dependent concurrent resource access operations to complete before handling
+// message. Defers completion signal to the end of the method once the real handler is called
+func wrappedHandler(ctx sdk.Context, msg sdk.Msg, handler sdk.Handler) (*sdk.Result, error) {
+	messageIndex := ctx.MessageIndex()
+
+	// Defer sending completion channels to the end of the message
+	defer acltypes.SendSignals(ctx.TxCompletionChannels()[messageIndex])
+
+	// Wait for signals to complete, this should be a blocking event
+	// TODO:: More granular waits on access time instead
+	acltypes.WaitForSignals(ctx.TxBlockingChannels()[messageIndex])
+
+	return handler(ctx, msg)
+}
+
 // runMsgs iterates through a list of messages and executes them with the provided
 // Context and execution mode. Messages will only be executed during simulation
 // and DeliverTx. An error is returned if any single message fails or if a
@@ -805,7 +821,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		if handler := app.msgServiceRouter.Handler(msg); handler != nil {
 			ctx = ctx.WithMessageIndex(i)
 			// ADR 031 request type routing
-			msgResult, err = handler(ctx, msg)
+			msgResult, err = wrappedHandler(ctx, msg, handler)
 			eventMsgName = sdk.MsgTypeURL(msg)
 		} else if legacyMsg, ok := msg.(legacytx.LegacyMsg); ok {
 			// legacy sdk.Msg routing

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -777,10 +777,10 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 func wrappedHandler(ctx sdk.Context, msg sdk.Msg, handler sdk.Handler) (*sdk.Result, error) {
 	messageIndex := ctx.MessageIndex()
 
-	// Defer sending completion channels to the end of the message
+	// Defer sending completion channels to the end of the message 
 	defer acltypes.SendSignals(ctx.TxCompletionChannels()[messageIndex])
 
-	// Wait for signals to complete, this should be a blocking event
+	// Wait for signals to complete, this should be blocking 
 	// TODO:: More granular waits on access time instead
 	acltypes.WaitForSignals(ctx.TxBlockingChannels()[messageIndex])
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -778,11 +778,11 @@ func wrappedHandler(ctx sdk.Context, msg sdk.Msg, handler sdk.Handler) (*sdk.Res
 	messageIndex := ctx.MessageIndex()
 
 	// Defer sending completion channels to the end of the message 
-	defer acltypes.SendSignals(ctx.TxCompletionChannels()[messageIndex])
+	defer acltypes.SendAllSignals(ctx.TxCompletionChannels()[messageIndex])
 
 	// Wait for signals to complete, this should be blocking 
 	// TODO:: More granular waits on access time instead
-	acltypes.WaitForSignals(ctx.TxBlockingChannels()[messageIndex])
+	acltypes.WaitForAllSignals(ctx.TxBlockingChannels()[messageIndex])
 
 	return handler(ctx, msg)
 }

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -6,7 +6,6 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 // Alias for Map of AccessOperation -> Channel
 type AccessOpsChannelMapping = map[*AccessOperation][]chan interface{}
 
-// Waits for all signals to complete before proceeding
 func WaitForSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
 	for _, channels := range accessOpsToChannelsMap {
 		for _, channel := range channels {

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -1,0 +1,24 @@
+package accesscontrol
+
+// Alias for Map of MessageIndex -> AccessOperation -> Channel
+type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
+
+// Alias for Map of AccessOperation -> Channel
+type AccessOpsChannelMapping = map[*AccessOperation][]chan interface{}
+
+// Waits for all signals to complete before proceeding
+func WaitForSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
+	for _, channels := range accessOpsToChannelsMap {
+		for _, channel := range channels {
+			<-channel
+		}
+	}
+}
+
+func SendSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
+	for accessOp, channels := range accessOpsToChannelsMap {
+		for _, channel := range channels {
+			channel <- accessOp
+		}
+	}
+}

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -4,7 +4,7 @@ package accesscontrol
 type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 
 // Alias for Map of AccessOperation -> Channel
-type AccessOpsChannelMapping = map[*AccessOperation][]chan interface{}
+type AccessOpsChannelMapping = map[AccessOperation][]chan interface{}
 
 func WaitForAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
 	for _, channels := range accessOpsToChannelsMap {

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -6,7 +6,7 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 // Alias for Map of AccessOperation -> Channel
 type AccessOpsChannelMapping = map[*AccessOperation][]chan interface{}
 
-func WaitForSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
+func WaitForAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
 	for _, channels := range accessOpsToChannelsMap {
 		for _, channel := range channels {
 			<-channel
@@ -14,10 +14,10 @@ func WaitForSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
 	}
 }
 
-func SendSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
-	for accessOp, channels := range accessOpsToChannelsMap {
+func SendAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
+	for _, channels := range accessOpsToChannelsMap {
 		for _, channel := range channels {
-			channel <- accessOp
+			channel <- struct{}{}
 		}
 	}
 }

--- a/types/context.go
+++ b/types/context.go
@@ -41,16 +41,10 @@ type Context struct {
 	eventManager  *EventManager
 	priority      int64 // The tx priority, only relevant in CheckTx
 
-	txBlockingChannels		MessageAccessOpsChannelMapping
-	txCompletionChannels	MessageAccessOpsChannelMapping
+	txBlockingChannels		acltypes.MessageAccessOpsChannelMapping
+	txCompletionChannels	acltypes.MessageAccessOpsChannelMapping
 	messageIndex int	// Used to track current message being processed
 }
-
-// Alias for Map of MessageIndex -> AccessOperation -> Channel
-type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
-
-// Alias for Map of AccessOperation -> Channel
-type AccessOpsChannelMapping = map[*acltypes.AccessOperation][]chan interface{}
 
 // Proposed rename, not done to avoid API breakage
 type Request = Context
@@ -71,8 +65,8 @@ func (c Context) IsReCheckTx() bool           { return c.recheckTx }
 func (c Context) MinGasPrices() DecCoins      { return c.minGasPrice }
 func (c Context) EventManager() *EventManager { return c.eventManager }
 func (c Context) Priority() int64             { return c.priority }
-func (c Context) TxCompletionChannels() MessageAccessOpsChannelMapping { return c.txCompletionChannels }
-func (c Context) TxBlockingChannels() 	MessageAccessOpsChannelMapping { return c.txBlockingChannels }
+func (c Context) TxCompletionChannels() acltypes.MessageAccessOpsChannelMapping { return c.txCompletionChannels }
+func (c Context) TxBlockingChannels() 	acltypes.MessageAccessOpsChannelMapping { return c.txBlockingChannels }
 func (c Context) MessageIndex() int		  { return c.messageIndex }
 
 // clone the header before returning
@@ -237,13 +231,13 @@ func (c Context) WithEventManager(em *EventManager) Context {
 }
 
 // WithTxCompletionChannels returns a Context with an updated list of completion channel
-func (c Context) WithTxCompletionChannels(completionChannels MessageAccessOpsChannelMapping) Context {
+func (c Context) WithTxCompletionChannels(completionChannels acltypes.MessageAccessOpsChannelMapping) Context {
 	c.txCompletionChannels = completionChannels
 	return c
 }
 
 // WithTxBlockingChannels returns a Context with an updated list of blocking channels for completion signals
-func (c Context) WithTxBlockingChannels(blockingChannels MessageAccessOpsChannelMapping) Context {
+func (c Context) WithTxBlockingChannels(blockingChannels acltypes.MessageAccessOpsChannelMapping) Context {
 	c.txBlockingChannels = blockingChannels
 	return c
 }


### PR DESCRIPTION
Creating a wrapper that gets called before all message handlers

If the completion signals are empty then it should not block anything as the slices of channels will be empty. 

