### PR TITLE
Add default value if acl keymap doesnt exist

### DIFF
--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -43,9 +43,14 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 
 func (k Keeper) GetResourceDependencyMapping(ctx sdk.Context, messageKey string) acltypes.MessageDependencyMapping {
 	store := ctx.KVStore(k.storeKey)
-	b := store.Get(types.GetResourceDependencyKey(messageKey))
+	depMapping := store.Get(types.GetResourceDependencyKey(messageKey))
+	if depMapping == nil {
+		// If the storage key doesn't exist in the mapping then assume synchronous processing
+		return types.SynchronousMessageDependencyMapping(messageKey)
+	}
+
 	dependencyMapping := acltypes.MessageDependencyMapping{}
-	k.cdc.MustUnmarshal(b, &dependencyMapping)
+	k.cdc.MustUnmarshal(depMapping, &dependencyMapping)
 	return dependencyMapping
 }
 

--- a/x/accesscontrol/types/genesis.go
+++ b/x/accesscontrol/types/genesis.go
@@ -7,18 +7,6 @@ import (
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 )
 
-func DefaultMessageDependencyMapping() []acltypes.MessageDependencyMapping {
-	return []acltypes.MessageDependencyMapping{
-		{
-			MessageKey: "",
-			AccessOps: []acltypes.AccessOperation{
-				{AccessType: acltypes.AccessType_UNKNOWN, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
-				{AccessType: acltypes.AccessType_COMMIT, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
-			},
-		},
-	}
-}
-
 // NewGenesisState creates a new GenesisState object
 func NewGenesisState(params Params, messageDependencyMapping []acltypes.MessageDependencyMapping) *GenesisState {
 	return &GenesisState{

--- a/x/accesscontrol/types/message_dependency_mapping.go
+++ b/x/accesscontrol/types/message_dependency_mapping.go
@@ -21,3 +21,19 @@ func ValidateMessageDependencyMapping(mapping acltypes.MessageDependencyMapping)
 	}
 	return nil
 }
+
+func SynchronousMessageDependencyMapping(messageKey string) acltypes.MessageDependencyMapping {
+	return acltypes.MessageDependencyMapping{
+		MessageKey: messageKey,
+		AccessOps: []acltypes.AccessOperation{
+			{AccessType: acltypes.AccessType_UNKNOWN, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
+			{AccessType: acltypes.AccessType_COMMIT, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
+		},
+	}
+}
+
+func DefaultMessageDependencyMapping() []acltypes.MessageDependencyMapping {
+	return []acltypes.MessageDependencyMapping{
+		SynchronousMessageDependencyMapping(""),
+	}
+}


### PR DESCRIPTION
Need to add  default resource access list if dep the msg key doesn't exist or it's not defined, this way it still just uses synchronous processing 

Ran load testing script with https://github.com/sei-protocol/sei-chain/compare/2.0.0beta...bweng-2.0.0beta-testing and verified that the DAG is built properly 