### PR TITLE
Move Parallel TX Signalling to Sei-Chain DeliverTx call 

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
 )
@@ -772,21 +771,6 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	return gInfo, result, anteEvents, priority, err
 }
 
-// Waits for all dependent concurrent resource access operations to complete before handling
-// message. Defers completion signal to the end of the method once the real handler is called
-func wrappedHandler(ctx sdk.Context, msg sdk.Msg, handler sdk.Handler) (*sdk.Result, error) {
-	messageIndex := ctx.MessageIndex()
-
-	// Defer sending completion channels to the end of the message 
-	defer acltypes.SendAllSignals(ctx.TxCompletionChannels()[messageIndex])
-
-	// Wait for signals to complete, this should be blocking 
-	// TODO:: More granular waits on access time instead
-	acltypes.WaitForAllSignals(ctx.TxBlockingChannels()[messageIndex])
-
-	return handler(ctx, msg)
-}
-
 // runMsgs iterates through a list of messages and executes them with the provided
 // Context and execution mode. Messages will only be executed during simulation
 // and DeliverTx. An error is returned if any single message fails or if a
@@ -821,7 +805,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		if handler := app.msgServiceRouter.Handler(msg); handler != nil {
 			ctx = ctx.WithMessageIndex(i)
 			// ADR 031 request type routing
-			msgResult, err = wrappedHandler(ctx, msg, handler)
+			msgResult, err = handler(ctx, msg)
 			eventMsgName = sdk.MsgTypeURL(msg)
 		} else if legacyMsg, ok := msg.(legacytx.LegacyMsg); ok {
 			// legacy sdk.Msg routing

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -803,7 +803,6 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		)
 
 		if handler := app.msgServiceRouter.Handler(msg); handler != nil {
-			ctx = ctx.WithMessageIndex(i)
 			// ADR 031 request type routing
 			msgResult, err = handler(ctx, msg)
 			eventMsgName = sdk.MsgTypeURL(msg)

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -6,18 +6,22 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 // Alias for Map of AccessOperation -> Channel
 type AccessOpsChannelMapping = map[AccessOperation][]chan interface{}
 
-func WaitForAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
-	for _, channels := range accessOpsToChannelsMap {
-		for _, channel := range channels {
-			<-channel
+func SendAllSignals(txIndex int, messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
+	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+		for _, channels := range accessOpsToChannelsMap {
+			for _, channel := range channels {
+				channel <- struct{}{}
+			}
 		}
 	}
 }
 
-func SendAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
-	for _, channels := range accessOpsToChannelsMap {
-		for _, channel := range channels {
-			channel <- struct{}{}
+func WaitForAllSignals(txIndex int, messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
+	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+		for _, channels := range accessOpsToChannelsMap {
+			for _, channel := range channels {
+				<-channel
+			}
 		}
 	}
 }

--- a/types/context.go
+++ b/types/context.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/gaskv"
 	stypes "github.com/cosmos/cosmos-sdk/store/types"
-	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 )
 
 /*
@@ -40,10 +39,6 @@ type Context struct {
 	consParams    *tmproto.ConsensusParams
 	eventManager  *EventManager
 	priority      int64 // The tx priority, only relevant in CheckTx
-
-	txBlockingChannels		acltypes.MessageAccessOpsChannelMapping
-	txCompletionChannels	acltypes.MessageAccessOpsChannelMapping
-	messageIndex int	// Used to track current message being processed
 }
 
 // Proposed rename, not done to avoid API breakage
@@ -65,9 +60,6 @@ func (c Context) IsReCheckTx() bool           { return c.recheckTx }
 func (c Context) MinGasPrices() DecCoins      { return c.minGasPrice }
 func (c Context) EventManager() *EventManager { return c.eventManager }
 func (c Context) Priority() int64             { return c.priority }
-func (c Context) TxCompletionChannels() acltypes.MessageAccessOpsChannelMapping { return c.txCompletionChannels }
-func (c Context) TxBlockingChannels() 	acltypes.MessageAccessOpsChannelMapping { return c.txBlockingChannels }
-func (c Context) MessageIndex() int		  { return c.messageIndex }
 
 // clone the header before returning
 func (c Context) BlockHeader() tmproto.Header {
@@ -227,24 +219,6 @@ func (c Context) WithConsensusParams(params *tmproto.ConsensusParams) Context {
 // WithEventManager returns a Context with an updated event manager
 func (c Context) WithEventManager(em *EventManager) Context {
 	c.eventManager = em
-	return c
-}
-
-// WithTxCompletionChannels returns a Context with an updated list of completion channel
-func (c Context) WithTxCompletionChannels(completionChannels acltypes.MessageAccessOpsChannelMapping) Context {
-	c.txCompletionChannels = completionChannels
-	return c
-}
-
-// WithTxBlockingChannels returns a Context with an updated list of blocking channels for completion signals
-func (c Context) WithTxBlockingChannels(blockingChannels acltypes.MessageAccessOpsChannelMapping) Context {
-	c.txBlockingChannels = blockingChannels
-	return c
-}
-
-// WithMessageIndex returns a Context with the current message index that's being processed
-func (c Context) WithMessageIndex(messageIndex int) Context {
-	c.messageIndex = messageIndex
 	return c
 }
 


### PR DESCRIPTION
Same as this PR: https://github.com/sei-protocol/sei-chain/pull/291

## Describe your changes and provide context
Previously we were signaling and blocking for each handler in the message - in theory, this is fine as we are supposed to be processed synchronously based on the access operation, however, due to us not having enough granularity, blocking on messages is not sufficient as the ordering for when each message is unblocked (between different TXs) could be different. This results in different gas fees or different bank AVL tree shapes as the node insertion order matters. 

Therefore, as we do not have more granular support for per-message concurrency, we should be okay with just blocking on the entire transaction and ensuring that no r/w can occur unless the entire TX is ready to be processed. This is operating on the assumption that the majority of transactions will not have overlapping resources. 

Note that the Gas used is based on the size of the data returned, depending on the ordering of the message process it's possible that some may result in the same bank data being returned with less digits, and therefore costing different gas. 

## Testing performed to validate your change
Ran the 20 iterations of load test with 5 rounds each and saw that the chain didn't get stuck and from previous outputs of the delivered, the messages are being processed sequentially as expected based on the logs. This was in a 5 node cluster

With these PRs merged, we should be able to then define more granular access operations for the message types we want to support e.g Bank Send should have access operations for read to sender, writing to both sender and receiver, and the contractAddr 
https://github.com/sei-protocol/sei-cosmos/pull/35
https://github.com/sei-protocol/sei-cosmos/pull/37
https://github.com/sei-protocol/sei-chain/pull/287
