### PR TITLE
Move blocking to beginning of runTx

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -656,6 +656,7 @@ func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context
 func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, result *sdk.Result, anteEvents []abci.Event, priority int64, err error) {
 	// Wait for signals to complete before starting the transaction. This is needed before any of the
 	// resources are acceessed by the ante handlers and message handlers.
+	// TODO(bweng):: add unit tests to enforce this 
 	acltypes.WaitForAllSignalsForTx(ctx.TxBlockingChannels())
 
 	// NOTE: GasWanted should be returned by the AnteHandler. GasUsed is

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -654,6 +654,10 @@ func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context
 // returned if the tx does not run out of gas and if all the messages are valid
 // and execute successfully. An error is returned otherwise.
 func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, result *sdk.Result, anteEvents []abci.Event, priority int64, err error) {
+	// Wait for signals to complete before starting the transaction. This is needed before any of the
+	// resources are acceessed by the ante handlers and message handlers.
+	acltypes.WaitForAllSignalsForTx(ctx.TxBlockingChannels())
+
 	// NOTE: GasWanted should be returned by the AnteHandler. GasUsed is
 	// determined by the GasMeter. We need access to the context to get the gas
 	// meter so we initialize upfront.
@@ -777,12 +781,8 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 func wrappedHandler(ctx sdk.Context, msg sdk.Msg, handler sdk.Handler) (*sdk.Result, error) {
 	messageIndex := ctx.MessageIndex()
 
-	// Defer sending completion channels to the end of the message 
-	defer acltypes.SendAllSignals(ctx.TxCompletionChannels()[messageIndex])
-
-	// Wait for signals to complete, this should be blocking 
-	// TODO:: More granular waits on access time instead
-	acltypes.WaitForAllSignals(ctx.TxBlockingChannels()[messageIndex])
+	// Defer sending completion channels to the end of the message
+	defer acltypes.SendAllSignalsForMsg(ctx.TxCompletionChannels()[messageIndex])
 
 	return handler(ctx, msg)
 }

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -6,16 +6,18 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 // Alias for Map of AccessOperation -> Channel
 type AccessOpsChannelMapping = map[AccessOperation][]chan interface{}
 
-func WaitForAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
-	for _, channels := range accessOpsToChannelsMap {
-		for _, channel := range channels {
-			<-channel
+func WaitForAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
+	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+		for _, channels := range accessOpsToChannelsMap {
+			for _, channel := range channels {
+				<-channel
+			}
 		}
 	}
 }
 
-func SendAllSignals(accessOpsToChannelsMap AccessOpsChannelMapping) {
-	for _, channels := range accessOpsToChannelsMap {
+func SendAllSignalsForMsg(accessOpsChannelMapping AccessOpsChannelMapping) {
+	for _, channels := range accessOpsChannelMapping {
 		for _, channel := range channels {
 			channel <- struct{}{}
 		}


### PR DESCRIPTION
## Describe your changes and provide context
There are resource accesses in the ante handler, we need to block before the access occurs, or else we will run into issues there where there's a race condition between the different accesses

## Testing performed to validate your change
Ran 20 iterations of the the basic msg load test with 5 validators and didn't experience any issues 

