### PR TITLE
Defer signalling to end of runTx instead + No Ante handler Dep

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -657,7 +657,8 @@ func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context
 func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, result *sdk.Result, anteEvents []abci.Event, priority int64, err error) {
 	// Wait for signals to complete before starting the transaction. This is needed before any of the
 	// resources are acceessed by the ante handlers and message handlers.
-	// TODO(bweng):: add unit tests to enforce this
+
+	// TODO:: Make this more granular by moving antehandler and messagehandler
 	defer acltypes.SendAllSignalsForTx(ctx.TxCompletionChannels())
 	acltypes.WaitForAllSignalsForTx(ctx.TxBlockingChannels())
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -658,6 +658,7 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	// Wait for signals to complete before starting the transaction. This is needed before any of the
 	// resources are acceessed by the ante handlers and message handlers.
 	// TODO(bweng):: add unit tests to enforce this
+	defer acltypes.SendAllSignalsForTx(ctx.TxCompletionChannels())
 	acltypes.WaitForAllSignalsForTx(ctx.TxBlockingChannels())
 
 	// NOTE: GasWanted should be returned by the AnteHandler. GasUsed is
@@ -778,17 +779,6 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	return gInfo, result, anteEvents, priority, err
 }
 
-// Waits for all dependent concurrent resource access operations to complete before handling
-// message. Defers completion signal to the end of the method once the real handler is called
-func wrappedHandler(ctx sdk.Context, msg sdk.Msg, handler sdk.Handler) (*sdk.Result, error) {
-	messageIndex := ctx.MessageIndex()
-
-	// Defer sending completion channels to the end of the message
-	defer acltypes.SendAllSignalsForMsg(ctx.TxCompletionChannels()[messageIndex])
-
-	return handler(ctx, msg)
-}
-
 // runMsgs iterates through a list of messages and executes them with the provided
 // Context and execution mode. Messages will only be executed during simulation
 // and DeliverTx. An error is returned if any single message fails or if a
@@ -823,7 +813,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		if handler := app.msgServiceRouter.Handler(msg); handler != nil {
 			ctx = ctx.WithMessageIndex(i)
 			// ADR 031 request type routing
-			msgResult, err = wrappedHandler(ctx, msg, handler)
+			msgResult, err = handler(ctx, msg)
 			eventMsgName = sdk.MsgTypeURL(msg)
 		} else if legacyMsg, ok := msg.(legacytx.LegacyMsg); ok {
 			// legacy sdk.Msg routing

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -16,10 +16,13 @@ func WaitForAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessO
 	}
 }
 
-func SendAllSignalsForMsg(accessOpsChannelMapping AccessOpsChannelMapping) {
-	for _, channels := range accessOpsChannelMapping {
-		for _, channel := range channels {
-			channel <- struct{}{}
+func SendAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
+	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+		for _, channels := range accessOpsToChannelsMap {
+			for _, channel := range channels {
+				channel <- struct{}{}
+			}
 		}
 	}
 }
+

--- a/types/handler.go
+++ b/types/handler.go
@@ -23,8 +23,15 @@ type AnteDepDecorator interface {
 
 type DefaultDepDecorator struct{}
 
+// Defeault AnteDeps returned
 func (d DefaultDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx Tx, next AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
-	defaultDeps := []sdkacltypes.AccessOperation{{ResourceType: sdkacltypes.ResourceType_ANY, AccessType: sdkacltypes.AccessType_UNKNOWN, IdentifierTemplate: "*"}}
+	defaultDeps := []sdkacltypes.AccessOperation{
+		{
+			ResourceType: sdkacltypes.ResourceType_ANY,
+			AccessType: sdkacltypes.AccessType_UNKNOWN,
+			IdentifierTemplate: "*",
+		},
+	}
 	return next(append(txDeps, defaultDeps...), tx)
 }
 

--- a/types/handler.go
+++ b/types/handler.go
@@ -31,6 +31,11 @@ func (d DefaultDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx T
 			AccessType: sdkacltypes.AccessType_UNKNOWN,
 			IdentifierTemplate: "*",
 		},
+		{
+			ResourceType: sdkacltypes.ResourceType_ANY,
+			AccessType: sdkacltypes.AccessType_COMMIT,
+			IdentifierTemplate: "*",
+		},
 	}
 	return next(append(txDeps, defaultDeps...), tx)
 }
@@ -112,7 +117,8 @@ func CustomDepWrappedAnteDecorator(decorator AnteDecorator, depDecorator AnteDep
 func DefaultWrappedAnteDecorator(decorator AnteDecorator) WrappedAnteDecorator {
 	return WrappedAnteDecorator{
 		Decorator:    decorator,
-		DepDecorator: DefaultDepDecorator{},
+		// TODO:: Use DefaultDepDecorator when each decorator defines their own
+		DepDecorator: NoDepDecorator{},
 	}
 }
 

--- a/types/handler.go
+++ b/types/handler.go
@@ -23,7 +23,8 @@ type AnteDepDecorator interface {
 
 type DefaultDepDecorator struct{}
 
-// Defeault AnteDeps returned
+// Defeault AnteDeps returned 
+// TODO:: enabling this causes dead lock in some cases at the moment, need to debug futher
 func (d DefaultDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx Tx, next AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
 	defaultDeps := []sdkacltypes.AccessOperation{
 		{

--- a/types/handler.go
+++ b/types/handler.go
@@ -31,11 +31,6 @@ func (d DefaultDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx T
 			AccessType: sdkacltypes.AccessType_UNKNOWN,
 			IdentifierTemplate: "*",
 		},
-		{
-			ResourceType: sdkacltypes.ResourceType_ANY,
-			AccessType: sdkacltypes.AccessType_COMMIT,
-			IdentifierTemplate: "*",
-		},
 	}
 	return next(append(txDeps, defaultDeps...), tx)
 }

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -227,7 +227,7 @@ func (k Keeper) GetMessageDependencies(ctx sdk.Context, msg sdk.Msg) []acltypes.
 	// Default behavior is to get the static dependency mapping for the message
 	messageKey := types.GenerateMessageKey(msg)
 	dependencyMapping := k.GetResourceDependencyMapping(ctx, messageKey)
-	if dependencyGenerator, ok := k.MessageDependencyGeneratorMapper[types.GenerateMessageKey(msg)]; ok {
+	if dependencyGenerator, ok := k.MessageDependencyGeneratorMapper[types.GenerateMessageKey(msg)]; dependencyMapping.DynamicEnabled && ok {
 		// if we have a dependency generator AND dynamic is enabled, use it
 		if dependencies, err := dependencyGenerator(k, ctx, msg); err == nil {
 			// validate the access ops before using them

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -227,16 +227,15 @@ func (k Keeper) GetMessageDependencies(ctx sdk.Context, msg sdk.Msg) []acltypes.
 	// Default behavior is to get the static dependency mapping for the message
 	messageKey := types.GenerateMessageKey(msg)
 	dependencyMapping := k.GetResourceDependencyMapping(ctx, messageKey)
-	if dependencyGenerator, ok := k.MessageDependencyGeneratorMapper[types.GenerateMessageKey(msg)]; dependencyMapping.DynamicEnabled && ok {
+	if dependencyGenerator, ok := k.MessageDependencyGeneratorMapper[types.GenerateMessageKey(msg)]; ok {
 		// if we have a dependency generator AND dynamic is enabled, use it
 		if dependencies, err := dependencyGenerator(k, ctx, msg); err == nil {
 			// validate the access ops before using them
 			validateErr := types.ValidateAccessOps(dependencies)
 			if validateErr == nil {
 				return dependencies
-			} else {
-				ctx.Logger().Error(validateErr.Error())
 			}
+			ctx.Logger().Error(validateErr.Error())
 		} else {
 			ctx.Logger().Error("Error generating message dependencies: ", err)
 		}


### PR DESCRIPTION
## Describe your changes and provide context
With the default ante handler, sei-status would hang after a couple of rounds of transactions even with the new signaling all the maps changes. 

**I think in general we should take a step back and try to get the higher-level concurrency working before trying to granularize as it's much harder to reason about at this point** 

## Testing performed to validate your change
With the defer signaling, I was able to run concurrently with synchronous dependencies but it still hangs after a couple of rounds - there's some deadlock that we probably need to look more into. Once I changed it to the No Dep decorator it was able to run fine without hanging 
