### PR TITLE
Add AnteHandler access ops and move completion channel signalling

### DIFF
--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -7,19 +7,25 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 type AccessOpsChannelMapping = map[AccessOperation][]chan interface{}
 
 func WaitForAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
+	println("ProcessTxConcurrent::waiting for Signal Tx")
 	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
 		for _, channels := range accessOpsToChannelsMap {
 			for _, channel := range channels {
 				<-channel
+				println("ProcessTxConcurrent::recieved one signal")
+			}
+		}
+	}
+	println("ProcessTxConcurrent::recieved all signals")
+}
+
+func SendAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
+	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+		for _, channels := range accessOpsToChannelsMap {
+			for _, channel := range channels {
+				channel <- struct{}{}
 			}
 		}
 	}
 }
 
-func SendAllSignalsForMsg(accessOpsChannelMapping AccessOpsChannelMapping) {
-	for _, channels := range accessOpsChannelMapping {
-		for _, channel := range channels {
-			channel <- struct{}{}
-		}
-	}
-}

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -7,16 +7,13 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 type AccessOpsChannelMapping = map[AccessOperation][]chan interface{}
 
 func WaitForAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
-	println("ProcessTxConcurrent::waiting for Signal Tx")
 	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
 		for _, channels := range accessOpsToChannelsMap {
 			for _, channel := range channels {
 				<-channel
-				println("ProcessTxConcurrent::recieved one signal")
 			}
 		}
 	}
-	println("ProcessTxConcurrent::recieved all signals")
 }
 
 func SendAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {

--- a/types/handler.go
+++ b/types/handler.go
@@ -23,8 +23,15 @@ type AnteDepDecorator interface {
 
 type DefaultDepDecorator struct{}
 
+// Defeault AnteDeps returned
 func (d DefaultDepDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx Tx, next AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
-	defaultDeps := []sdkacltypes.AccessOperation{{ResourceType: sdkacltypes.ResourceType_ANY, AccessType: sdkacltypes.AccessType_UNKNOWN, IdentifierTemplate: "*"}}
+	defaultDeps := []sdkacltypes.AccessOperation{
+		{
+			ResourceType: sdkacltypes.ResourceType_ANY,
+			AccessType: sdkacltypes.AccessType_UNKNOWN,
+			IdentifierTemplate: "*",
+		},
+	}
 	return next(append(txDeps, defaultDeps...), tx)
 }
 
@@ -105,7 +112,9 @@ func CustomDepWrappedAnteDecorator(decorator AnteDecorator, depDecorator AnteDep
 func DefaultWrappedAnteDecorator(decorator AnteDecorator) WrappedAnteDecorator {
 	return WrappedAnteDecorator{
 		Decorator:    decorator,
-		DepDecorator: DefaultDepDecorator{},
+		// TODO:: Use DefaultDepDecorator when each decorator defines their own
+		//		  See NewConsumeGasForTxSizeDecorator for an example of how to implement a decorator
+		DepDecorator: NoDepDecorator{},
 	}
 }
 

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -49,13 +49,13 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, sdk.AnteDepGenerat
 		sdk.DefaultWrappedAnteDecorator(NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(NewValidateMemoDecorator(options.AccountKeeper)),
-		sdk.DefaultWrappedAnteDecorator(NewConsumeGasForTxSizeDecorator(options.AccountKeeper)),
-		sdk.DefaultWrappedAnteDecorator(NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
+		NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
 		sdk.DefaultWrappedAnteDecorator(NewSetPubKeyDecorator(options.AccountKeeper)), // SetPubKeyDecorator must be called before all signature verification decorators
 		sdk.DefaultWrappedAnteDecorator(NewValidateSigCountDecorator(options.AccountKeeper)),
 		sdk.DefaultWrappedAnteDecorator(NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer)),
 		sdk.DefaultWrappedAnteDecorator(sigVerifyDecorator),
-		sdk.DefaultWrappedAnteDecorator(NewIncrementSequenceDecorator(options.AccountKeeper)),
+		NewIncrementSequenceDecorator(options.AccountKeeper),
 	}
 	anteHandler, anteDepGenerator := sdk.ChainAnteDecorators(anteDecorators...)
 

--- a/x/auth/ante/basic.go
+++ b/x/auth/ante/basic.go
@@ -86,7 +86,6 @@ func (d ConsumeTxSizeGasDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation
 	sigTx, _ := tx.(authsigning.SigVerifiableTx)
 	deps := []sdkacltypes.AccessOperation{}
 	for _, signer := range sigTx.GetSigners() {
-		fmt.Printf("AnteDeps:Signer:%s", signer.String())
 		deps = append(deps,
 			sdkacltypes.AccessOperation{
 				AccessType:         sdkacltypes.AccessType_WRITE,

--- a/x/auth/ante/basic.go
+++ b/x/auth/ante/basic.go
@@ -1,10 +1,13 @@
 package ante
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
@@ -79,10 +82,25 @@ type ConsumeTxSizeGasDecorator struct {
 	ak AccountKeeper
 }
 
-func NewConsumeGasForTxSizeDecorator(ak AccountKeeper) ConsumeTxSizeGasDecorator {
-	return ConsumeTxSizeGasDecorator{
-		ak: ak,
+func (d ConsumeTxSizeGasDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+	sigTx, _ := tx.(authsigning.SigVerifiableTx)
+	deps := []sdkacltypes.AccessOperation{}
+	for _, signer := range sigTx.GetSigners() {
+		fmt.Printf("AnteDeps:Signer:%s", signer.String())
+		deps = append(deps,
+			sdkacltypes.AccessOperation{
+				AccessType:         sdkacltypes.AccessType_WRITE,
+				ResourceType:       sdkacltypes.ResourceType_KV,
+				IdentifierTemplate:  signer.String(),
+			},
+		)
+
 	}
+	return next(append(txDeps, deps...), tx)
+}
+
+func NewConsumeGasForTxSizeDecorator(ak AccountKeeper) ConsumeTxSizeGasDecorator {
+	return ConsumeTxSizeGasDecorator{ak: ak}
 }
 
 func (cgts ConsumeTxSizeGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
@@ -92,7 +110,7 @@ func (cgts ConsumeTxSizeGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 	}
 	params := cgts.ak.GetParams(ctx)
 
-	ctx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*sdk.Gas(len(ctx.TxBytes())), "txSize")
+	ctx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*sdk.Gas(len(ctx.TxBytes())), "ConsumeTxSizeGasDecoratorAnteHandle")
 
 	// simulate gas cost for signatures in simulate mode
 	if simulate {
@@ -135,7 +153,7 @@ func (cgts ConsumeTxSizeGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 				cost *= params.TxSigLimit
 			}
 
-			ctx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*cost, "txSize")
+			ctx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*cost, fmt.Sprintf("txSizeSigners_%d", i))
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
* Adds the AnteHandlers Dependency Decorators for the decorators that have read/write operations to/from keepers 
* Moves the MsgCompletion signaling to the end of RunTx. The main issue is that the signaling SHOULD happen after the write() calls so that dependent transactions have the updated data. 
     * We can make it more granular in the future but for now we should just move it out so that its easier to reason/

## Testing performed to validate your change
With this branch - able to run a couple of rounds of load testing before running into the app hash error due to different gas consumed for the same TX  on validators, this is with concurrency enabled
https://github.com/sei-protocol/sei-chain/pull/309 
