### PR TITLE
Use buffered channel for completion signal

### DIFF
--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -7,7 +7,7 @@ type MessageAccessOpsChannelMapping = map[int]AccessOpsChannelMapping
 type AccessOpsChannelMapping = map[AccessOperation][]chan interface{}
 
 func WaitForAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
-	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+	for _, accessOpsToChannelsMap := range messageIndexToAccessOpsChannelMapping {
 		for _, channels := range accessOpsToChannelsMap {
 			for _, channel := range channels {
 				<-channel
@@ -17,7 +17,7 @@ func WaitForAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessO
 }
 
 func SendAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsChannelMapping) {
-	for _, accessOpsToChannelsMap  := range messageIndexToAccessOpsChannelMapping {
+	for _, accessOpsToChannelsMap := range messageIndexToAccessOpsChannelMapping {
 		for _, channels := range accessOpsToChannelsMap {
 			for _, channel := range channels {
 				channel <- struct{}{}
@@ -25,4 +25,3 @@ func SendAllSignalsForTx(messageIndexToAccessOpsChannelMapping MessageAccessOpsC
 		}
 	}
 }
-

--- a/types/accesscontrol/resource.go
+++ b/types/accesscontrol/resource.go
@@ -6,8 +6,15 @@ type TreeNode struct {
 }
 
 var ResourceTree = map[ResourceType]TreeNode{
-	ResourceType_ANY:        {ResourceType_ANY, []ResourceType{ResourceType_KV, ResourceType_Mem}},
-	ResourceType_KV:         {ResourceType_ANY, []ResourceType{}},
+	ResourceType_ANY: {ResourceType_ANY, []ResourceType{ResourceType_KV, ResourceType_Mem}},
+	ResourceType_KV: {ResourceType_ANY, []ResourceType{
+		ResourceType_KV_BANK,
+		ResourceType_KV_DEX,
+		ResourceType_KV_EPOCH,
+		ResourceType_KV_ORACLE,
+		ResourceType_KV_STAKING,
+		ResourceType_KV_WASM,
+	}},
 	ResourceType_Mem:        {ResourceType_ANY, []ResourceType{ResourceType_DexMem}},
 	ResourceType_DexMem:     {ResourceType_Mem, []ResourceType{}},
 	ResourceType_KV_BANK:    {ResourceType_KV, []ResourceType{}},

--- a/x/accesscontrol/types/graph.go
+++ b/x/accesscontrol/types/graph.go
@@ -71,7 +71,8 @@ func (dag *Dag) GetCompletionSignal(edge DagEdge) *CompletionSignal {
 		CompletionAccessOperation: fromNode.AccessOperation,
 		BlockedAccessOperation:    toNode.AccessOperation,
 		// channel used for signalling
-		Channel: make(chan interface{}),
+		// use buffered channel so that writing to channel won't be blocked by reads
+		Channel: make(chan interface{}, 1),
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
There are two types of Go channels: unbuffered and buffered. Buffered channel is created with an additional capacity argument to `make`. The difference between buffered and unbuffered channel is that if another goroutine starts reading the channel before the writing goroutine writes to it, the write will be blocked in the unbuffered channel's case until the reading goroutine gives up reading, whereas a buffered channel will allow the write.

Also backfilled some resource mappings.

## Testing performed to validate your change
Tested with wasm execute messages. Deadlock with unbuffered channel but function properly with buffered channel

