### PR TITLE
Set default access ops for wasm contracts

### DIFF
--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -116,7 +116,12 @@ func (k Keeper) GetWasmDependencyMapping(ctx sdk.Context, contractAddress sdk.Ac
 	store := ctx.KVStore(k.storeKey)
 	b := store.Get(types.GetWasmContractAddressKey(contractAddress))
 	if b == nil {
-		return acltypes.WasmDependencyMapping{}, ErrWasmDependencyMappingNotFound
+		// return default (synchronous) dependency mapping so that wasm resource type as a whole
+		// won't have dynamic mapping disabled if already enabled
+		return acltypes.WasmDependencyMapping{
+			Enabled:   true, // if wasm resource type as a whole is disabled, this will be ignored anyway
+			AccessOps: types.SynchronousAccessOps(),
+		}, nil
 	}
 	dependencyMapping := acltypes.WasmDependencyMapping{}
 	k.cdc.MustUnmarshal(b, &dependencyMapping)

--- a/x/accesscontrol/types/message_dependency_mapping.go
+++ b/x/accesscontrol/types/message_dependency_mapping.go
@@ -53,10 +53,14 @@ func SynchronousMessageDependencyMapping(messageKey MessageKey) acltypes.Message
 	return acltypes.MessageDependencyMapping{
 		MessageKey:     string(messageKey),
 		DynamicEnabled: true,
-		AccessOps: []acltypes.AccessOperation{
-			{AccessType: acltypes.AccessType_UNKNOWN, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
-			{AccessType: acltypes.AccessType_COMMIT, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
-		},
+		AccessOps:      SynchronousAccessOps(),
+	}
+}
+
+func SynchronousAccessOps() []acltypes.AccessOperation {
+	return []acltypes.AccessOperation{
+		{AccessType: acltypes.AccessType_UNKNOWN, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
+		{AccessType: acltypes.AccessType_COMMIT, ResourceType: acltypes.ResourceType_ANY, IdentifierTemplate: "*"},
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Right now if a wasm contract doesn't have access ops specified, it will cause all wasm messages to have parallel processing disabled because it will return an error. To prevent this we will return a default mapping for wasm messages instead.

## Testing performed to validate your change
tested with multiple contracts (one specified dependency and one doesn't)

