### PR TITLE
Refactor runTx to allow correct instrumentation

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -662,6 +662,10 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	defer acltypes.SendAllSignalsForTx(ctx.TxCompletionChannels())
 	acltypes.WaitForAllSignalsForTx(ctx.TxBlockingChannels())
 
+	return app.RunTxUnblocked(ctx, mode, txBytes)
+}
+
+func (app *BaseApp) RunTxUnblocked(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, result *sdk.Result, anteEvents []abci.Event, priority int64, err error) {
 	// NOTE: GasWanted should be returned by the AnteHandler. GasUsed is
 	// determined by the GasMeter. We need access to the context to get the gas
 	// meter so we initialize upfront.


### PR DESCRIPTION
## Describe your changes and provide context
Right now tracing is inaccurate since the span starts before the dependencies for a TX is met, so traces for all TXs start at the same time despite that some will not start execution until its dependencies are done.

By refactoring the actual execution logic into an exported function, we can overwrite it on Sei level to start span after the dependencies are met.

## Testing performed to validate your change
local sei
