### PR TITLE
Add multiplier gas meter

### DIFF
--- a/store/types/gas.go
+++ b/store/types/gas.go
@@ -53,7 +53,7 @@ type GasMeter interface {
 type basicGasMeter struct {
 	limit    Gas
 	consumed Gas
-	lock *sync.Mutex
+	lock     *sync.Mutex
 }
 
 // NewGasMeter returns a reference to a new basicGasMeter.
@@ -61,7 +61,7 @@ func NewGasMeter(limit Gas) GasMeter {
 	return &basicGasMeter{
 		limit:    limit,
 		consumed: 0,
-		lock: &sync.Mutex{},
+		lock:     &sync.Mutex{},
 	}
 }
 
@@ -149,16 +149,46 @@ func (g *basicGasMeter) String() string {
 	return fmt.Sprintf("BasicGasMeter:\n  limit: %d\n  consumed: %d", g.limit, g.consumed)
 }
 
+type multiplierGasMeter struct {
+	basicGasMeter
+	multiplierNominator   uint64
+	multiplierDenominator uint64
+}
+
+func NewMultiplierGasMeter(limit Gas, multiplierNominator uint64, multiplierDenominator uint64) GasMeter {
+	return &multiplierGasMeter{
+		basicGasMeter: basicGasMeter{
+			limit:    limit,
+			consumed: 0,
+			lock:     &sync.Mutex{},
+		},
+		multiplierNominator:   multiplierNominator,
+		multiplierDenominator: multiplierDenominator,
+	}
+}
+
+func (g *multiplierGasMeter) adjustGas(original Gas) Gas {
+	return original * g.multiplierNominator / g.multiplierDenominator
+}
+
+func (g *multiplierGasMeter) ConsumeGas(amount Gas, descriptor string) {
+	g.basicGasMeter.ConsumeGas(g.adjustGas(amount), descriptor)
+}
+
+func (g *multiplierGasMeter) RefundGas(amount Gas, descriptor string) {
+	g.basicGasMeter.RefundGas(g.adjustGas(amount), descriptor)
+}
+
 type infiniteGasMeter struct {
 	consumed Gas
-	lock *sync.Mutex
+	lock     *sync.Mutex
 }
 
 // NewInfiniteGasMeter returns a reference to a new infiniteGasMeter.
 func NewInfiniteGasMeter() GasMeter {
 	return &infiniteGasMeter{
 		consumed: 0,
-		lock: &sync.Mutex{},
+		lock:     &sync.Mutex{},
 	}
 }
 

--- a/store/types/gas.go
+++ b/store/types/gas.go
@@ -151,24 +151,24 @@ func (g *basicGasMeter) String() string {
 
 type multiplierGasMeter struct {
 	basicGasMeter
-	multiplierNominator   uint64
+	multiplierNumerator   uint64
 	multiplierDenominator uint64
 }
 
-func NewMultiplierGasMeter(limit Gas, multiplierNominator uint64, multiplierDenominator uint64) GasMeter {
+func NewMultiplierGasMeter(limit Gas, multiplierNumerator uint64, multiplierDenominator uint64) GasMeter {
 	return &multiplierGasMeter{
 		basicGasMeter: basicGasMeter{
 			limit:    limit,
 			consumed: 0,
 			lock:     &sync.Mutex{},
 		},
-		multiplierNominator:   multiplierNominator,
+		multiplierNumerator:   multiplierNumerator,
 		multiplierDenominator: multiplierDenominator,
 	}
 }
 
 func (g *multiplierGasMeter) adjustGas(original Gas) Gas {
-	return original * g.multiplierNominator / g.multiplierDenominator
+	return original * g.multiplierNumerator / g.multiplierDenominator
 }
 
 func (g *multiplierGasMeter) ConsumeGas(amount Gas, descriptor string) {

--- a/store/types/gas_test.go
+++ b/store/types/gas_test.go
@@ -76,7 +76,7 @@ func TestMultiplierGasMeter(t *testing.T) {
 	cases := []struct {
 		limit                 Gas
 		usage                 []Gas
-		multiplierNominator   uint64
+		multiplierNumerator   uint64
 		multiplierDenominator uint64
 	}{
 		{10, []Gas{1, 2, 3, 4}, 1, 1},
@@ -88,12 +88,12 @@ func TestMultiplierGasMeter(t *testing.T) {
 	}
 
 	for tcnum, tc := range cases {
-		meter := NewMultiplierGasMeter(tc.limit, tc.multiplierNominator, tc.multiplierDenominator)
+		meter := NewMultiplierGasMeter(tc.limit, tc.multiplierNumerator, tc.multiplierDenominator)
 		used := uint64(0)
 
 		for unum, usage := range tc.usage {
 			usage := usage
-			used += usage * tc.multiplierNominator / tc.multiplierDenominator
+			used += usage * tc.multiplierNumerator / tc.multiplierDenominator
 			require.NotPanics(t, func() { meter.ConsumeGas(usage, "") }, "Not exceeded limit but panicked. tc #%d, usage #%d", tcnum, unum)
 			require.Equal(t, used, meter.GasConsumed(), "Gas consumption not match. tc #%d, usage #%d", tcnum, unum)
 			require.Equal(t, used, meter.GasConsumedToLimit(), "Gas consumption (to limit) not match. tc #%d, usage #%d", tcnum, unum)

--- a/store/types/gas_test.go
+++ b/store/types/gas_test.go
@@ -71,6 +71,42 @@ func TestGasMeter(t *testing.T) {
 	}
 }
 
+func TestMultiplierGasMeter(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		limit                 Gas
+		usage                 []Gas
+		multiplierNominator   uint64
+		multiplierDenominator uint64
+	}{
+		{10, []Gas{1, 2, 3, 4}, 1, 1},
+		{1000, []Gas{40, 30, 20, 10}, 10, 1},
+		{100000, []Gas{99998, 2, 100000}, 1, 2},
+		{100000000, []Gas{50000000, 40000000, 10000000}, 1, 1},
+		{65535, []Gas{32768, 32767}, 1, 1},
+		{65536, []Gas{32768, 32767, 1}, 1, 1},
+	}
+
+	for tcnum, tc := range cases {
+		meter := NewMultiplierGasMeter(tc.limit, tc.multiplierNominator, tc.multiplierDenominator)
+		used := uint64(0)
+
+		for unum, usage := range tc.usage {
+			usage := usage
+			used += usage * tc.multiplierNominator / tc.multiplierDenominator
+			require.NotPanics(t, func() { meter.ConsumeGas(usage, "") }, "Not exceeded limit but panicked. tc #%d, usage #%d", tcnum, unum)
+			require.Equal(t, used, meter.GasConsumed(), "Gas consumption not match. tc #%d, usage #%d", tcnum, unum)
+			require.Equal(t, used, meter.GasConsumedToLimit(), "Gas consumption (to limit) not match. tc #%d, usage #%d", tcnum, unum)
+			require.False(t, meter.IsPastLimit(), "Not exceeded limit but got IsPastLimit() true")
+			if unum < len(tc.usage)-1 {
+				require.False(t, meter.IsOutOfGas(), "Not yet at limit but got IsOutOfGas() true")
+			} else {
+				require.True(t, meter.IsOutOfGas(), "At limit but got IsOutOfGas() false")
+			}
+		}
+	}
+}
+
 func TestAddUint64Overflow(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -39,7 +39,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, sdk.AnteDepGenerat
 	sigVerifyDecorator = sequentialVerifyDecorator
 
 	anteDecorators := []sdk.AnteFullDecorator{
-		sdk.DefaultWrappedAnteDecorator(NewSetUpContextDecorator()), // outermost AnteDecorator. SetUpContext must be called first
+		sdk.DefaultWrappedAnteDecorator(NewDefaultSetUpContextDecorator()), // outermost AnteDecorator. SetUpContext must be called first
 		sdk.DefaultWrappedAnteDecorator(NewRejectExtensionOptionsDecorator()),
 		sdk.DefaultWrappedAnteDecorator(NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(NewTxTimeoutHeightDecorator()),

--- a/x/auth/ante/setup_test.go
+++ b/x/auth/ante/setup_test.go
@@ -27,7 +27,7 @@ func (suite *AnteTestSuite) TestSetup() {
 	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
 	suite.Require().NoError(err)
 
-	sud := ante.NewSetUpContextDecorator()
+	sud := ante.NewDefaultSetUpContextDecorator()
 	antehandler, _ := sdk.ChainAnteDecorators(sdk.DefaultWrappedAnteDecorator(sud))
 
 	// Set height to non-zero value for GasMeter to be set
@@ -62,7 +62,7 @@ func (suite *AnteTestSuite) TestRecoverPanic() {
 	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
 	suite.Require().NoError(err)
 
-	sud := ante.NewSetUpContextDecorator()
+	sud := ante.NewDefaultSetUpContextDecorator()
 	antehandler, _ := sdk.ChainAnteDecorators(sdk.DefaultWrappedAnteDecorator(sud), sdk.DefaultWrappedAnteDecorator(OutOfGasDecorator{}))
 
 	// Set height to non-zero value for GasMeter to be set


### PR DESCRIPTION
## Describe your changes and provide context
Add a new gas meter type that allows passing in a multiplier. To ensure computation stability we represent multiplier in two ints (nominator and denominator). This PR also extended SetUpContextDecorator so that applications can have custom logic to decide whether to use multiplier gas meter and what multiplier to use.

## Testing performed to validate your change
unit test

