### PR TITLE
Pass Account Keeper to ACL Keeper

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -280,7 +280,13 @@ func NewSimApp(
 	)
 
 	app.AuthzKeeper = authzkeeper.NewKeeper(keys[authzkeeper.StoreKey], appCodec, app.BaseApp.MsgServiceRouter())
-	app.AccessControlKeeper = aclkeeper.NewKeeper(appCodec, keys[acltypes.StoreKey], app.GetSubspace(acltypes.ModuleName), aclkeeper.WithDependencyMappingGenerator(acltestutil.MessageDependencyGeneratorTestHelper()))
+	app.AccessControlKeeper = aclkeeper.NewKeeper(
+		appCodec,
+		keys[acltypes.StoreKey],
+		app.GetSubspace(acltypes.ModuleName),
+		app.AccountKeeper,
+		aclkeeper.WithDependencyMappingGenerator(acltestutil.MessageDependencyGeneratorTestHelper()),
+	)
 
 	// register the proposal types
 	govRouter := govtypes.NewRouter()

--- a/types/accesscontrol/validation.go
+++ b/types/accesscontrol/validation.go
@@ -1,8 +1,6 @@
 package accesscontrol
 
 import (
-	"log"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -76,7 +74,6 @@ func (validator *MsgValidator) ValidateAccessOperations(accessOps []AccessOperat
 
 			// The resource type was not a parent type where it could match anything nor was it found in the respective store key mapping
 			if !ok {
-				log.Printf("ResourceType=%s not found in mapping for StoreKey=%s or default key", accessOp.GetResourceType(), storeKey)
 				matched = false
 				continue
 			}

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -14,8 +14,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	"github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 )
 
 // Option is an extension point to instantiate keeper with non default values
@@ -33,7 +33,7 @@ type (
 		storeKey                         sdk.StoreKey
 		paramSpace                       paramtypes.Subspace
 		MessageDependencyGeneratorMapper DependencyGeneratorMap
-		AccountKeeper       			 minttypes.AccountKeeper
+		AccountKeeper       			 authkeeper.AccountKeeper
 	}
 )
 
@@ -43,7 +43,7 @@ func NewKeeper(
 	cdc codec.Codec,
 	storeKey sdk.StoreKey,
 	paramSpace paramtypes.Subspace,
-	ak 		minttypes.AccountKeeper,
+	ak 		authkeeper.AccountKeeper,
 	opts ...Option,
 ) Keeper {
 	if !paramSpace.HasKeyTable() {

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -12,10 +12,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	"github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	minttypes "github.com/sei-protocol/sei-chain/x/mint/types"
 )
 
 // Option is an extension point to instantiate keeper with non default values
@@ -33,6 +33,7 @@ type (
 		storeKey                         sdk.StoreKey
 		paramSpace                       paramtypes.Subspace
 		MessageDependencyGeneratorMapper DependencyGeneratorMap
+		AccountKeeper       			 minttypes.AccountKeeper
 	}
 )
 
@@ -42,6 +43,7 @@ func NewKeeper(
 	cdc codec.Codec,
 	storeKey sdk.StoreKey,
 	paramSpace paramtypes.Subspace,
+	ak 		minttypes.AccountKeeper,
 	opts ...Option,
 ) Keeper {
 	if !paramSpace.HasKeyTable() {
@@ -53,6 +55,7 @@ func NewKeeper(
 		storeKey:                         storeKey,
 		paramSpace:                       paramSpace,
 		MessageDependencyGeneratorMapper: DefaultMessageDependencyGenerator(),
+		AccountKeeper: ak,
 	}
 
 	for _, o := range opts {

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -630,7 +630,6 @@ func (k BaseKeeper) BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 		if ok {
 			return nil
 		}
-
 		acc := k.ak.GetModuleAccount(ctx, moduleName)
 		return k.subUnlockedCoins(ctx, acc.GetAddress(), amounts)
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Some dependency generators may need account information (e.g module address) at run time, and it needs the AccountKeeper to access this information 

Will update sei-chain to pass in app.go too
## Testing performed to validate your change

