### PR TITLE
Add hard rollback support and fix existing rollback 

### DIFF
--- a/FORKED_CHANGELOG.md
+++ b/FORKED_CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * [\#2](https://github.com/sei-protocol/sei-cosmos/pull/2) Fix GRPC bug
+* [\#88](https://github.com/sei-protocol/sei-cosmos/pull/88) Fix Rollback bug not actually rolling back CMS version
 
 ### Improvements
 
@@ -48,12 +49,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [\#14](https://github.com/sei-protocol/sei-cosmos/pull/14) Integrate Cosmos with Tendermint tracing
 * (x/auth/vesting) [\#11652](https://github.com/cosmos/cosmos-sdk/pull/11652) Add util functions for `Period(s)`
 
-
 ### Features
 * [\#17](https://github.com/sei-protocol/sei-cosmos/pull/17) Support SR25519 algorithm for client transaction signing
 * [\#23](https://github.com/sei-protocol/sei-cosmos/pull/23) Add priority to CheckTx based on gas fees
 * (x/accesscontrol) [\#24](https://github.com/sei-protocol/sei-cosmos/pull/24) Add AccessControl module
-* [\#27](https://github.com/sei-protocol/sei-cosmos/pull/27) Add tx channels for parallel DeliverTx signaling 
+* [\#27](https://github.com/sei-protocol/sei-cosmos/pull/27) Add tx channels for parallel DeliverTx signaling
 * (x/accesscontrol) [\#30](https://github.com/sei-protocol/sei-cosmos/pull/30) Add resource hierarchy helper to build resource dependencies
 * (x/accesscontrol) [\#33](https://github.com/sei-protocol/sei-cosmos/pull/33) Add gov proposal handler for x/accesscontrol
 * (x/accesscontrol) [\#36](https://github.com/sei-protocol/sei-cosmos/pull/36) Add dependency DAG to x/accesscontrol
@@ -63,3 +63,4 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/accesscontrol) [\#59](https://github.com/sei-protocol/sei-cosmos/pull/59) Add gov proposal type for wasm dependency mapping updates
 * [\#61](https://github.com/sei-protocol/sei-cosmos/pull/61) Add deferred withdrawl for module accounts
 * [\#63](https://github.com/sei-protocol/sei-cosmos/pull/63) Add support for deferred mint/burn from the module accounts
+* [\#88](https://github.com/sei-protocol/sei-cosmos/pull/88) Add support for hard rollbacks

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -299,11 +299,8 @@ func DefaultStoreLoader(ms sdk.CommitMultiStore) error {
 
 // CommitMultiStore returns the root multi-store.
 // App constructor can use this to access the `cms`.
-// UNSAFE: only safe to use during app initialization.
+// UNSAFE: must not be used during the abci life cycle.
 func (app *BaseApp) CommitMultiStore() sdk.CommitMultiStore {
-	if app.sealed {
-		panic("cannot call CommitMultiStore() after baseapp is sealed")
-	}
 	return app.cms
 }
 

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.84
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.85
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.13
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.83
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.83
+	github.com/tendermint/tendermint => ../sei-tendermint // github.com/sei-protocol/sei-tendermint v0.1.83
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => ../sei-tendermint // github.com/sei-protocol/sei-tendermint v0.1.83
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.84
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.sum
+++ b/go.sum
@@ -1092,6 +1092,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/sei-tendermint v0.1.84 h1:fJBxYSCAFV3xfsFcdFUVwsR+065NxYM/bjwup7Eyuec=
+github.com/sei-protocol/sei-tendermint v0.1.84/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -1092,8 +1092,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.83 h1:ReVM8UiYrknAO9qav1bJt7lR7t11BENERP5m8R337oc=
-github.com/sei-protocol/sei-tendermint v0.1.83/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -1092,8 +1092,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.84 h1:fJBxYSCAFV3xfsFcdFUVwsR+065NxYM/bjwup7Eyuec=
-github.com/sei-protocol/sei-tendermint v0.1.84/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
+github.com/sei-protocol/sei-tendermint v0.1.85 h1:rsTnez6eeeMLRCjplq6XuqQ9gfmnU4i0bJ7OUCd80IY=
+github.com/sei-protocol/sei-tendermint v0.1.85/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -1092,8 +1092,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.11.0/go.mod h1:SX8bptShuG8reGC0XS09+a4H2BoWSJi+fscA+Pulbpo=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.13 h1:uaMXhi+zpaqcUDlshxjqmPmUI/zSZla2a2ZmOtDK5RM=
-github.com/sei-protocol/sei-tendermint v0.1.13/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
+github.com/sei-protocol/sei-tendermint v0.1.83 h1:ReVM8UiYrknAO9qav1bJt7lR7t11BENERP5m8R337oc=
+github.com/sei-protocol/sei-tendermint v0.1.83/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -17,6 +17,10 @@ type multiStore struct {
 	kv map[sdk.StoreKey]kvStore
 }
 
+func (ms multiStore) RollbackToVersion(version int64) error {
+	panic("not implemented")
+}
+
 func (ms multiStore) CacheMultiStore() sdk.CacheMultiStore {
 	panic("not implemented")
 }

--- a/server/rollback.go
+++ b/server/rollback.go
@@ -9,7 +9,7 @@ import (
 	tmcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 )
 
-var removeBlock bool = false
+var removeBlock = false
 
 // NewRollbackCmd creates a command to rollback tendermint and multistore state by one height.
 func NewRollbackCmd(defaultNodeHome string) *cobra.Command {

--- a/server/rollback.go
+++ b/server/rollback.go
@@ -9,6 +9,8 @@ import (
 	tmcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 )
 
+var removeBlock bool = false
+
 // NewRollbackCmd creates a command to rollback tendermint and multistore state by one height.
 func NewRollbackCmd(defaultNodeHome string) *cobra.Command {
 	cmd := &cobra.Command{
@@ -31,7 +33,7 @@ application.
 				return err
 			}
 			// rollback tendermint state
-			height, hash, err := tmcmd.RollbackState(ctx.Config)
+			height, hash, err := tmcmd.RollbackState(ctx.Config, removeBlock)
 			if err != nil {
 				return fmt.Errorf("failed to rollback tendermint state: %w", err)
 			}
@@ -44,6 +46,7 @@ application.
 		},
 	}
 
+	cmd.Flags().BoolVar(&removeBlock, "hard", false, "remove last block as well as state")
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	return cmd
 }

--- a/server/rollback.go
+++ b/server/rollback.go
@@ -32,7 +32,13 @@ application.
 			if err != nil {
 				return err
 			}
-			app := appCreator(ctx.Logger, db, nil, ctx.Viper)
+
+			app := appCreator(
+				ctx.Logger,
+				db,
+				nil,
+				ctx.Viper,
+			)
 
 			// rollback tendermint state
 			height, hash, err := tmcmd.RollbackState(ctx.Config, removeBlock)
@@ -48,6 +54,7 @@ application.
 		},
 	}
 
+	cmd.Flags().String(flags.FlagChainID, "sei-chain", "genesis file chain-id, if left blank will use sei")
 	cmd.Flags().BoolVar(&removeBlock, "hard", false, "remove last block as well as state")
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	return cmd

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gogo/protobuf/grpc"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -52,6 +53,9 @@ type (
 
 		// RegisterTendermintService registers the gRPC Query service for tendermint queries.
 		RegisterTendermintService(clientCtx client.Context)
+
+		// Return the multistore instance
+		CommitMultiStore() sdk.CommitMultiStore
 	}
 
 	// AppCreator is a function that allows us to lazily initialize an

--- a/server/util.go
+++ b/server/util.go
@@ -263,7 +263,14 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 }
 
 // add server commands
-func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator types.AppCreator, appExport types.AppExporter, addStartFlags types.ModuleInitFlags, tracerProviderOptions []trace.TracerProviderOption) {
+func AddCommands(
+	rootCmd *cobra.Command,
+	defaultNodeHome string,
+	appCreator types.AppCreator,
+	appExport types.AppExporter,
+	addStartFlags types.ModuleInitFlags,
+	tracerProviderOptions []trace.TracerProviderOption,
+) {
 	tendermintCmd := &cobra.Command{
 		Use:   "tendermint",
 		Short: "Tendermint subcommands",

--- a/server/util.go
+++ b/server/util.go
@@ -284,7 +284,7 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 		tendermintCmd,
 		ExportCmd(appExport, defaultNodeHome),
 		version.NewVersionCommand(),
-		NewRollbackCmd(defaultNodeHome),
+		NewRollbackCmd(appCreator, defaultNodeHome),
 	)
 }
 

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -205,6 +205,12 @@ func (st *Store) DeleteVersions(versions ...int64) error {
 	return st.tree.DeleteVersions(versions...)
 }
 
+// LoadVersionForOverwriting attempts to load a tree at a previously committed
+// version, or the latest version below it. Any versions greater than targetVersion will be deleted.
+func (st *Store) LoadVersionForOverwriting(targetVersion int64) (int64, error) {
+	return st.tree.LoadVersionForOverwriting(targetVersion)
+}
+
 // Implements types.KVStore.
 func (st *Store) Iterator(start, end []byte) types.Iterator {
 	var iTree *iavl.ImmutableTree

--- a/store/iavl/tree.go
+++ b/store/iavl/tree.go
@@ -32,6 +32,7 @@ type (
 		GetVersionedWithProof(key []byte, version int64) ([]byte, *iavl.RangeProof, error)
 		GetImmutable(version int64) (*iavl.ImmutableTree, error)
 		SetInitialVersion(version uint64)
+		LoadVersionForOverwriting(targetVersion int64) (int64, error)
 	}
 
 	// immutableTree is a simple wrapper around a reference to an iavl.ImmutableTree
@@ -68,6 +69,10 @@ func (it *immutableTree) DeleteVersions(_ ...int64) error {
 
 func (it *immutableTree) SetInitialVersion(_ uint64) {
 	panic("cannot call 'SetInitialVersion' on an immutable IAVL tree")
+}
+
+func (it *immutableTree) LoadVersionForOverwriting(targetVersion int64) (int64, error) {
+	panic("cannot call 'LoadVersionForOverwriting' on an immutable IAVL tree")
 }
 
 func (it *immutableTree) VersionExists(version int64) bool {

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -198,6 +198,9 @@ type CommitMultiStore interface {
 
 	// SetIAVLCacheSize sets the cache size of the IAVL tree.
 	SetIAVLCacheSize(size int)
+
+	// RollbackToVersion rollback the db to specific version(height).
+	RollbackToVersion(version int64) error
 }
 
 //---------subsp-------------------------------


### PR DESCRIPTION
## Describe your changes and provide context
Add support for hard rollbacks and fixes existing rollback mechanism to actually rollback the CMS 

Cherry-picks this commit: https://github.com/Wryhder/cosmos-sdk/commit/c8142f02e43f062e44d1a6132d557198da272af6 

## Testing performed to validate your change

Sent transactions then rollback back blocks
![image](https://user-images.githubusercontent.com/18161326/202228141-a821544d-c671-4d6b-bfd0-c70468348a92.png)

Stopped all validators and hard rolled back, restarted them and saw that they started from the block we rolled back to and then did another run of TXs 
