### PR TITLE
Add limit to cachekv store

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -621,7 +621,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height)
+	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height, app.CacheSize)
 	if err != nil {
 		return sdk.Context{},
 			sdkerrors.Wrapf(

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/snapshots"
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -161,6 +162,8 @@ type BaseApp struct { //nolint: maligned
 	// which informs Tendermint what to index. If empty, all events will be indexed.
 	indexEvents map[string]struct{}
 
+	CacheSize int
+
 	ChainID string
 }
 
@@ -198,6 +201,7 @@ func NewBaseApp(
 		msgServiceRouter: NewMsgServiceRouter(),
 		txDecoder:        txDecoder,
 		fauxMerkleMode:   false,
+		CacheSize:        storetypes.DefaultCacheSizeLimit,
 	}
 
 	for _, option := range options {
@@ -437,7 +441,7 @@ func (app *BaseApp) IsSealed() bool { return app.sealed }
 // provided header, and minimum gas prices set. It is set on InitChain and reset
 // on Commit.
 func (app *BaseApp) setCheckState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore()
+	ms := app.cms.CacheMultiStore(app.CacheSize)
 	app.checkState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, true, app.logger).WithMinGasPrices(app.minGasPrices),
@@ -449,7 +453,7 @@ func (app *BaseApp) setCheckState(header tmproto.Header) {
 // and provided header. It is set on InitChain and BeginBlock and set to nil on
 // Commit.
 func (app *BaseApp) setDeliverState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore()
+	ms := app.cms.CacheMultiStore(app.CacheSize)
 	app.deliverState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
@@ -457,7 +461,7 @@ func (app *BaseApp) setDeliverState(header tmproto.Header) {
 }
 
 func (app *BaseApp) setPrepareProposalState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore()
+	ms := app.cms.CacheMultiStore(app.CacheSize)
 	app.prepareProposalState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
@@ -465,7 +469,7 @@ func (app *BaseApp) setPrepareProposalState(header tmproto.Header) {
 }
 
 func (app *BaseApp) setProcessProposalState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore()
+	ms := app.cms.CacheMultiStore(app.CacheSize)
 	app.processProposalState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
@@ -648,7 +652,7 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context 
 	}
 
 	if mode == runTxModeSimulate {
-		ctx, _ = ctx.CacheContext()
+		ctx, _ = ctx.CacheContext(app.CacheSize)
 	}
 
 	return ctx
@@ -659,7 +663,7 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context 
 func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context, sdk.CacheMultiStore) {
 	ms := ctx.MultiStore()
 	// TODO: https://github.com/cosmos/cosmos-sdk/issues/2824
-	msCache := ms.CacheMultiStore()
+	msCache := ms.CacheMultiStore(app.CacheSize)
 	if msCache.TracingEnabled() {
 		msCache = msCache.SetTracingContext(
 			sdk.TraceContext(

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -439,12 +439,12 @@ func TestLoadVersionPruning(t *testing.T) {
 	}
 
 	for _, v := range []int64{1, 2, 4} {
-		_, err = app.cms.CacheMultiStoreWithVersion(v)
+		_, err = app.cms.CacheMultiStoreWithVersion(v, store.DefaultCacheSizeLimit)
 		require.NoError(t, err)
 	}
 
 	for _, v := range []int64{3, 5, 6, 7} {
-		_, err = app.cms.CacheMultiStoreWithVersion(v)
+		_, err = app.cms.CacheMultiStoreWithVersion(v, store.DefaultCacheSizeLimit)
 		require.NoError(t, err)
 	}
 

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -11,8 +11,8 @@ type state struct {
 
 // CacheMultiStore calls and returns a CacheMultiStore on the state's underling
 // CacheMultiStore.
-func (st *state) CacheMultiStore() sdk.CacheMultiStore {
-	return st.ms.CacheMultiStore()
+func (st *state) CacheMultiStore(cacheSize int) sdk.CacheMultiStore {
+	return st.ms.CacheMultiStore(cacheSize)
 }
 
 // Context returns the Context of the state.

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -3,6 +3,7 @@ package baseapp
 import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
+	"github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -22,7 +23,7 @@ func (app *BaseApp) Check(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *sdk
 
 func (app *BaseApp) Simulate(txBytes []byte) (sdk.GasInfo, *sdk.Result, error) {
 	ctx := app.checkState.ctx.WithTxBytes(txBytes).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.checkState.ctx))
-	ctx, _ = ctx.CacheContext()
+	ctx, _ = ctx.CacheContext(types.DefaultCacheSizeLimit)
 	gasInfo, result, _, _, err := app.runTx(ctx, runTxModeSimulate, txBytes)
 	return gasInfo, result, err
 }

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -21,23 +21,23 @@ func (ms multiStore) RollbackToVersion(version int64) error {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheMultiStore() sdk.CacheMultiStore {
+func (ms multiStore) CacheMultiStore(_ int) sdk.CacheMultiStore {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheMultiStoreWithVersion(_ int64) (sdk.CacheMultiStore, error) {
+func (ms multiStore) CacheMultiStoreWithVersion(_ int64, _ int) (sdk.CacheMultiStore, error) {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheWrap(_ store.StoreKey) sdk.CacheWrap {
+func (ms multiStore) CacheWrap(_ store.StoreKey, _ int) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheWrapWithTrace(_ store.StoreKey, _ io.Writer, _ sdk.TraceContext) sdk.CacheWrap {
+func (ms multiStore) CacheWrapWithTrace(_ store.StoreKey, _ io.Writer, _ sdk.TraceContext, _ int) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener) store.CacheWrap {
+func (ms multiStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener, _ int) store.CacheWrap {
 	panic("not implemented")
 }
 
@@ -153,15 +153,15 @@ type kvStore struct {
 	store map[string][]byte
 }
 
-func (kv kvStore) CacheWrap(_ store.StoreKey) sdk.CacheWrap {
+func (kv kvStore) CacheWrap(_ store.StoreKey, _ int) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (kv kvStore) CacheWrapWithTrace(_ store.StoreKey, w io.Writer, tc sdk.TraceContext) sdk.CacheWrap {
+func (kv kvStore) CacheWrapWithTrace(_ store.StoreKey, w io.Writer, tc sdk.TraceContext, _ int) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (kv kvStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener) store.CacheWrap {
+func (kv kvStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener, _ int) store.CacheWrap {
 	panic("not implemented")
 }
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -251,6 +251,7 @@ func NewSimApp(
 	)
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.ModuleAccountAddrs(),
+		app.CacheSize,
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
@@ -261,7 +262,7 @@ func NewSimApp(
 	)
 	app.DistrKeeper = distrkeeper.NewKeeper(
 		appCodec, keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(),
+		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(), app.CacheSize,
 	)
 	app.SlashingKeeper = slashingkeeper.NewKeeper(
 		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
@@ -298,12 +299,12 @@ func NewSimApp(
 	//TODO: we may need to add acl gov proposal types here
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.GetSubspace(govtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, govRouter,
+		&stakingKeeper, govRouter, app.CacheSize,
 	)
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-			// register the governance hooks
+		// register the governance hooks
 		),
 	)
 

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -90,8 +90,8 @@ func (cmgr *CommitKVStoreCacheManager) Reset() {
 }
 
 // CacheWrap implements the CacheWrapper interface
-func (ckv *CommitKVStoreCache) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return cachekv.NewStore(ckv, storeKey)
+func (ckv *CommitKVStoreCache) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return cachekv.NewStore(ckv, storeKey, size)
 }
 
 // Get retrieves a value by key. It will first look in the write-through cache.

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -18,37 +18,59 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-// If value is nil but deleted is false, it means the parent doesn't have the
-// key.  (No need to delete upon Write())
-type cValue struct {
-	value []byte
-	dirty bool
+type mapCacheBackend struct {
+	m map[string]*types.CValue
+}
+
+func (b mapCacheBackend) Get(key string) (val *types.CValue, ok bool) {
+	val, ok = b.m[key]
+	return
+}
+
+func (b mapCacheBackend) Set(key string, val *types.CValue) {
+	b.m[key] = val
+}
+
+func (b mapCacheBackend) Len() int {
+	return len(b.m)
+}
+
+func (b mapCacheBackend) Delete(key string) {
+	delete(b.m, key)
+}
+
+func (b mapCacheBackend) Range(f func(string, *types.CValue) bool) {
+	for k, v := range b.m {
+		if !f(k, v) {
+			break
+		}
+	}
 }
 
 // Store wraps an in-memory cache around an underlying types.KVStore.
 type Store struct {
 	mtx           sync.Mutex
-	cache         map[string]*cValue
+	cache         *types.BoundedCache
 	deleted       map[string]struct{}
 	unsortedCache map[string]struct{}
 	sortedCache   *dbm.MemDB // always ascending sorted
 	parent        types.KVStore
 	eventManager  *sdktypes.EventManager
-	storeKey	  types.StoreKey
+	storeKey      types.StoreKey
 }
 
 var _ types.CacheKVStore = (*Store)(nil)
 
 // NewStore creates a new Store object
-func NewStore(parent types.KVStore, storeKey types.StoreKey) *Store {
+func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Store {
 	return &Store{
-		cache:         make(map[string]*cValue),
+		cache:         types.NewBoundedCache(mapCacheBackend{make(map[string]*types.CValue)}, cacheSize),
 		deleted:       make(map[string]struct{}),
 		unsortedCache: make(map[string]struct{}),
 		sortedCache:   dbm.NewMemDB(),
 		parent:        parent,
 		eventManager:  sdktypes.NewEventManager(),
-		storeKey: 	   storeKey,
+		storeKey:      storeKey,
 	}
 }
 
@@ -73,12 +95,12 @@ func (store *Store) Get(key []byte) (value []byte) {
 
 	types.AssertValidKey(key)
 
-	cacheValue, ok := store.cache[conv.UnsafeBytesToStr(key)]
+	cacheValue, ok := store.cache.Get(conv.UnsafeBytesToStr(key))
 	if !ok {
 		value = store.parent.Get(key)
 		store.setCacheValue(key, value, false, false)
 	} else {
-		value = cacheValue.value
+		value = cacheValue.Value()
 	}
 	store.eventManager.EmitResourceAccessReadEvent("get", store.storeKey, key, value)
 
@@ -123,13 +145,14 @@ func (store *Store) Write() {
 
 	// We need a copy of all of the keys.
 	// Not the best, but probably not a bottleneck depending.
-	keys := make([]string, 0, len(store.cache))
+	keys := make([]string, 0, store.cache.Len())
 
-	for key, dbValue := range store.cache {
-		if dbValue.dirty {
+	store.cache.Range(func(key string, dbValue *types.CValue) bool {
+		if dbValue.Dirty() {
 			keys = append(keys, key)
 		}
-	}
+		return true
+	})
 
 	sort.Strings(keys)
 
@@ -145,19 +168,20 @@ func (store *Store) Write() {
 			continue
 		}
 
-		cacheValue := store.cache[key]
-		if cacheValue.value != nil {
+		cacheValue, _ := store.cache.Get(key)
+		if cacheValue.Value() != nil {
 			// It already exists in the parent, hence delete it.
-			store.parent.Set([]byte(key), cacheValue.value)
+			store.parent.Set([]byte(key), cacheValue.Value())
 		}
 	}
 
 	// Clear the cache using the map clearing idiom
 	// and not allocating fresh objects.
 	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
-	for key := range store.cache {
-		delete(store.cache, key)
-	}
+	store.cache.Range(func(key string, _ *types.CValue) bool {
+		store.cache.Delete(key)
+		return true
+	})
 	for key := range store.deleted {
 		delete(store.deleted, key)
 	}
@@ -168,18 +192,18 @@ func (store *Store) Write() {
 }
 
 // CacheWrap implements CacheWrapper.
-func (store *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return NewStore(store, storeKey)
+func (store *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return NewStore(store, storeKey, size)
 }
 
 // CacheWrapWithTrace implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
-	return NewStore(tracekv.NewStore(store, w, tc), storeKey)
+func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
+	return NewStore(tracekv.NewStore(store, w, tc), storeKey, size)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey)
+func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
+	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey, size)
 }
 
 //----------------------------------------
@@ -312,8 +336,8 @@ func (store *Store) dirtyItems(start, end []byte) {
 	if n < 1024 {
 		for key := range store.unsortedCache {
 			if dbm.IsKeyInDomain(conv.UnsafeStrToBytes(key), start, end) {
-				cacheValue := store.cache[key]
-				unsorted = append(unsorted, &kv.Pair{Key: []byte(key), Value: cacheValue.value})
+				cacheValue, _ := store.cache.Get(key)
+				unsorted = append(unsorted, &kv.Pair{Key: []byte(key), Value: cacheValue.Value()})
 			}
 		}
 		store.clearUnsortedCacheSubset(unsorted, stateUnsorted)
@@ -343,8 +367,8 @@ func (store *Store) dirtyItems(start, end []byte) {
 	kvL := make([]*kv.Pair, 0)
 	for i := startIndex; i <= endIndex; i++ {
 		key := strL[i]
-		cacheValue := store.cache[key]
-		kvL = append(kvL, &kv.Pair{Key: []byte(key), Value: cacheValue.value})
+		cacheValue, _ := store.cache.Get(key)
+		kvL = append(kvL, &kv.Pair{Key: []byte(key), Value: cacheValue.Value()})
 	}
 
 	// kvL was already sorted so pass it in as is.
@@ -389,10 +413,7 @@ func (store *Store) clearUnsortedCacheSubset(unsorted []*kv.Pair, sortState sort
 // Only entrypoint to mutate store.cache.
 func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
 	keyStr := conv.UnsafeBytesToStr(key)
-	store.cache[keyStr] = &cValue{
-		value: value,
-		dirty: dirty,
-	}
+	store.cache.Set(keyStr, types.NewCValue(value, dirty))
 	if deleted {
 		store.deleted[keyStr] = struct{}{}
 	} else {

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -40,8 +40,14 @@ func (b mapCacheBackend) Delete(key string) {
 }
 
 func (b mapCacheBackend) Range(f func(string, *types.CValue) bool) {
-	for k, v := range b.m {
-		if !f(k, v) {
+	// this is always called within a mutex so all operations below are atomic
+	keys := []string{}
+	for k := range b.m {
+		keys = append(keys, k)
+	}
+	for _, key := range keys {
+		val, _ := b.Get(key)
+		if !f(key, val) {
 			break
 		}
 	}

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -178,10 +178,7 @@ func (store *Store) Write() {
 	// Clear the cache using the map clearing idiom
 	// and not allocating fresh objects.
 	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
-	store.cache.Range(func(key string, _ *types.CValue) bool {
-		store.cache.Delete(key)
-		return true
-	})
+	store.cache.DeleteAll()
 	for key := range store.deleted {
 		delete(store.deleted, key)
 	}

--- a/store/cachekv/store_bench_test.go
+++ b/store/cachekv/store_bench_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
+	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
 var sink interface{}
@@ -16,7 +17,7 @@ const defaultValueSizeBz = 1 << 12
 // This benchmark measures the time of iterator.Next() when the parent store is blank
 func benchmarkBlankParentIteratorNext(b *testing.B, keysize int) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 	// Use a singleton for value, to not waste time computing it
 	value := randSlice(defaultValueSizeBz)
 	// Use simple values for keys, pick a random start,
@@ -44,7 +45,7 @@ func benchmarkBlankParentIteratorNext(b *testing.B, keysize int) {
 // Benchmark setting New keys to a store, where the new keys are in sequence.
 func benchmarkBlankParentAppend(b *testing.B, keysize int) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 
 	// Use a singleton for value, to not waste time computing it
 	value := randSlice(32)
@@ -66,7 +67,7 @@ func benchmarkBlankParentAppend(b *testing.B, keysize int) {
 // the speed of this function does not depend on the values in the parent store
 func benchmarkRandomSet(b *testing.B, keysize int) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 
 	// Use a singleton for value, to not waste time computing it
 	value := randSlice(defaultValueSizeBz)
@@ -105,7 +106,7 @@ func benchmarkIteratorOnParentWithManyDeletes(b *testing.B, numDeletes int) {
 	for _, k := range keys {
 		mem.Set(k, value)
 	}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 	// Delete all keys from the cache KV store.
 	// The keys[1:] is to keep at least one entry in parent, due to a bug in the SDK iterator design.
 	// Essentially the iterator will never be valid, in that it should never run.

--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -15,7 +15,7 @@ import (
 
 func newCacheKVStore() types.CacheKVStore {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	return cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	return cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 }
 
 func keyFmt(i int) []byte { return bz(fmt.Sprintf("key%0.8d", i)) }
@@ -23,7 +23,7 @@ func valFmt(i int) []byte { return bz(fmt.Sprintf("value%0.8d", i)) }
 
 func TestCacheKVStore(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 
 	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
 
@@ -49,11 +49,11 @@ func TestCacheKVStore(t *testing.T) {
 	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
 
 	// make a new one, check it
-	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
 
 	// make a new one and delete - should not be removed from mem
-	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	st.Delete(keyFmt(1))
 	require.Empty(t, st.Get(keyFmt(1)))
 	require.Equal(t, mem.Get(keyFmt(1)), valFmt(2))
@@ -66,7 +66,7 @@ func TestCacheKVStore(t *testing.T) {
 
 func TestCacheKVStoreNoNilSet(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	require.Panics(t, func() { st.Set([]byte("key"), nil) }, "setting a nil value should panic")
 	require.Panics(t, func() { st.Set(nil, []byte("value")) }, "setting a nil key should panic")
 	require.Panics(t, func() { st.Set([]byte(""), []byte("value")) }, "setting an empty key should panic")
@@ -74,7 +74,7 @@ func TestCacheKVStoreNoNilSet(t *testing.T) {
 
 func TestCacheKVStoreNested(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 
 	// set. check its there on st and not on mem.
 	st.Set(keyFmt(1), valFmt(1))
@@ -82,7 +82,7 @@ func TestCacheKVStoreNested(t *testing.T) {
 	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
 
 	// make a new from st and check
-	st2 := cachekv.NewStore(st, types.NewKVStoreKey("CacheKvTest"))
+	st2 := cachekv.NewStore(st, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	require.Equal(t, valFmt(1), st2.Get(keyFmt(1)))
 
 	// update the value on st2, check it only effects st2

--- a/store/concurrentcachekv/store.go
+++ b/store/concurrentcachekv/store.go
@@ -184,10 +184,7 @@ func (store *Store) Write() {
 	// Clear the cache using the map clearing idiom
 	// and not allocating fresh objects.
 	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
-	store.cache.Range(func(key string, _ *types.CValue) bool {
-		store.cache.Delete(key)
-		return true
-	})
+	store.cache.DeleteAll()
 
 	store.deleted.Range(func(key, value any) bool {
 		store.deleted.Delete(key)

--- a/store/concurrentcachekv/store.go
+++ b/store/concurrentcachekv/store.go
@@ -2,7 +2,6 @@ package cachekv
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"sort"
 	"sync"
@@ -20,35 +19,64 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-// If value is nil but deleted is false, it means the parent doesn't have the
-// key.  (No need to delete upon Write())
-type cValue struct {
-	value []byte
-	dirty bool
+type syncMapCacheBackend struct {
+	m sync.Map
+}
+
+func (b syncMapCacheBackend) Get(key string) (*types.CValue, bool) {
+	val, ok := b.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	typedVal, ok := val.(*types.CValue)
+	return typedVal, ok
+}
+
+func (b syncMapCacheBackend) Set(key string, val *types.CValue) {
+	b.m.Store(key, val)
+}
+
+func (b syncMapCacheBackend) Len() (len int) {
+	b.m.Range(func(_, _ any) bool {
+		len++
+		return true
+	})
+	return
+}
+
+func (b syncMapCacheBackend) Delete(key string) {
+	b.m.Delete(key)
+}
+
+func (b syncMapCacheBackend) Range(f func(string, *types.CValue) bool) {
+	b.m.Range(func(k, v any) bool {
+		return f(k.(string), v.(*types.CValue))
+	})
 }
 
 // Store wraps an in-memory cache around an underlying types.KVStore.
 // Concurrent Safe Version of CacheKV
 type Store struct {
 	mtx           sync.Mutex
-	cache         *sync.Map
+	cache         *types.BoundedCache
 	deleted       *sync.Map
 	unsortedCache *sync.Map
 	sortedCache   *dbm.MemDB // always ascending sorted
 	parent        types.KVStore
 	eventManager  *sdktypes.EventManager
-	storeKey	  types.StoreKey
+	storeKey      types.StoreKey
 }
 
 var _ types.CacheKVStore = (*Store)(nil)
 
 // NewStore creates a new Store object
-func NewStore(parent types.KVStore, storeKey types.StoreKey) *Store {
+func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Store {
 	return &Store{
-		sortedCache:   dbm.NewMemDB(),
-		parent:        parent,
-		eventManager:  sdktypes.NewEventManager(),
-		storeKey: 	   storeKey,
+		cache:        types.NewBoundedCache(syncMapCacheBackend{sync.Map{}}, cacheSize),
+		sortedCache:  dbm.NewMemDB(),
+		parent:       parent,
+		eventManager: sdktypes.NewEventManager(),
+		storeKey:     storeKey,
 	}
 }
 
@@ -73,13 +101,12 @@ func (store *Store) Get(key []byte) (value []byte) {
 
 	types.AssertValidKey(key)
 
-	val, ok := store.cache.Load(conv.UnsafeBytesToStr(key))
-	cacheValue := val.(*cValue)
+	cacheValue, ok := store.cache.Get(conv.UnsafeBytesToStr(key))
 	if !ok {
 		value = store.parent.Get(key)
 		store.setCacheValue(key, value, false, false)
 	} else {
-		value = cacheValue.value
+		value = cacheValue.Value()
 	}
 	store.eventManager.EmitResourceAccessReadEvent("get", store.storeKey, key, value)
 
@@ -126,11 +153,9 @@ func (store *Store) Write() {
 	// Not the best, but probably not a bottleneck depending.
 	keys := make([]string, 0)
 
-	store.cache.Range(func(key, value any) bool {
-		stringKey := key.(string)
-		cacheValue := value.(*cValue)
-		if cacheValue.dirty {
-			keys = append(keys, stringKey)
+	store.cache.Range(func(key string, dbValue *types.CValue) bool {
+		if dbValue.Dirty() {
+			keys = append(keys, key)
 		}
 		return true
 	})
@@ -149,21 +174,17 @@ func (store *Store) Write() {
 			continue
 		}
 
-		value, ok := store.cache.Load(key)
-		if !ok {
-			panic(fmt.Sprintf("Cache Store key=%s should exist in ConcurrentCacheKV store", key))
-		}
-		cacheValue := value.(*cValue)
-		if cacheValue.value != nil {
+		cacheValue, _ := store.cache.Get(key)
+		if cacheValue.Value() != nil {
 			// It already exists in the parent, hence delete it.
-			store.parent.Set([]byte(key), cacheValue.value)
+			store.parent.Set([]byte(key), cacheValue.Value())
 		}
 	}
 
 	// Clear the cache using the map clearing idiom
 	// and not allocating fresh objects.
 	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
-	store.cache.Range(func(key, value any) bool {
+	store.cache.Range(func(key string, _ *types.CValue) bool {
 		store.cache.Delete(key)
 		return true
 	})
@@ -181,18 +202,18 @@ func (store *Store) Write() {
 }
 
 // CacheWrap implements CacheWrapper.
-func (store *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return NewStore(store, storeKey)
+func (store *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return NewStore(store, storeKey, size)
 }
 
 // CacheWrapWithTrace implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
-	return NewStore(tracekv.NewStore(store, w, tc), storeKey)
+func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
+	return NewStore(tracekv.NewStore(store, w, tc), storeKey, size)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey)
+func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
+	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey, size)
 }
 
 //----------------------------------------
@@ -330,12 +351,8 @@ func (store *Store) dirtyItems(start, end []byte) {
 		store.unsortedCache.Range(func(key, value any) bool {
 			stringKey := key.(string)
 			if dbm.IsKeyInDomain(conv.UnsafeStrToBytes(stringKey), start, end) {
-				value, ok := store.cache.Load(key)
-				if !ok {
-					panic(fmt.Sprintf("key=%s should exist in ConcurrentCacheKv", stringKey))
-				}
-				cacheValue := value.(*cValue)
-				unsorted = append(unsorted, &kv.Pair{Key: []byte(stringKey), Value: cacheValue.value})
+				cacheValue, _ := store.cache.Get(stringKey)
+				unsorted = append(unsorted, &kv.Pair{Key: []byte(stringKey), Value: cacheValue.Value()})
 			}
 			return true
 		})
@@ -368,12 +385,8 @@ func (store *Store) dirtyItems(start, end []byte) {
 	kvL := make([]*kv.Pair, 0)
 	for i := startIndex; i <= endIndex; i++ {
 		key := strL[i]
-		value,  ok := store.cache.Load(key)
-		if !ok {
-			panic(fmt.Sprintf("key=%s should exist in ConcurrentCacheKv", key))
-		}
-		cacheValue := value.(*cValue)
-		kvL = append(kvL, &kv.Pair{Key: []byte(key), Value: cacheValue.value})
+		cacheValue, _ := store.cache.Get(key)
+		kvL = append(kvL, &kv.Pair{Key: []byte(key), Value: cacheValue.Value()})
 	}
 
 	// kvL was already sorted so pass it in as is.
@@ -412,10 +425,7 @@ func (store *Store) clearUnsortedCacheSubset(unsorted []*kv.Pair, sortState sort
 // Only entrypoint to mutate store.cache.
 func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
 	keyStr := conv.UnsafeBytesToStr(key)
-	store.cache.Store(
-		keyStr,
-		&cValue{ value: value, dirty: dirty},
-	)
+	store.cache.Set(keyStr, types.NewCValue(value, dirty))
 	if deleted {
 		store.deleted.Store(keyStr, struct{}{})
 	} else {

--- a/store/concurrentcachekv/store_bench_test.go
+++ b/store/concurrentcachekv/store_bench_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
+	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
 var sink interface{}
@@ -16,7 +17,7 @@ const defaultValueSizeBz = 1 << 12
 // This benchmark measures the time of iterator.Next() when the parent store is blank
 func benchmarkBlankParentIteratorNext(b *testing.B, keysize int) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 	// Use a singleton for value, to not waste time computing it
 	value := randSlice(defaultValueSizeBz)
 	// Use simple values for keys, pick a random start,
@@ -44,7 +45,7 @@ func benchmarkBlankParentIteratorNext(b *testing.B, keysize int) {
 // Benchmark setting New keys to a store, where the new keys are in sequence.
 func benchmarkBlankParentAppend(b *testing.B, keysize int) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 
 	// Use a singleton for value, to not waste time computing it
 	value := randSlice(32)
@@ -66,7 +67,7 @@ func benchmarkBlankParentAppend(b *testing.B, keysize int) {
 // the speed of this function does not depend on the values in the parent store
 func benchmarkRandomSet(b *testing.B, keysize int) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 
 	// Use a singleton for value, to not waste time computing it
 	value := randSlice(defaultValueSizeBz)
@@ -105,7 +106,7 @@ func benchmarkIteratorOnParentWithManyDeletes(b *testing.B, numDeletes int) {
 	for _, k := range keys {
 		mem.Set(k, value)
 	}
-	kvstore := cachekv.NewStore(mem, nil)
+	kvstore := cachekv.NewStore(mem, nil, types.DefaultCacheSizeLimit)
 	// Delete all keys from the cache KV store.
 	// The keys[1:] is to keep at least one entry in parent, due to a bug in the SDK iterator design.
 	// Essentially the iterator will never be valid, in that it should never run.

--- a/store/concurrentcachekv/store_test.go
+++ b/store/concurrentcachekv/store_test.go
@@ -15,7 +15,7 @@ import (
 
 func newCacheKVStore() types.CacheKVStore {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	return cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	return cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 }
 
 func keyFmt(i int) []byte { return bz(fmt.Sprintf("key%0.8d", i)) }
@@ -23,7 +23,7 @@ func valFmt(i int) []byte { return bz(fmt.Sprintf("value%0.8d", i)) }
 
 func TestCacheKVStore(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 
 	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
 
@@ -49,11 +49,11 @@ func TestCacheKVStore(t *testing.T) {
 	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
 
 	// make a new one, check it
-	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
 
 	// make a new one and delete - should not be removed from mem
-	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	st.Delete(keyFmt(1))
 	require.Empty(t, st.Get(keyFmt(1)))
 	require.Equal(t, mem.Get(keyFmt(1)), valFmt(2))
@@ -66,7 +66,7 @@ func TestCacheKVStore(t *testing.T) {
 
 func TestCacheKVStoreNoNilSet(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	require.Panics(t, func() { st.Set([]byte("key"), nil) }, "setting a nil value should panic")
 	require.Panics(t, func() { st.Set(nil, []byte("value")) }, "setting a nil key should panic")
 	require.Panics(t, func() { st.Set([]byte(""), []byte("value")) }, "setting an empty key should panic")
@@ -74,7 +74,7 @@ func TestCacheKVStoreNoNilSet(t *testing.T) {
 
 func TestCacheKVStoreNested(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"))
+	st := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 
 	// set. check its there on st and not on mem.
 	st.Set(keyFmt(1), valFmt(1))
@@ -82,7 +82,7 @@ func TestCacheKVStoreNested(t *testing.T) {
 	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
 
 	// make a new from st and check
-	st2 := cachekv.NewStore(st, types.NewKVStoreKey("CacheKvTest"))
+	st2 := cachekv.NewStore(st, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	require.Equal(t, valFmt(1), st2.Get(keyFmt(1)))
 
 	// update the value on st2, check it only effects st2

--- a/store/dbadapter/store.go
+++ b/store/dbadapter/store.go
@@ -81,18 +81,18 @@ func (Store) GetStoreType() types.StoreType {
 }
 
 // CacheWrap branches the underlying store.
-func (dsa Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return cachekv.NewStore(dsa, storeKey)
+func (dsa Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return cachekv.NewStore(dsa, storeKey, size)
 }
 
 // CacheWrapWithTrace implements KVStore.
-func (dsa Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(dsa, w, tc), storeKey)
+func (dsa Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(dsa, w, tc), storeKey, size)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (dsa Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(dsa, storeKey, listeners), storeKey)
+func (dsa Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(dsa, storeKey, listeners), storeKey, size)
 }
 
 // dbm.DB implements KVStore so we can CacheKVStore it.

--- a/store/dbadapter/store_test.go
+++ b/store/dbadapter/store_test.go
@@ -79,12 +79,12 @@ func TestCacheWraps(t *testing.T) {
 	mockDB := mocks.NewMockDB(mockCtrl)
 	store := dbadapter.Store{mockDB}
 
-	cacheWrapper := store.CacheWrap(nil)
+	cacheWrapper := store.CacheWrap(nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil)
+	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
+	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -91,17 +91,17 @@ func (gs *Store) ReverseIterator(start, end []byte) types.Iterator {
 }
 
 // Implements KVStore.
-func (gs *Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
+func (gs *Store) CacheWrap(_ types.StoreKey, _ int) types.CacheWrap {
 	panic("cannot CacheWrap a GasKVStore")
 }
 
 // CacheWrapWithTrace implements the KVStore interface.
-func (gs *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
+func (gs *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext, _ int) types.CacheWrap {
 	panic("cannot CacheWrapWithTrace a GasKVStore")
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (gs *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+func (gs *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener, _ int) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a GasKVStore")
 }
 

--- a/store/gaskv/store_test.go
+++ b/store/gaskv/store_test.go
@@ -23,9 +23,9 @@ func TestGasKVStoreBasic(t *testing.T) {
 	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
 
 	require.Equal(t, types.StoreTypeDB, st.GetStoreType())
-	require.Panics(t, func() { st.CacheWrap(nil) })
-	require.Panics(t, func() { st.CacheWrapWithTrace(nil, nil, nil) })
-	require.Panics(t, func() { st.CacheWrapWithListeners(nil, nil) })
+	require.Panics(t, func() { st.CacheWrap(nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { st.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { st.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit) })
 
 	require.Panics(t, func() { st.Set(nil, []byte("value")) }, "setting a nil key should panic")
 	require.Panics(t, func() { st.Set([]byte(""), []byte("value")) }, "setting an empty key should panic")

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -35,7 +35,8 @@ var (
 
 // Store Implements types.KVStore and CommitKVStore.
 type Store struct {
-	tree Tree
+	tree       Tree
+	cacheLimit int
 }
 
 // LoadStore returns an IAVL Store as a CommitKVStore. Internally, it will load the
@@ -158,18 +159,18 @@ func (st *Store) GetStoreType() types.StoreType {
 }
 
 // Implements Store.
-func (st *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return cachekv.NewStore(st, storeKey)
+func (st *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return cachekv.NewStore(st, storeKey, size)
 }
 
 // CacheWrapWithTrace implements the Store interface.
-func (st *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(st, w, tc), storeKey)
+func (st *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(st, w, tc), storeKey, size)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (st *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(st, storeKey, listeners), storeKey)
+func (st *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(st, storeKey, listeners), storeKey, size)
 }
 
 // Implements types.KVStore.

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -642,12 +642,12 @@ func TestCacheWraps(t *testing.T) {
 	tree, _ := newAlohaTree(t, db)
 	store := UnsafeNewStore(tree)
 
-	cacheWrapper := store.CacheWrap(nil)
+	cacheWrapper := store.CacheWrap(nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil)
+	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
+	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/listenkv/store.go
+++ b/store/listenkv/store.go
@@ -135,19 +135,19 @@ func (s *Store) GetStoreType() types.StoreType {
 
 // CacheWrap implements the KVStore interface. It panics as a Store
 // cannot be cache wrapped.
-func (s *Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
+func (s *Store) CacheWrap(_ types.StoreKey, _ int) types.CacheWrap {
 	panic("cannot CacheWrap a ListenKVStore")
 }
 
 // CacheWrapWithTrace implements the KVStore interface. It panics as a
 // Store cannot be cache wrapped.
-func (s *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
+func (s *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext, _ int) types.CacheWrap {
 	panic("cannot CacheWrapWithTrace a ListenKVStore")
 }
 
 // CacheWrapWithListeners implements the KVStore interface. It panics as a
 // Store cannot be cache wrapped.
-func (s *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+func (s *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener, _ int) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a ListenKVStore")
 }
 

--- a/store/listenkv/store_test.go
+++ b/store/listenkv/store_test.go
@@ -284,15 +284,15 @@ func TestListenKVStoreGetStoreType(t *testing.T) {
 
 func TestListenKVStoreCacheWrap(t *testing.T) {
 	store := newEmptyListenKVStore(nil)
-	require.Panics(t, func() { store.CacheWrap(nil) })
+	require.Panics(t, func() { store.CacheWrap(nil, types.DefaultCacheSizeLimit) })
 }
 
 func TestListenKVStoreCacheWrapWithTrace(t *testing.T) {
 	store := newEmptyListenKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil) })
+	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit) })
 }
 
 func TestListenKVStoreCacheWrapWithListeners(t *testing.T) {
 	store := newEmptyListenKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil) })
+	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit) })
 }

--- a/store/mem/mem_test.go
+++ b/store/mem/mem_test.go
@@ -28,13 +28,13 @@ func TestStore(t *testing.T) {
 	db.Delete(key)
 	require.Nil(t, db.Get(key))
 
-	cacheWrapper := db.CacheWrap(nil)
+	cacheWrapper := db.CacheWrap(nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := db.CacheWrapWithTrace(nil, nil, nil)
+	cacheWrappedWithTrace := db.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := db.CacheWrapWithListeners(nil, nil)
+	cacheWrappedWithListeners := db.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }
 

--- a/store/mem/store.go
+++ b/store/mem/store.go
@@ -37,18 +37,18 @@ func (s Store) GetStoreType() types.StoreType {
 }
 
 // CacheWrap branches the underlying store.
-func (s Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return cachekv.NewStore(s, storeKey)
+func (s Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return cachekv.NewStore(s, storeKey, size)
 }
 
 // CacheWrapWithTrace implements KVStore.
-func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey)
+func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey, size)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey)
+func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey, size)
 }
 
 // Commit performs a no-op as entries are persistent between commitments.

--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -49,18 +49,18 @@ func (s Store) GetStoreType() types.StoreType {
 }
 
 // Implements CacheWrap
-func (s Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
-	return cachekv.NewStore(s, storeKey)
+func (s Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
+	return cachekv.NewStore(s, storeKey, size)
 }
 
 // CacheWrapWithTrace implements the KVStore interface.
-func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey)
+func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey, size)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey)
+func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey, size)
 }
 
 func (s Store) GetWorkingHash() []byte {

--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -433,12 +433,12 @@ func TestCacheWraps(t *testing.T) {
 	db := dbm.NewMemDB()
 	store := dbadapter.Store{DB: db}
 
-	cacheWrapper := store.CacheWrap(nil)
+	cacheWrapper := store.CacheWrap(nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil)
+	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
+	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -63,7 +63,7 @@ func TestCacheMultiStore(t *testing.T) {
 	var db dbm.DB = dbm.NewMemDB()
 	ms := newMultiStoreWithMounts(db, types.PruneNothing)
 
-	cacheMulti := ms.CacheMultiStore()
+	cacheMulti := ms.CacheMultiStore(types.DefaultCacheSizeLimit)
 	require.IsType(t, cachemulti.Store{}, cacheMulti)
 }
 
@@ -85,11 +85,11 @@ func TestCacheMultiStoreWithVersion(t *testing.T) {
 	require.Equal(t, int64(1), cID.Version)
 
 	// require no failure when given an invalid or pruned version
-	_, err = ms.CacheMultiStoreWithVersion(cID.Version + 1)
+	_, err = ms.CacheMultiStoreWithVersion(cID.Version+1, types.DefaultCacheSizeLimit)
 	require.NoError(t, err)
 
 	// require a valid version can be cache-loaded
-	cms, err := ms.CacheMultiStoreWithVersion(cID.Version)
+	cms, err := ms.CacheMultiStoreWithVersion(cID.Version, types.DefaultCacheSizeLimit)
 	require.NoError(t, err)
 
 	// require a valid key lookup yields the correct value
@@ -498,12 +498,12 @@ func TestMultiStore_Pruning(t *testing.T) {
 			}
 
 			for _, v := range tc.saved {
-				_, err := ms.CacheMultiStoreWithVersion(v)
+				_, err := ms.CacheMultiStoreWithVersion(v, types.DefaultCacheSizeLimit)
 				require.NoError(t, err, "expected error when loading height: %d", v)
 			}
 
 			for _, v := range tc.deleted {
-				_, err := ms.CacheMultiStoreWithVersion(v)
+				_, err := ms.CacheMultiStoreWithVersion(v, types.DefaultCacheSizeLimit)
 				require.NoError(t, err, "expected error when loading height: %d", v)
 			}
 		})
@@ -539,7 +539,7 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 	require.Empty(t, ms.pruneHeights)
 
 	for _, v := range pruneHeights {
-		_, err := ms.CacheMultiStoreWithVersion(v)
+		_, err := ms.CacheMultiStoreWithVersion(v, types.DefaultCacheSizeLimit)
 		require.NoError(t, err, "expected error when loading height: %d", v)
 	}
 }
@@ -671,13 +671,13 @@ func TestCacheWraps(t *testing.T) {
 	db := dbm.NewMemDB()
 	multi := newMultiStoreWithMounts(db, types.PruneNothing)
 
-	cacheWrapper := multi.CacheWrap(nil)
+	cacheWrapper := multi.CacheWrap(nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, cachemulti.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := multi.CacheWrapWithTrace(nil, nil, nil)
+	cacheWrappedWithTrace := multi.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, cachemulti.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := multi.CacheWrapWithListeners(nil, nil)
+	cacheWrappedWithListeners := multi.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
 	require.IsType(t, cachemulti.Store{}, cacheWrappedWithListeners)
 }
 
@@ -694,9 +694,9 @@ func TestTraceConcurrency(t *testing.T) {
 	multi.SetTracer(b)
 	multi.SetTracingContext(tc)
 
-	cms := multi.CacheMultiStore()
+	cms := multi.CacheMultiStore(types.DefaultCacheSizeLimit)
 	store1 := cms.GetKVStore(key)
-	cw := store1.CacheWrapWithTrace(nil, b, tc)
+	cw := store1.CacheWrapWithTrace(nil, b, tc, types.DefaultCacheSizeLimit)
 	_ = cw
 	require.NotNil(t, store1)
 

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -167,18 +167,18 @@ func (tkv *Store) GetStoreType() types.StoreType {
 
 // CacheWrap implements the KVStore interface. It panics because a Store
 // cannot be branched.
-func (tkv *Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
+func (tkv *Store) CacheWrap(_ types.StoreKey, _ int) types.CacheWrap {
 	panic("cannot CacheWrap a TraceKVStore")
 }
 
 // CacheWrapWithTrace implements the KVStore interface. It panics as a
 // Store cannot be branched.
-func (tkv *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
+func (tkv *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext, _ int) types.CacheWrap {
 	panic("cannot CacheWrapWithTrace a TraceKVStore")
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (tkv *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+func (tkv *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener, _ int) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a TraceKVStore")
 }
 

--- a/store/tracekv/store_test.go
+++ b/store/tracekv/store_test.go
@@ -284,15 +284,15 @@ func TestTraceKVStoreGetStoreType(t *testing.T) {
 
 func TestTraceKVStoreCacheWrap(t *testing.T) {
 	store := newEmptyTraceKVStore(nil)
-	require.Panics(t, func() { store.CacheWrap(nil) })
+	require.Panics(t, func() { store.CacheWrap(nil, types.DefaultCacheSizeLimit) })
 }
 
 func TestTraceKVStoreCacheWrapWithTrace(t *testing.T) {
 	store := newEmptyTraceKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil) })
+	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit) })
 }
 
 func TestTraceKVStoreCacheWrapWithListeners(t *testing.T) {
 	store := newEmptyTraceKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil) })
+	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit) })
 }

--- a/store/types/cache.go
+++ b/store/types/cache.go
@@ -69,7 +69,7 @@ func (c *BoundedCache) Set(key string, val *CValue) {
 			return len >= c.limit
 		})
 		for _, key := range keysToEvict {
-			c.Delete(key)
+			c.CacheBackend.Delete(key)
 		}
 	}
 	c.CacheBackend.Set(key, val)
@@ -80,6 +80,16 @@ func (c *BoundedCache) Delete(key string) {
 	defer c.mu.Unlock()
 
 	c.CacheBackend.Delete(key)
+}
+
+func (c *BoundedCache) DeleteAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.CacheBackend.Range(func(key string, _ *CValue) bool {
+		c.CacheBackend.Delete(key)
+		return true
+	})
 }
 
 func (c *BoundedCache) Range(f func(string, *CValue) bool) {

--- a/store/types/cache.go
+++ b/store/types/cache.go
@@ -1,0 +1,90 @@
+package types
+
+import "sync"
+
+const DefaultCacheSizeLimit = 1000000
+
+// If value is nil but deleted is false, it means the parent doesn't have the
+// key.  (No need to delete upon Write())
+type CValue struct {
+	value []byte
+	dirty bool
+}
+
+func NewCValue(value []byte, dirty bool) *CValue {
+	return &CValue{
+		value: value,
+		dirty: dirty,
+	}
+}
+
+func (v *CValue) Value() []byte {
+	return v.value
+}
+
+func (v *CValue) Dirty() bool {
+	return v.dirty
+}
+
+type CacheBackend interface {
+	Get(string) (*CValue, bool)
+	Set(string, *CValue)
+	Len() int
+	Delete(string)
+	Range(func(string, *CValue) bool)
+}
+
+// This struct is solely for the purpose of preventing the process from crashing because of
+// OOM. It is not intended for usage at limit during normal operation. The node operator
+// should minimize the time of running at cache limit by switching to a machine with larger
+// RAM and bump up cache limit in app config, once the old limit is seen to be reached.
+type BoundedCache struct {
+	CacheBackend
+	limit int
+
+	mu *sync.Mutex
+}
+
+func NewBoundedCache(backend CacheBackend, limit int) *BoundedCache {
+	if limit == 0 {
+		panic("cache limit must be at least 1")
+	}
+	return &BoundedCache{
+		CacheBackend: backend,
+		limit:        limit,
+		mu:           &sync.Mutex{},
+	}
+}
+
+func (c *BoundedCache) Set(key string, val *CValue) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.Len() >= c.limit {
+		len := c.Len()
+		keysToEvict := []string{}
+		c.CacheBackend.Range(func(key string, _ *CValue) bool {
+			keysToEvict = append(keysToEvict, key)
+			len--
+			return len >= c.limit
+		})
+		for _, key := range keysToEvict {
+			c.Delete(key)
+		}
+	}
+	c.CacheBackend.Set(key, val)
+}
+
+func (c *BoundedCache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.CacheBackend.Delete(key)
+}
+
+func (c *BoundedCache) Range(f func(string, *CValue) bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.CacheBackend.Range(f)
+}

--- a/store/types/cache_test.go
+++ b/store/types/cache_test.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mapCacheBackend struct {
+	m map[string]*CValue
+}
+
+func (b mapCacheBackend) Get(key string) (val *CValue, ok bool) {
+	val, ok = b.m[key]
+	return
+}
+
+func (b mapCacheBackend) Set(key string, val *CValue) {
+	b.m[key] = val
+}
+
+func (b mapCacheBackend) Len() int {
+	return len(b.m)
+}
+
+func (b mapCacheBackend) Delete(key string) {
+	delete(b.m, key)
+}
+
+func (b mapCacheBackend) Range(f func(string, *CValue) bool) {
+	for k, v := range b.m {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+func TestCacheLimit(t *testing.T) {
+	cache := NewBoundedCache(mapCacheBackend{make(map[string]*CValue)}, 2)
+	require.Equal(t, 0, cache.Len())
+	cache.Set("abc", &CValue{value: []byte("123")})
+	require.Equal(t, 1, cache.Len())
+	v, ok := cache.Get("abc")
+	require.True(t, ok)
+	require.Equal(t, "123", string(v.value))
+	cache.Set("def", &CValue{value: []byte("456")})
+	require.Equal(t, 2, cache.Len())
+	v, ok = cache.Get("abc")
+	require.True(t, ok)
+	require.Equal(t, "123", string(v.value))
+	v, ok = cache.Get("def")
+	require.True(t, ok)
+	require.Equal(t, "456", string(v.value))
+	cache.Set("ghi", &CValue{value: []byte("789")})
+	require.Equal(t, 2, cache.Len())
+	v, ok = cache.Get("ghi")
+	require.True(t, ok)
+	require.Equal(t, "789", string(v.value))
+	// only one of abc and def should still exist in the cache. We don't care which one
+	if v, ok := cache.Get("abc"); ok {
+		require.Equal(t, "123", string(v.value))
+		_, ok = cache.Get("def")
+		require.False(t, ok)
+	} else {
+		v, ok = cache.Get("def")
+		require.True(t, ok)
+		require.Equal(t, "456", string(v.value))
+	}
+
+	cache.Delete("ghi")
+	require.Equal(t, 1, cache.Len())
+}

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -107,11 +107,11 @@ type MultiStore interface {
 	// Branches MultiStore into a cached storage object.
 	// NOTE: Caller should probably not call .Write() on each, but
 	// call CacheMultiStore.Write().
-	CacheMultiStore() CacheMultiStore
+	CacheMultiStore(size int) CacheMultiStore
 
 	// CacheMultiStoreWithVersion branches the underlying MultiStore where
 	// each stored is loaded at a specific version (height).
-	CacheMultiStoreWithVersion(version int64) (CacheMultiStore, error)
+	CacheMultiStoreWithVersion(version int64, size int) (CacheMultiStore, error)
 
 	// Convenience for fetching substores.
 	// If the store does not exist, panics.
@@ -276,24 +276,24 @@ type CacheWrap interface {
 	GetEvents() []abci.Event
 
 	// CacheWrap recursively wraps again.
-	CacheWrap(storeKey StoreKey) CacheWrap
+	CacheWrap(storeKey StoreKey, size int) CacheWrap
 
 	// CacheWrapWithTrace recursively wraps again with tracing enabled.
-	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext) CacheWrap
+	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext, size int) CacheWrap
 
 	// CacheWrapWithListeners recursively wraps again with listening enabled
-	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener) CacheWrap
+	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener, size int) CacheWrap
 }
 
 type CacheWrapper interface {
 	// CacheWrap branches a store.
-	CacheWrap(storeKey StoreKey) CacheWrap
+	CacheWrap(storeKey StoreKey, size int) CacheWrap
 
 	// CacheWrapWithTrace branches a store with tracing enabled.
-	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext) CacheWrap
+	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext, size int) CacheWrap
 
 	// CacheWrapWithListeners recursively wraps again with listening enabled
-	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener) CacheWrap
+	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener, size int) CacheWrap
 }
 
 func (cid CommitID) IsZero() bool {

--- a/types/context.go
+++ b/types/context.go
@@ -41,12 +41,12 @@ type Context struct {
 	eventManager  *EventManager
 	priority      int64 // The tx priority, only relevant in CheckTx
 
-	txBlockingChannels		acltypes.MessageAccessOpsChannelMapping
-	txCompletionChannels	acltypes.MessageAccessOpsChannelMapping
-	txMsgAccessOps			map[int][]acltypes.AccessOperation
+	txBlockingChannels   acltypes.MessageAccessOpsChannelMapping
+	txCompletionChannels acltypes.MessageAccessOpsChannelMapping
+	txMsgAccessOps       map[int][]acltypes.AccessOperation
 
 	msgValidator *acltypes.MsgValidator
-	messageIndex int	// Used to track current message being processed
+	messageIndex int // Used to track current message being processed
 
 	contextMemCache *ContextMemCache
 }
@@ -70,12 +70,16 @@ func (c Context) IsReCheckTx() bool           { return c.recheckTx }
 func (c Context) MinGasPrices() DecCoins      { return c.minGasPrice }
 func (c Context) EventManager() *EventManager { return c.eventManager }
 func (c Context) Priority() int64             { return c.priority }
-func (c Context) TxCompletionChannels() acltypes.MessageAccessOpsChannelMapping { return c.txCompletionChannels }
-func (c Context) TxBlockingChannels() 	acltypes.MessageAccessOpsChannelMapping { return c.txBlockingChannels }
-func (c Context) TxMsgAccessOps() map[int][]acltypes.AccessOperation		  { return c.txMsgAccessOps }
-func (c Context) MessageIndex() int		  { return c.messageIndex }
-func (c Context) MsgValidator() *acltypes.MsgValidator { return c.msgValidator }
-func (c Context) ContextMemCache() *ContextMemCache { return c.contextMemCache }
+func (c Context) TxCompletionChannels() acltypes.MessageAccessOpsChannelMapping {
+	return c.txCompletionChannels
+}
+func (c Context) TxBlockingChannels() acltypes.MessageAccessOpsChannelMapping {
+	return c.txBlockingChannels
+}
+func (c Context) TxMsgAccessOps() map[int][]acltypes.AccessOperation { return c.txMsgAccessOps }
+func (c Context) MessageIndex() int                                  { return c.messageIndex }
+func (c Context) MsgValidator() *acltypes.MsgValidator               { return c.msgValidator }
+func (c Context) ContextMemCache() *ContextMemCache                  { return c.contextMemCache }
 
 // clone the header before returning
 func (c Context) BlockHeader() tmproto.Header {
@@ -105,20 +109,20 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 	// https://github.com/gogo/protobuf/issues/519
 	header.Time = header.Time.UTC()
 	return Context{
-		ctx:          context.Background(),
-		ms:           ms,
-		header:       header,
-		chainID:      header.ChainID,
-		checkTx:      isCheckTx,
-		logger:       logger,
-		gasMeter:     stypes.NewInfiniteGasMeter(),
-		minGasPrice:  DecCoins{},
-		eventManager: NewEventManager(),
+		ctx:             context.Background(),
+		ms:              ms,
+		header:          header,
+		chainID:         header.ChainID,
+		checkTx:         isCheckTx,
+		logger:          logger,
+		gasMeter:        stypes.NewInfiniteGasMeter(),
+		minGasPrice:     DecCoins{},
+		eventManager:    NewEventManager(),
 		contextMemCache: NewContextMemCache(),
 
-		txBlockingChannels:		make(acltypes.MessageAccessOpsChannelMapping),
-		txCompletionChannels:	make(acltypes.MessageAccessOpsChannelMapping),
-		txMsgAccessOps:			make(map[int][]acltypes.AccessOperation),
+		txBlockingChannels:   make(acltypes.MessageAccessOpsChannelMapping),
+		txCompletionChannels: make(acltypes.MessageAccessOpsChannelMapping),
+		txMsgAccessOps:       make(map[int][]acltypes.AccessOperation),
 	}
 }
 
@@ -249,7 +253,6 @@ func (c Context) WithTxMsgAccessOps(accessOps map[int][]acltypes.AccessOperation
 	return c
 }
 
-
 // WithTxCompletionChannels returns a Context with an updated list of completion channel
 func (c Context) WithTxCompletionChannels(completionChannels acltypes.MessageAccessOpsChannelMapping) Context {
 	c.txCompletionChannels = completionChannels
@@ -320,8 +323,8 @@ func (c Context) TransientStore(key StoreKey) KVStore {
 // CacheContext returns a new Context with the multi-store cached and a new
 // EventManager. The cached context is written to the context when writeCache
 // is called.
-func (c Context) CacheContext() (cc Context, writeCache func()) {
-	cms := c.MultiStore().CacheMultiStore()
+func (c Context) CacheContext(cacheSize int) (cc Context, writeCache func()) {
+	cms := c.MultiStore().CacheMultiStore(cacheSize)
 	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())
 	return cc, cms.Write
 }

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -11,6 +11,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/tests/mocks"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/types"
@@ -37,7 +38,7 @@ func (s *contextTestSuite) TestCacheContext() {
 	s.Require().Equal(v1, store.Get(k1))
 	s.Require().Nil(store.Get(k2))
 
-	cctx, write := ctx.CacheContext()
+	cctx, write := ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
 	cstore := cctx.KVStore(key)
 	s.Require().Equal(v1, cstore.Get(k1))
 	s.Require().Nil(cstore.Get(k2))

--- a/x/bank/handler_test.go
+++ b/x/bank/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/simapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -71,7 +72,7 @@ func TestSendToModuleAccount(t *testing.T) {
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		app.AppCodec(), app.GetKey(types.StoreKey), app.AccountKeeper, app.GetSubspace(types.ModuleName), map[string]bool{
 			moduleAccAddr.String(): true,
-		},
+		}, storetypes.DefaultCacheSizeLimit,
 	)
 	handler := bank.NewHandler(app.BankKeeper)
 

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -87,6 +87,7 @@ func (suite *IntegrationTestSuite) initKeepersWithmAccPerms(blockedAddrs map[str
 	keeper := keeper.NewBaseKeeper(
 		appCodec, app.GetKey(types.StoreKey), authKeeper,
 		app.GetSubspace(types.ModuleName), blockedAddrs,
+		100,
 	)
 
 	return authKeeper, keeper
@@ -297,7 +298,6 @@ func (suite *IntegrationTestSuite) TestSupply_DeferredMintCoins() {
 	suite.Require().Equal(sdk.Coins{}, getCoinsByName(ctx, keeper, authKeeper, multiPermAcc.GetName()))
 	keeper.WriteDeferredOperations(ctx)
 	suite.Require().Equal(initCoins, getCoinsByName(ctx, keeper, authKeeper, multiPermAcc.GetName()))
-
 
 	suite.Require().Equal(initialSupply.Add(initCoins...), totalSupply)
 	suite.Require().Panics(func() { keeper.DeferredMintCoins(ctx, authtypes.Burner, initCoins) }) // nolint:errcheck
@@ -1160,7 +1160,7 @@ func (suite *IntegrationTestSuite) TestBalanceTrackingEvents() {
 	)
 
 	suite.app.BankKeeper = keeper.NewBaseKeeper(suite.app.AppCodec(), suite.app.GetKey(types.StoreKey),
-		suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil)
+		suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil, 100)
 
 	// set account with multiple permissions
 	suite.app.AccountKeeper.SetModuleAccount(suite.ctx, multiPermAcc)
@@ -1320,7 +1320,7 @@ func (suite *IntegrationTestSuite) TestMintCoinRestrictions() {
 
 	for _, test := range tests {
 		suite.app.BankKeeper = keeper.NewBaseKeeper(suite.app.AppCodec(), suite.app.GetKey(types.StoreKey),
-			suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil).WithMintCoinsRestriction(keeper.MintingRestrictionFn(test.restrictionFn))
+			suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil, 100).WithMintCoinsRestriction(keeper.MintingRestrictionFn(test.restrictionFn))
 		for _, testCase := range test.testCases {
 			if testCase.expectPass {
 				suite.Require().NoError(
@@ -1402,7 +1402,6 @@ func (suite *IntegrationTestSuite) TestDeferredOperationsFromModuleToAccount() {
 	suite.Require().Equal(sdk.NewCoins().String(), getCoinsByName(ctx, keeper, authKeeper, holderAcc.GetName()).String())
 	suite.Require().Equal(totalSupply.String(), getCoinsByName(ctx, keeper, authKeeper, authtypes.Minter).String())
 }
-
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))

--- a/x/capability/capability_test.go
+++ b/x/capability/capability_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -72,7 +73,7 @@ func (suite *CapabilityTestSuite) TestInitializeMemStore() {
 
 	// Mock the first transaction getting capability and subsequently failing
 	// by using a cached context and discarding all cached writes.
-	cacheCtx, _ := ctx.CacheContext()
+	cacheCtx, _ := ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
 	_, ok := newSk1.GetCapability(cacheCtx, "transfer")
 	suite.Require().True(ok)
 

--- a/x/capability/genesis_test.go
+++ b/x/capability/genesis_test.go
@@ -6,6 +6,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/capability"
@@ -40,7 +41,7 @@ func (suite *CapabilityTestSuite) TestGenesis() {
 	newKeeper := keeper.NewKeeper(suite.cdc, newApp.GetKey(types.StoreKey), newApp.GetMemKey(types.MemStoreKey))
 	newSk1 := newKeeper.ScopeToModule(banktypes.ModuleName)
 	newSk2 := newKeeper.ScopeToModule(stakingtypes.ModuleName)
-	deliverCtx, _ := newApp.BaseApp.NewUncachedContext(false, tmproto.Header{}).WithBlockGasMeter(sdk.NewInfiniteGasMeter()).CacheContext()
+	deliverCtx, _ := newApp.BaseApp.NewUncachedContext(false, tmproto.Header{}).WithBlockGasMeter(sdk.NewInfiniteGasMeter()).CacheContext(storetypes.DefaultCacheSizeLimit)
 
 	capability.InitGenesis(deliverCtx, *newKeeper, *genState)
 

--- a/x/capability/keeper/keeper_test.go
+++ b/x/capability/keeper/keeper_test.go
@@ -8,6 +8,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/capability/keeper"
@@ -279,7 +280,7 @@ func (suite KeeperTestSuite) TestRevertCapability() {
 
 	ms := suite.ctx.MultiStore()
 
-	msCache := ms.CacheMultiStore()
+	msCache := ms.CacheMultiStore(storetypes.DefaultCacheSizeLimit)
 	cacheCtx := suite.ctx.WithMultiStore(msCache)
 
 	capName := "revert"

--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 )
@@ -22,7 +23,7 @@ func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvar
 	}
 
 	// use a cached context to avoid gas costs during invariants
-	cacheCtx, _ := ctx.CacheContext()
+	cacheCtx, _ := ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
 
 	found := false
 	msgFullRoute := msg.FullInvariantRoute()

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -66,7 +66,7 @@ func CanWithdrawInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 
 		// cache, we don't want to write changes
-		ctx, _ = ctx.CacheContext()
+		ctx, _ = ctx.CacheContext(k.cacheSize)
 
 		var remaining sdk.DecCoins
 

--- a/x/distribution/keeper/keeper.go
+++ b/x/distribution/keeper/keeper.go
@@ -24,13 +24,14 @@ type Keeper struct {
 	blockedAddrs map[string]bool
 
 	feeCollectorName string // name of the FeeCollector ModuleAccount
+	cacheSize        int
 }
 
 // NewKeeper creates a new distribution Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	ak types.AccountKeeper, bk types.BankKeeper, sk types.StakingKeeper,
-	feeCollectorName string, blockedAddrs map[string]bool,
+	feeCollectorName string, blockedAddrs map[string]bool, cacheSize int,
 ) Keeper {
 
 	// ensure distribution module account is set
@@ -52,6 +53,7 @@ func NewKeeper(
 		stakingKeeper:    sk,
 		feeCollectorName: feeCollectorName,
 		blockedAddrs:     blockedAddrs,
+		cacheSize:        cacheSize,
 	}
 }
 

--- a/x/distribution/keeper/querier.go
+++ b/x/distribution/keeper/querier.go
@@ -130,7 +130,7 @@ func queryDelegationRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext()
+	ctx, _ = ctx.CacheContext(k.cacheSize)
 
 	val := k.stakingKeeper.Validator(ctx, params.ValidatorAddress)
 	if val == nil {
@@ -164,7 +164,7 @@ func queryDelegatorTotalRewards(ctx sdk.Context, _ []string, req abci.RequestQue
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext()
+	ctx, _ = ctx.CacheContext(k.cacheSize)
 
 	total := sdk.DecCoins{}
 
@@ -202,7 +202,7 @@ func queryDelegatorValidators(ctx sdk.Context, _ []string, req abci.RequestQuery
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext()
+	ctx, _ = ctx.CacheContext(k.cacheSize)
 
 	var validators []sdk.ValAddress
 
@@ -230,7 +230,7 @@ func queryDelegatorWithdrawAddress(ctx sdk.Context, _ []string, req abci.Request
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext()
+	ctx, _ = ctx.CacheContext(k.cacheSize)
 	withdrawAddr := k.GetDelegatorWithdrawAddr(ctx, params.DelegatorAddress)
 
 	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, withdrawAddr)

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -57,7 +57,7 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 
 		if passes {
 			handler := keeper.Router().GetRoute(proposal.ProposalRoute())
-			cacheCtx, writeCache := ctx.CacheContext()
+			cacheCtx, writeCache := ctx.CacheContext(keeper.CacheSize)
 
 			// The proposal handler may execute state mutating logic depending
 			// on the proposal content. If the handler fails, no state mutation

--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -34,6 +34,8 @@ type Keeper struct {
 
 	// Proposal router
 	router types.Router
+
+	CacheSize int
 }
 
 // NewKeeper returns a governance keeper. It handles:
@@ -45,7 +47,7 @@ type Keeper struct {
 // CONTRACT: the parameter Subspace must have the param key table already initialized
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace types.ParamSubspace,
-	authKeeper types.AccountKeeper, bankKeeper types.BankKeeper, sk types.StakingKeeper, rtr types.Router,
+	authKeeper types.AccountKeeper, bankKeeper types.BankKeeper, sk types.StakingKeeper, rtr types.Router, cacheSize int,
 ) Keeper {
 
 	// ensure governance module account is set
@@ -66,6 +68,7 @@ func NewKeeper(
 		sk:         sk,
 		cdc:        cdc,
 		router:     rtr,
+		CacheSize:  cacheSize,
 	}
 }
 

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -18,7 +18,7 @@ func (keeper Keeper) SubmitProposal(ctx sdk.Context, content types.Content) (typ
 	// Execute the proposal content in a new context branch (with branched store)
 	// to validate the actual parameter changes before the proposal proceeds
 	// through the governance process. State is not persisted.
-	cacheCtx, _ := ctx.CacheContext()
+	cacheCtx, _ := ctx.CacheContext(keeper.CacheSize)
 	handler := keeper.router.GetRoute(content.ProposalRoute())
 	if err := handler(cacheCtx, content); err != nil {
 		return types.Proposal{}, sdkerrors.Wrap(types.ErrInvalidProposalContent, err.Error())

--- a/x/staking/keeper/test_common.go
+++ b/x/staking/keeper/test_common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math/rand"
 
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -41,7 +42,7 @@ func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Vali
 	keeper.SetValidatorByPowerIndex(ctx, validator)
 
 	if !apply {
-		ctx, _ = ctx.CacheContext()
+		ctx, _ = ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
 	}
 	_, err := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
To prevent the process from OOMing on large amount of data read (e.g. for order book matching), we will introduce a limit to the cachekv store and its thread-safe equivalent, such that some data will be evicted from the cache if it's full and needs to load something new.

The eviction logic will be random instead of LRU to avoid any overhead that might hurt performance when the cache is not populated fully, which should be the state a validator tries to keep. The tradeoff is that if the limit is reached, a naive random eviction logic will likely incur more evictions than a LRU, so a validator should increase the RAM size and bump the limit soon after they see the limit is reached.

## Testing performed to validate your change
unit test

