### PR TITLE
Change CacheKv to use sync.map for deleted 

### DIFF
--- a/store/cachekv/memiterator.go
+++ b/store/cachekv/memiterator.go
@@ -57,9 +57,6 @@ func newMemIterator(
 }
 
 func (mi *memIterator) Value() []byte {
-	mi.mutex.Lock()
-	defer mi.mutex.Unlock()
-
 	key := mi.Iterator.Key()
 	// We need to handle the case where deleted is modified and includes our current key
 	// We handle this by maintaining a lastKey object in the iterator.
@@ -67,6 +64,9 @@ func (mi *memIterator) Value() []byte {
 	// then we are calling value on the same thing as last time.
 	// Therefore we don't check the mi.deleted to see if this key is included in there.
 	reCallingOnOldLastKey := (mi.lastKey != nil) && bytes.Equal(key, mi.lastKey)
+
+	mi.mutex.Lock()
+	defer mi.mutex.Unlock()
 	if _, ok := mi.deleted[string(key)]; ok && !reCallingOnOldLastKey {
 		return nil
 	}

--- a/store/cachekv/mergeiterator.go
+++ b/store/cachekv/mergeiterator.go
@@ -3,6 +3,7 @@ package cachekv
 import (
 	"bytes"
 	"errors"
+	"sync"
 
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
@@ -18,6 +19,7 @@ type cacheMergeIterator struct {
 	parent    types.Iterator
 	cache     types.Iterator
 	ascending bool
+	mutex 	  *sync.Mutex
 }
 
 var _ types.Iterator = (*cacheMergeIterator)(nil)

--- a/store/cachekv/mergeiterator.go
+++ b/store/cachekv/mergeiterator.go
@@ -3,7 +3,6 @@ package cachekv
 import (
 	"bytes"
 	"errors"
-	"sync"
 
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
@@ -19,7 +18,6 @@ type cacheMergeIterator struct {
 	parent    types.Iterator
 	cache     types.Iterator
 	ascending bool
-	mutex 	  *sync.Mutex
 }
 
 var _ types.Iterator = (*cacheMergeIterator)(nil)
@@ -212,7 +210,6 @@ func (iter *cacheMergeIterator) skipUntilExistsOrInvalid() bool {
 			return iter.cache.Valid()
 		}
 		// Parent is valid.
-
 		if !iter.cache.Valid() {
 			return true
 		}

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -235,7 +235,7 @@ func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	}
 
 	store.dirtyItems(start, end)
-	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
+	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey, &store.mtx)
 
 	return NewCacheMergeIterator(parent, cache, ascending)
 }

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -57,7 +57,7 @@ func (b mapCacheBackend) Range(f func(string, *types.CValue) bool) {
 type Store struct {
 	mtx           sync.Mutex
 	cache         *types.BoundedCache
-	deleted       map[string]struct{}
+	deleted       *sync.Map
 	unsortedCache map[string]struct{}
 	sortedCache   *dbm.MemDB // always ascending sorted
 	parent        types.KVStore
@@ -71,7 +71,7 @@ var _ types.CacheKVStore = (*Store)(nil)
 func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Store {
 	return &Store{
 		cache:         types.NewBoundedCache(mapCacheBackend{make(map[string]*types.CValue)}, cacheSize),
-		deleted:       make(map[string]struct{}),
+		deleted:       &sync.Map{},
 		unsortedCache: make(map[string]struct{}),
 		sortedCache:   dbm.NewMemDB(),
 		parent:        parent,
@@ -185,9 +185,10 @@ func (store *Store) Write() {
 	// and not allocating fresh objects.
 	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
 	store.cache.DeleteAll()
-	for key := range store.deleted {
-		delete(store.deleted, key)
-	}
+	store.deleted.Range(func(key, value any) bool {
+		store.deleted.Delete(key)
+		return true
+	})
 	for key := range store.unsortedCache {
 		delete(store.unsortedCache, key)
 	}
@@ -235,7 +236,7 @@ func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	}
 
 	store.dirtyItems(start, end)
-	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey, &store.mtx)
+	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
 
 	return NewCacheMergeIterator(parent, cache, ascending)
 }
@@ -418,9 +419,9 @@ func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
 	keyStr := conv.UnsafeBytesToStr(key)
 	store.cache.Set(keyStr, types.NewCValue(value, dirty))
 	if deleted {
-		store.deleted[keyStr] = struct{}{}
+		store.deleted.Store(keyStr, struct{}{})
 	} else {
-		delete(store.deleted, keyStr)
+		store.deleted.Delete(keyStr)
 	}
 	if dirty {
 		store.unsortedCache[conv.UnsafeBytesToStr(key)] = struct{}{}
@@ -428,6 +429,6 @@ func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
 }
 
 func (store *Store) isDeleted(key string) bool {
-	_, ok := store.deleted[key]
+	_, ok := store.deleted.Load(key)
 	return ok
 }

--- a/store/concurrentcachekv/store.go
+++ b/store/concurrentcachekv/store.go
@@ -250,7 +250,7 @@ func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	store.dirtyItems(start, end)
 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
 
-	return cachekv.NewCacheMergeIterator(parent, cache, ascending)
+	return cachekv.NewCacheMergeIterator(parent, cache, ascending, &sync.Mutex{})
 }
 
 func findStartIndex(strL []string, startQ string) int {

--- a/store/concurrentcachekv/store.go
+++ b/store/concurrentcachekv/store.go
@@ -250,7 +250,7 @@ func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	store.dirtyItems(start, end)
 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
 
-	return cachekv.NewCacheMergeIterator(parent, cache, ascending, &sync.Mutex{})
+	return cachekv.NewCacheMergeIterator(parent, cache, ascending)
 }
 
 func findStartIndex(strL []string, startQ string) int {

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -36,7 +36,7 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 	}
 
 	if msg.Commission.Rate.LT(k.MinCommissionRate(ctx)) {
-		return nil, sdkerrors.Wrapf(types.ErrCommissionLTMinRate, "cannot set validator commission to less than minimum rate of %s", k.MinCommissionRate(ctx))
+		return nil, sdkerrors.Wrapf(types.ErrCommissionLTMinRate, "cannot set validator commission=%s to less than minimum rate of %s", msg.Commission.Rate, k.MinCommissionRate(ctx))
 	}
 
 	// check to see if the pubkey or sender has been registered before


### PR DESCRIPTION
## Describe your changes and provide context
Tried out two solutions previously but neither of them is trivial - this seems to be the simplest solution for dealing with concurrent r/ws to the CacheKv store as it's only an issue for the deleted map. 

* Using concurrentCacheKv has an issue where the parent could have a branch from a regular CacheKv, and in the parallel execution logic, we may still run into the issue where it calls the parent non-concurrent safe version. 
   * This makes the logic fragile and prone to mistakes in the future 
* Passing the mutex lock in the cacheKv to the iterator, doesn't really work either because these iterators are nested, so the mutex lock passed to the iterator will not be able to acquire the lock without some more granular concurrency, but this may mean we make methods no longer completely atomic 

Probably going to delete the concurrentCacheKv store 
## Testing performed to validate your change
Was able to run the cluster for ~6 hours - it did run into some issues later but I don't think it's related to this change or the concurrent k/v change as previously the concurrent r/w panic would happen < 1 hour 
![image](https://user-images.githubusercontent.com/18161326/205078309-4aaa1faf-2b6e-42a4-8a9b-bd9089f5434a.png)
