### PR TITLE
Revert interface-breaking changes by the cache limit feature

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -640,7 +640,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height, app.CacheSize)
+	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height)
 	if err != nil {
 		return sdk.Context{},
 			sdkerrors.Wrapf(

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -137,15 +137,10 @@ type BaseApp struct { //nolint: maligned
 	// which informs Tendermint what to index. If empty, all events will be indexed.
 	indexEvents map[string]struct{}
 
-<<<<<<< HEAD
-	CacheSize int
-
 	// abciListeners for hooking into the ABCI message processing of the BaseApp
 	// and exposing the requests and responses to external consumers
 	abciListeners []ABCIListener
 
-=======
->>>>>>> dc72664 (use hardcoded limit for now)
 	ChainID string
 }
 
@@ -217,7 +212,6 @@ func NewBaseApp(
 		}
 	}
 	app := &BaseApp{
-<<<<<<< HEAD
 		logger: logger,
 		name:   name,
 		appStore: appStore{
@@ -233,20 +227,6 @@ func NewBaseApp(
 			msgServiceRouter: NewMsgServiceRouter(),
 		},
 		txDecoder: txDecoder,
-		CacheSize: storetypes.DefaultCacheSizeLimit,
-=======
-		logger:           logger,
-		name:             name,
-		db:               db,
-		cms:              cms,
-		storeLoader:      DefaultStoreLoader,
-		router:           NewRouter(),
-		queryRouter:      NewQueryRouter(),
-		grpcQueryRouter:  NewGRPCQueryRouter(),
-		msgServiceRouter: NewMsgServiceRouter(),
-		txDecoder:        txDecoder,
-		fauxMerkleMode:   false,
->>>>>>> dc72664 (use hardcoded limit for now)
 	}
 
 	for _, option := range options {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/snapshots"
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -138,12 +137,15 @@ type BaseApp struct { //nolint: maligned
 	// which informs Tendermint what to index. If empty, all events will be indexed.
 	indexEvents map[string]struct{}
 
+<<<<<<< HEAD
 	CacheSize int
 
 	// abciListeners for hooking into the ABCI message processing of the BaseApp
 	// and exposing the requests and responses to external consumers
 	abciListeners []ABCIListener
 
+=======
+>>>>>>> dc72664 (use hardcoded limit for now)
 	ChainID string
 }
 
@@ -215,6 +217,7 @@ func NewBaseApp(
 		}
 	}
 	app := &BaseApp{
+<<<<<<< HEAD
 		logger: logger,
 		name:   name,
 		appStore: appStore{
@@ -231,6 +234,19 @@ func NewBaseApp(
 		},
 		txDecoder: txDecoder,
 		CacheSize: storetypes.DefaultCacheSizeLimit,
+=======
+		logger:           logger,
+		name:             name,
+		db:               db,
+		cms:              cms,
+		storeLoader:      DefaultStoreLoader,
+		router:           NewRouter(),
+		queryRouter:      NewQueryRouter(),
+		grpcQueryRouter:  NewGRPCQueryRouter(),
+		msgServiceRouter: NewMsgServiceRouter(),
+		txDecoder:        txDecoder,
+		fauxMerkleMode:   false,
+>>>>>>> dc72664 (use hardcoded limit for now)
 	}
 
 	for _, option := range options {
@@ -470,7 +486,7 @@ func (app *BaseApp) IsSealed() bool { return app.sealed }
 // provided header, and minimum gas prices set. It is set on InitChain and reset
 // on Commit.
 func (app *BaseApp) setCheckState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore(app.CacheSize)
+	ms := app.cms.CacheMultiStore()
 	app.checkState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, true, app.logger).WithMinGasPrices(app.minGasPrices),
@@ -482,7 +498,7 @@ func (app *BaseApp) setCheckState(header tmproto.Header) {
 // and provided header. It is set on InitChain and BeginBlock and set to nil on
 // Commit.
 func (app *BaseApp) setDeliverState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore(app.CacheSize)
+	ms := app.cms.CacheMultiStore()
 	app.deliverState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
@@ -490,7 +506,7 @@ func (app *BaseApp) setDeliverState(header tmproto.Header) {
 }
 
 func (app *BaseApp) setPrepareProposalState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore(app.CacheSize)
+	ms := app.cms.CacheMultiStore()
 	app.prepareProposalState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
@@ -498,7 +514,7 @@ func (app *BaseApp) setPrepareProposalState(header tmproto.Header) {
 }
 
 func (app *BaseApp) setProcessProposalState(header tmproto.Header) {
-	ms := app.cms.CacheMultiStore(app.CacheSize)
+	ms := app.cms.CacheMultiStore()
 	app.processProposalState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
@@ -681,7 +697,7 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context 
 	}
 
 	if mode == runTxModeSimulate {
-		ctx, _ = ctx.CacheContext(app.CacheSize)
+		ctx, _ = ctx.CacheContext()
 	}
 
 	return ctx
@@ -692,7 +708,7 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context 
 func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context, sdk.CacheMultiStore) {
 	ms := ctx.MultiStore()
 	// TODO: https://github.com/cosmos/cosmos-sdk/issues/2824
-	msCache := ms.CacheMultiStore(app.CacheSize)
+	msCache := ms.CacheMultiStore()
 	if msCache.TracingEnabled() {
 		msCache = msCache.SetTracingContext(
 			sdk.TraceContext(

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -113,12 +113,12 @@ func TestLoadVersionPruning(t *testing.T) {
 	}
 
 	for _, v := range []int64{1, 2, 4} {
-		_, err = app.cms.CacheMultiStoreWithVersion(v, store.DefaultCacheSizeLimit)
+		_, err = app.cms.CacheMultiStoreWithVersion(v)
 		require.NoError(t, err)
 	}
 
 	for _, v := range []int64{3, 5, 6, 7} {
-		_, err = app.cms.CacheMultiStoreWithVersion(v, store.DefaultCacheSizeLimit)
+		_, err = app.cms.CacheMultiStoreWithVersion(v)
 		require.NoError(t, err)
 	}
 

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -11,8 +11,8 @@ type state struct {
 
 // CacheMultiStore calls and returns a CacheMultiStore on the state's underling
 // CacheMultiStore.
-func (st *state) CacheMultiStore(cacheSize int) sdk.CacheMultiStore {
-	return st.ms.CacheMultiStore(cacheSize)
+func (st *state) CacheMultiStore() sdk.CacheMultiStore {
+	return st.ms.CacheMultiStore()
 }
 
 // Context returns the Context of the state.

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -3,7 +3,6 @@ package baseapp
 import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	"github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -23,7 +22,7 @@ func (app *BaseApp) Check(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *sdk
 
 func (app *BaseApp) Simulate(txBytes []byte) (sdk.GasInfo, *sdk.Result, error) {
 	ctx := app.checkState.ctx.WithTxBytes(txBytes).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.checkState.ctx))
-	ctx, _ = ctx.CacheContext(types.DefaultCacheSizeLimit)
+	ctx, _ = ctx.CacheContext()
 	gasInfo, result, _, _, err := app.runTx(ctx, runTxModeSimulate, txBytes)
 	return gasInfo, result, err
 }

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -21,23 +21,23 @@ func (ms multiStore) RollbackToVersion(version int64) error {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheMultiStore(_ int) sdk.CacheMultiStore {
+func (ms multiStore) CacheMultiStore() sdk.CacheMultiStore {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheMultiStoreWithVersion(_ int64, _ int) (sdk.CacheMultiStore, error) {
+func (ms multiStore) CacheMultiStoreWithVersion(_ int64) (sdk.CacheMultiStore, error) {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheWrap(_ store.StoreKey, _ int) sdk.CacheWrap {
+func (ms multiStore) CacheWrap(_ store.StoreKey) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheWrapWithTrace(_ store.StoreKey, _ io.Writer, _ sdk.TraceContext, _ int) sdk.CacheWrap {
+func (ms multiStore) CacheWrapWithTrace(_ store.StoreKey, _ io.Writer, _ sdk.TraceContext) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (ms multiStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener, _ int) store.CacheWrap {
+func (ms multiStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener) store.CacheWrap {
 	panic("not implemented")
 }
 
@@ -157,15 +157,15 @@ type kvStore struct {
 	store map[string][]byte
 }
 
-func (kv kvStore) CacheWrap(_ store.StoreKey, _ int) sdk.CacheWrap {
+func (kv kvStore) CacheWrap(_ store.StoreKey) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (kv kvStore) CacheWrapWithTrace(_ store.StoreKey, w io.Writer, tc sdk.TraceContext, _ int) sdk.CacheWrap {
+func (kv kvStore) CacheWrapWithTrace(_ store.StoreKey, w io.Writer, tc sdk.TraceContext) sdk.CacheWrap {
 	panic("not implemented")
 }
 
-func (kv kvStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener, _ int) store.CacheWrap {
+func (kv kvStore) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener) store.CacheWrap {
 	panic("not implemented")
 }
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -258,7 +258,6 @@ func NewSimApp(
 	)
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.ModuleAccountAddrs(),
-		app.CacheSize,
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
@@ -269,7 +268,7 @@ func NewSimApp(
 	)
 	app.DistrKeeper = distrkeeper.NewKeeper(
 		appCodec, keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(), app.CacheSize,
+		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(),
 	)
 	app.SlashingKeeper = slashingkeeper.NewKeeper(
 		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
@@ -306,7 +305,7 @@ func NewSimApp(
 	//TODO: we may need to add acl gov proposal types here
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.GetSubspace(govtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, govRouter, app.CacheSize,
+		&stakingKeeper, govRouter,
 	)
 
 	app.GovKeeper = *govKeeper.SetHooks(

--- a/store/cache/cache_test.go
+++ b/store/cache/cache_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestGetOrSetStoreCache(t *testing.T) {
 	db := dbm.NewMemDB()
-	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, types.DefaultCacheSizeLimit)
 
 	sKey := types.NewKVStoreKey("test")
 	tree, err := iavl.NewMutableTree(db, 100, false)
@@ -29,7 +29,7 @@ func TestGetOrSetStoreCache(t *testing.T) {
 
 func TestUnwrap(t *testing.T) {
 	db := dbm.NewMemDB()
-	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, types.DefaultCacheSizeLimit)
 
 	sKey := types.NewKVStoreKey("test")
 	tree, err := iavl.NewMutableTree(db, 100, false)
@@ -43,7 +43,7 @@ func TestUnwrap(t *testing.T) {
 
 func TestStoreCache(t *testing.T) {
 	db := dbm.NewMemDB()
-	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, types.DefaultCacheSizeLimit)
 
 	sKey := types.NewKVStoreKey("test")
 	tree, err := iavl.NewMutableTree(db, 100, false)

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -64,6 +64,7 @@ type Store struct {
 	parent        types.KVStore
 	eventManager  *sdktypes.EventManager
 	storeKey      types.StoreKey
+	cacheSize     int
 }
 
 var _ types.CacheKVStore = (*Store)(nil)
@@ -78,6 +79,7 @@ func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Sto
 		parent:        parent,
 		eventManager:  sdktypes.NewEventManager(),
 		storeKey:      storeKey,
+		cacheSize:     cacheSize,
 	}
 }
 
@@ -197,18 +199,18 @@ func (store *Store) Write() {
 }
 
 // CacheWrap implements CacheWrapper.
-func (store *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return NewStore(store, storeKey, size)
+func (store *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return NewStore(store, storeKey, store.cacheSize)
 }
 
 // CacheWrapWithTrace implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
-	return NewStore(tracekv.NewStore(store, w, tc), storeKey, size)
+func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	return NewStore(tracekv.NewStore(store, w, tc), storeKey, store.cacheSize)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
-	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey, size)
+func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey, store.cacheSize)
 }
 
 //----------------------------------------

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -40,13 +40,13 @@ var _ types.CacheMultiStore = Store{}
 func NewFromKVStore(
 	store types.KVStore, stores map[types.StoreKey]types.CacheWrapper,
 	keys map[string]types.StoreKey, traceWriter io.Writer, traceContext types.TraceContext,
-	listeners map[types.StoreKey][]types.WriteListener, cacheLimit int,
+	listeners map[types.StoreKey][]types.WriteListener,
 ) Store {
 	if listeners == nil {
 		listeners = make(map[types.StoreKey][]types.WriteListener)
 	}
 	cms := Store{
-		db:           cachekv.NewStore(store, nil, cacheLimit),
+		db:           cachekv.NewStore(store, nil, types.DefaultCacheSizeLimit),
 		stores:       make(map[types.StoreKey]types.CacheWrap, len(stores)),
 		keys:         keys,
 		traceWriter:  traceWriter,
@@ -56,10 +56,21 @@ func NewFromKVStore(
 
 	for key, store := range stores {
 		if cms.TracingEnabled() {
+<<<<<<< HEAD
 			store = tracekv.NewStore(store.(types.KVStore), cms.traceWriter, cms.traceContext)
 		}
 		if cms.ListeningEnabled(key) {
 			store = listenkv.NewStore(store.(types.KVStore), key, listeners[key])
+=======
+			cacheWrapped = store.CacheWrapWithTrace(key, cms.traceWriter, cms.traceContext)
+		} else {
+			cacheWrapped = store.CacheWrap(key)
+		}
+		if cms.ListeningEnabled(key) {
+			cms.stores[key] = cacheWrapped.CacheWrapWithListeners(key, cms.listeners[key])
+		} else {
+			cms.stores[key] = cacheWrapped
+>>>>>>> dc72664 (use hardcoded limit for now)
 		}
 		cms.stores[key] = cachekv.NewStore(store.(types.KVStore), key, cacheLimit)
 	}
@@ -71,20 +82,24 @@ func NewFromKVStore(
 // CacheWrapper objects. Each CacheWrapper store is a branched store.
 func NewStore(
 	db dbm.DB, stores map[types.StoreKey]types.CacheWrapper, keys map[string]types.StoreKey,
-	traceWriter io.Writer, traceContext types.TraceContext, listeners map[types.StoreKey][]types.WriteListener, cacheLimit int,
+	traceWriter io.Writer, traceContext types.TraceContext, listeners map[types.StoreKey][]types.WriteListener,
 ) Store {
 
-	return NewFromKVStore(dbadapter.Store{DB: db}, stores, keys, traceWriter, traceContext, listeners, cacheLimit)
+	return NewFromKVStore(dbadapter.Store{DB: db}, stores, keys, traceWriter, traceContext, listeners)
 }
 
-func newCacheMultiStoreFromCMS(cms Store, cacheLimit int) Store {
+func newCacheMultiStoreFromCMS(cms Store) Store {
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 	for k, v := range cms.stores {
 		stores[k] = v
 	}
 
+<<<<<<< HEAD
 	// don't pass listeners to nested cache store.
 	return NewFromKVStore(cms.db, stores, nil, cms.traceWriter, cms.traceContext, nil, cacheLimit)
+=======
+	return NewFromKVStore(cms.db, stores, nil, cms.traceWriter, cms.traceContext, cms.listeners)
+>>>>>>> dc72664 (use hardcoded limit for now)
 }
 
 // SetTracer sets the tracer for the MultiStore that the underlying
@@ -155,23 +170,23 @@ func (cms Store) GetEvents() []abci.Event {
 }
 
 // Implements CacheWrapper.
-func (cms Store) CacheWrap(_ types.StoreKey, size int) types.CacheWrap {
-	return cms.CacheMultiStore(size).(types.CacheWrap)
+func (cms Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
+	return cms.CacheMultiStore().(types.CacheWrap)
 }
 
 // CacheWrapWithTrace implements the CacheWrapper interface.
-func (cms Store) CacheWrapWithTrace(storeKey types.StoreKey, _ io.Writer, _ types.TraceContext, size int) types.CacheWrap {
-	return cms.CacheWrap(storeKey, size)
+func (cms Store) CacheWrapWithTrace(storeKey types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
+	return cms.CacheWrap(storeKey)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (cms Store) CacheWrapWithListeners(storeKey types.StoreKey, _ []types.WriteListener, size int) types.CacheWrap {
-	return cms.CacheWrap(storeKey, size)
+func (cms Store) CacheWrapWithListeners(storeKey types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+	return cms.CacheWrap(storeKey)
 }
 
 // Implements MultiStore.
-func (cms Store) CacheMultiStore(size int) types.CacheMultiStore {
-	return newCacheMultiStoreFromCMS(cms, size)
+func (cms Store) CacheMultiStore() types.CacheMultiStore {
+	return newCacheMultiStoreFromCMS(cms)
 }
 
 // CacheMultiStoreWithVersion implements the MultiStore interface. It will panic
@@ -179,7 +194,7 @@ func (cms Store) CacheMultiStore(size int) types.CacheMultiStore {
 //
 // TODO: The store implementation can possibly be modified to support this as it
 // seems safe to load previous versions (heights).
-func (cms Store) CacheMultiStoreWithVersion(_ int64, _ int) (types.CacheMultiStore, error) {
+func (cms Store) CacheMultiStoreWithVersion(_ int64) (types.CacheMultiStore, error) {
 	panic("cannot branch cached multi-store with a version")
 }
 

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -56,23 +56,12 @@ func NewFromKVStore(
 
 	for key, store := range stores {
 		if cms.TracingEnabled() {
-<<<<<<< HEAD
 			store = tracekv.NewStore(store.(types.KVStore), cms.traceWriter, cms.traceContext)
 		}
 		if cms.ListeningEnabled(key) {
 			store = listenkv.NewStore(store.(types.KVStore), key, listeners[key])
-=======
-			cacheWrapped = store.CacheWrapWithTrace(key, cms.traceWriter, cms.traceContext)
-		} else {
-			cacheWrapped = store.CacheWrap(key)
 		}
-		if cms.ListeningEnabled(key) {
-			cms.stores[key] = cacheWrapped.CacheWrapWithListeners(key, cms.listeners[key])
-		} else {
-			cms.stores[key] = cacheWrapped
->>>>>>> dc72664 (use hardcoded limit for now)
-		}
-		cms.stores[key] = cachekv.NewStore(store.(types.KVStore), key, cacheLimit)
+		cms.stores[key] = cachekv.NewStore(store.(types.KVStore), key, types.DefaultCacheSizeLimit)
 	}
 
 	return cms
@@ -94,12 +83,7 @@ func newCacheMultiStoreFromCMS(cms Store) Store {
 		stores[k] = v
 	}
 
-<<<<<<< HEAD
-	// don't pass listeners to nested cache store.
-	return NewFromKVStore(cms.db, stores, nil, cms.traceWriter, cms.traceContext, nil, cacheLimit)
-=======
-	return NewFromKVStore(cms.db, stores, nil, cms.traceWriter, cms.traceContext, cms.listeners)
->>>>>>> dc72664 (use hardcoded limit for now)
+	return NewFromKVStore(cms.db, stores, nil, cms.traceWriter, cms.traceContext, nil)
 }
 
 // SetTracer sets the tracer for the MultiStore that the underlying

--- a/store/concurrentcachekv/store.go
+++ b/store/concurrentcachekv/store.go
@@ -74,6 +74,7 @@ type Store struct {
 	parent        types.KVStore
 	eventManager  *sdktypes.EventManager
 	storeKey      types.StoreKey
+	cacheSize     int
 }
 
 var _ types.CacheKVStore = (*Store)(nil)
@@ -86,6 +87,7 @@ func NewStore(parent types.KVStore, storeKey types.StoreKey, cacheSize int) *Sto
 		parent:       parent,
 		eventManager: sdktypes.NewEventManager(),
 		storeKey:     storeKey,
+		cacheSize:    cacheSize,
 	}
 }
 
@@ -208,18 +210,18 @@ func (store *Store) Write() {
 }
 
 // CacheWrap implements CacheWrapper.
-func (store *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return NewStore(store, storeKey, size)
+func (store *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return NewStore(store, storeKey, store.cacheSize)
 }
 
 // CacheWrapWithTrace implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
-	return NewStore(tracekv.NewStore(store, w, tc), storeKey, size)
+func (store *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	return NewStore(tracekv.NewStore(store, w, tc), storeKey, store.cacheSize)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
-	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey, size)
+func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	return NewStore(listenkv.NewStore(store, storeKey, listeners), storeKey, store.cacheSize)
 }
 
 //----------------------------------------

--- a/store/dbadapter/store.go
+++ b/store/dbadapter/store.go
@@ -81,18 +81,18 @@ func (Store) GetStoreType() types.StoreType {
 }
 
 // CacheWrap branches the underlying store.
-func (dsa Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return cachekv.NewStore(dsa, storeKey, size)
+func (dsa Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return cachekv.NewStore(dsa, storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithTrace implements KVStore.
-func (dsa Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(dsa, w, tc), storeKey, size)
+func (dsa Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(dsa, w, tc), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (dsa Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(dsa, storeKey, listeners), storeKey, size)
+func (dsa Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(dsa, storeKey, listeners), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // dbm.DB implements KVStore so we can CacheKVStore it.

--- a/store/dbadapter/store_test.go
+++ b/store/dbadapter/store_test.go
@@ -79,12 +79,12 @@ func TestCacheWraps(t *testing.T) {
 	mockDB := mocks.NewMockDB(mockCtrl)
 	store := dbadapter.Store{mockDB}
 
-	cacheWrapper := store.CacheWrap(nil, types.DefaultCacheSizeLimit)
+	cacheWrapper := store.CacheWrap(nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -91,17 +91,17 @@ func (gs *Store) ReverseIterator(start, end []byte) types.Iterator {
 }
 
 // Implements KVStore.
-func (gs *Store) CacheWrap(_ types.StoreKey, _ int) types.CacheWrap {
+func (gs *Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
 	panic("cannot CacheWrap a GasKVStore")
 }
 
 // CacheWrapWithTrace implements the KVStore interface.
-func (gs *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext, _ int) types.CacheWrap {
+func (gs *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
 	panic("cannot CacheWrapWithTrace a GasKVStore")
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (gs *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener, _ int) types.CacheWrap {
+func (gs *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a GasKVStore")
 }
 

--- a/store/gaskv/store_test.go
+++ b/store/gaskv/store_test.go
@@ -23,9 +23,9 @@ func TestGasKVStoreBasic(t *testing.T) {
 	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
 
 	require.Equal(t, types.StoreTypeDB, st.GetStoreType())
-	require.Panics(t, func() { st.CacheWrap(nil, types.DefaultCacheSizeLimit) })
-	require.Panics(t, func() { st.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit) })
-	require.Panics(t, func() { st.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { st.CacheWrap(nil) })
+	require.Panics(t, func() { st.CacheWrapWithTrace(nil, nil, nil) })
+	require.Panics(t, func() { st.CacheWrapWithListeners(nil, nil) })
 
 	require.Panics(t, func() { st.Set(nil, []byte("value")) }, "setting a nil key should panic")
 	require.Panics(t, func() { st.Set([]byte(""), []byte("value")) }, "setting an empty key should panic")

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -36,8 +36,7 @@ var (
 
 // Store Implements types.KVStore and CommitKVStore.
 type Store struct {
-	tree       Tree
-	cacheLimit int
+	tree Tree
 }
 
 // LoadStore returns an IAVL Store as a CommitKVStore. Internally, it will load the
@@ -184,18 +183,18 @@ func (st *Store) GetStoreType() types.StoreType {
 }
 
 // Implements Store.
-func (st *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return cachekv.NewStore(st, storeKey, size)
+func (st *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return cachekv.NewStore(st, storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithTrace implements the Store interface.
-func (st *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(st, w, tc), storeKey, size)
+func (st *Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(st, w, tc), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (st *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(st, storeKey, listeners), storeKey, size)
+func (st *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(st, storeKey, listeners), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // Implements types.KVStore.

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -650,12 +650,12 @@ func TestCacheWraps(t *testing.T) {
 	tree, _ := newAlohaTree(t, db)
 	store := UnsafeNewStore(tree)
 
-	cacheWrapper := store.CacheWrap(nil, types.DefaultCacheSizeLimit)
+	cacheWrapper := store.CacheWrap(nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/listenkv/store.go
+++ b/store/listenkv/store.go
@@ -135,19 +135,19 @@ func (s *Store) GetStoreType() types.StoreType {
 
 // CacheWrap implements the KVStore interface. It panics as a Store
 // cannot be cache wrapped.
-func (s *Store) CacheWrap(_ types.StoreKey, _ int) types.CacheWrap {
+func (s *Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
 	panic("cannot CacheWrap a ListenKVStore")
 }
 
 // CacheWrapWithTrace implements the KVStore interface. It panics as a
 // Store cannot be cache wrapped.
-func (s *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext, _ int) types.CacheWrap {
+func (s *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
 	panic("cannot CacheWrapWithTrace a ListenKVStore")
 }
 
 // CacheWrapWithListeners implements the KVStore interface. It panics as a
 // Store cannot be cache wrapped.
-func (s *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener, _ int) types.CacheWrap {
+func (s *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a ListenKVStore")
 }
 

--- a/store/listenkv/store_test.go
+++ b/store/listenkv/store_test.go
@@ -284,15 +284,15 @@ func TestListenKVStoreGetStoreType(t *testing.T) {
 
 func TestListenKVStoreCacheWrap(t *testing.T) {
 	store := newEmptyListenKVStore(nil)
-	require.Panics(t, func() { store.CacheWrap(nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { store.CacheWrap(nil) })
 }
 
 func TestListenKVStoreCacheWrapWithTrace(t *testing.T) {
 	store := newEmptyListenKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil) })
 }
 
 func TestListenKVStoreCacheWrapWithListeners(t *testing.T) {
 	store := newEmptyListenKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil) })
 }

--- a/store/mem/mem_test.go
+++ b/store/mem/mem_test.go
@@ -28,13 +28,13 @@ func TestStore(t *testing.T) {
 	db.Delete(key)
 	require.Nil(t, db.Get(key))
 
-	cacheWrapper := db.CacheWrap(nil, types.DefaultCacheSizeLimit)
+	cacheWrapper := db.CacheWrap(nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := db.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithTrace := db.CacheWrapWithTrace(nil, nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := db.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithListeners := db.CacheWrapWithListeners(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }
 

--- a/store/mem/store.go
+++ b/store/mem/store.go
@@ -37,18 +37,18 @@ func (s Store) GetStoreType() types.StoreType {
 }
 
 // CacheWrap branches the underlying store.
-func (s Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return cachekv.NewStore(s, storeKey, size)
+func (s Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return cachekv.NewStore(s, storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithTrace implements KVStore.
-func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey, size)
+func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey, size)
+func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // Commit performs a no-op as entries are persistent between commitments.

--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -49,18 +49,18 @@ func (s Store) GetStoreType() types.StoreType {
 }
 
 // Implements CacheWrap
-func (s Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return cachekv.NewStore(s, storeKey, size)
+func (s Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return cachekv.NewStore(s, storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithTrace implements the KVStore interface.
-func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext, size int) types.CacheWrap {
-	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey, size)
+func (s Store) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(s, w, tc), storeKey, types.DefaultCacheSizeLimit)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener, size int) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey, size)
+func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners), storeKey, types.DefaultCacheSizeLimit)
 }
 
 func (s Store) GetWorkingHash() ([]byte, error) {

--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -433,12 +433,12 @@ func TestCacheWraps(t *testing.T) {
 	db := dbm.NewMemDB()
 	store := dbadapter.Store{DB: db}
 
-	cacheWrapper := store.CacheWrap(nil, types.DefaultCacheSizeLimit)
+	cacheWrapper := store.CacheWrap(nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -509,35 +509,35 @@ func (rs *Store) PruneStores(clearStorePruningHeihgts bool, pruningHeights []int
 }
 
 // CacheWrap implements CacheWrapper/Store/CommitStore.
-func (rs *Store) CacheWrap(storeKey types.StoreKey, size int) types.CacheWrap {
-	return rs.CacheMultiStore(size).(types.CacheWrap)
+func (rs *Store) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	return rs.CacheMultiStore().(types.CacheWrap)
 }
 
 // CacheWrapWithTrace implements the CacheWrapper interface.
-func (rs *Store) CacheWrapWithTrace(storeKey types.StoreKey, _ io.Writer, _ types.TraceContext, size int) types.CacheWrap {
-	return rs.CacheWrap(storeKey, size)
+func (rs *Store) CacheWrapWithTrace(storeKey types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
+	return rs.CacheWrap(storeKey)
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (rs *Store) CacheWrapWithListeners(storeKey types.StoreKey, _ []types.WriteListener, size int) types.CacheWrap {
-	return rs.CacheWrap(storeKey, size)
+func (rs *Store) CacheWrapWithListeners(storeKey types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+	return rs.CacheWrap(storeKey)
 }
 
 // CacheMultiStore creates ephemeral branch of the multi-store and returns a CacheMultiStore.
 // It implements the MultiStore interface.
-func (rs *Store) CacheMultiStore(size int) types.CacheMultiStore {
+func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 	for k, v := range rs.stores {
 		stores[k] = v
 	}
-	return cachemulti.NewStore(rs.db, stores, rs.keysByName, rs.traceWriter, rs.getTracingContext(), rs.listeners, size)
+	return cachemulti.NewStore(rs.db, stores, rs.keysByName, rs.traceWriter, rs.getTracingContext(), rs.listeners)
 }
 
 // CacheMultiStoreWithVersion is analogous to CacheMultiStore except that it
 // attempts to load stores at a given version (height). An error is returned if
 // any store cannot be loaded. This should only be used for querying and
 // iterating at past heights.
-func (rs *Store) CacheMultiStoreWithVersion(version int64, size int) (types.CacheMultiStore, error) {
+func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
 	cachedStores := make(map[types.StoreKey]types.CacheWrapper)
 	for key, store := range rs.stores {
 		switch store.GetStoreType() {
@@ -560,7 +560,7 @@ func (rs *Store) CacheMultiStoreWithVersion(version int64, size int) (types.Cach
 		}
 	}
 
-	return cachemulti.NewStore(rs.db, cachedStores, rs.keysByName, rs.traceWriter, rs.getTracingContext(), rs.listeners, size), nil
+	return cachemulti.NewStore(rs.db, cachedStores, rs.keysByName, rs.traceWriter, rs.getTracingContext(), rs.listeners), nil
 }
 
 // GetStore returns a mounted Store for a given StoreKey. If the StoreKey does

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -857,7 +857,7 @@ func TestStateListeners(t *testing.T) {
 	ms.AddListeners(testStoreKey1, []types.WriteListener{listener})
 
 	require.NoError(t, ms.LoadLatestVersion())
-	cacheMulti := ms.CacheMultiStore(types.DefaultCacheSizeLimit)
+	cacheMulti := ms.CacheMultiStore()
 
 	store1 := cacheMulti.GetKVStore(testStoreKey1)
 	store1.Set([]byte{1}, []byte{1})
@@ -869,7 +869,7 @@ func TestStateListeners(t *testing.T) {
 
 	// test nested cache store
 	listener.stateCache = []types.StoreKVPair{}
-	nested := cacheMulti.CacheMultiStore(types.DefaultCacheSizeLimit)
+	nested := cacheMulti.CacheMultiStore()
 
 	store1 = nested.GetKVStore(testStoreKey1)
 	store1.Set([]byte{1}, []byte{1})

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -64,7 +64,7 @@ func TestCacheMultiStore(t *testing.T) {
 	var db dbm.DB = dbm.NewMemDB()
 	ms := newMultiStoreWithMounts(db, types.PruneNothing)
 
-	cacheMulti := ms.CacheMultiStore(types.DefaultCacheSizeLimit)
+	cacheMulti := ms.CacheMultiStore()
 	require.IsType(t, cachemulti.Store{}, cacheMulti)
 }
 
@@ -86,11 +86,11 @@ func TestCacheMultiStoreWithVersion(t *testing.T) {
 	require.Equal(t, int64(1), cID.Version)
 
 	// require no failure when given an invalid or pruned version
-	_, err = ms.CacheMultiStoreWithVersion(cID.Version+1, types.DefaultCacheSizeLimit)
+	_, err = ms.CacheMultiStoreWithVersion(cID.Version + 1)
 	require.NoError(t, err)
 
 	// require a valid version can be cache-loaded
-	cms, err := ms.CacheMultiStoreWithVersion(cID.Version, types.DefaultCacheSizeLimit)
+	cms, err := ms.CacheMultiStoreWithVersion(cID.Version)
 	require.NoError(t, err)
 
 	// require a valid key lookup yields the correct value
@@ -519,12 +519,12 @@ func TestMultiStore_Pruning(t *testing.T) {
 			}
 
 			for _, v := range tc.saved {
-				_, err := ms.CacheMultiStoreWithVersion(v, types.DefaultCacheSizeLimit)
+				_, err := ms.CacheMultiStoreWithVersion(v)
 				require.NoError(t, err, "expected error when loading height: %d", v)
 			}
 
 			for _, v := range tc.deleted {
-				_, err := ms.CacheMultiStoreWithVersion(v, types.DefaultCacheSizeLimit)
+				_, err := ms.CacheMultiStoreWithVersion(v)
 				require.NoError(t, err, "expected error when loading height: %d", v)
 			}
 		})
@@ -560,7 +560,7 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 	require.Empty(t, ms.pruneHeights)
 
 	for _, v := range pruneHeights {
-		_, err := ms.CacheMultiStoreWithVersion(v, types.DefaultCacheSizeLimit)
+		_, err := ms.CacheMultiStoreWithVersion(v)
 		require.NoError(t, err, "expected error when loading height: %d", v)
 	}
 }
@@ -692,13 +692,13 @@ func TestCacheWraps(t *testing.T) {
 	db := dbm.NewMemDB()
 	multi := newMultiStoreWithMounts(db, types.PruneNothing)
 
-	cacheWrapper := multi.CacheWrap(nil, types.DefaultCacheSizeLimit)
+	cacheWrapper := multi.CacheWrap(nil)
 	require.IsType(t, cachemulti.Store{}, cacheWrapper)
 
-	cacheWrappedWithTrace := multi.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithTrace := multi.CacheWrapWithTrace(nil, nil, nil)
 	require.IsType(t, cachemulti.Store{}, cacheWrappedWithTrace)
 
-	cacheWrappedWithListeners := multi.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit)
+	cacheWrappedWithListeners := multi.CacheWrapWithListeners(nil, nil)
 	require.IsType(t, cachemulti.Store{}, cacheWrappedWithListeners)
 }
 
@@ -715,9 +715,9 @@ func TestTraceConcurrency(t *testing.T) {
 	multi.SetTracer(b)
 	multi.SetTracingContext(tc)
 
-	cms := multi.CacheMultiStore(types.DefaultCacheSizeLimit)
+	cms := multi.CacheMultiStore()
 	store1 := cms.GetKVStore(key)
-	cw := store1.CacheWrapWithTrace(nil, b, tc, types.DefaultCacheSizeLimit)
+	cw := store1.CacheWrapWithTrace(nil, b, tc)
 	_ = cw
 	require.NotNil(t, store1)
 

--- a/store/store.go
+++ b/store/store.go
@@ -18,5 +18,5 @@ func NewCommitMultiStoreWithArchival(db dbm.DB, archivalDb dbm.DB, archivalVersi
 }
 
 func NewCommitKVStoreCacheManager() types.MultiStorePersistentCache {
-	return cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	return cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, types.DefaultCacheSizeLimit)
 }

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -167,18 +167,18 @@ func (tkv *Store) GetStoreType() types.StoreType {
 
 // CacheWrap implements the KVStore interface. It panics because a Store
 // cannot be branched.
-func (tkv *Store) CacheWrap(_ types.StoreKey, _ int) types.CacheWrap {
+func (tkv *Store) CacheWrap(_ types.StoreKey) types.CacheWrap {
 	panic("cannot CacheWrap a TraceKVStore")
 }
 
 // CacheWrapWithTrace implements the KVStore interface. It panics as a
 // Store cannot be branched.
-func (tkv *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext, _ int) types.CacheWrap {
+func (tkv *Store) CacheWrapWithTrace(_ types.StoreKey, _ io.Writer, _ types.TraceContext) types.CacheWrap {
 	panic("cannot CacheWrapWithTrace a TraceKVStore")
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (tkv *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener, _ int) types.CacheWrap {
+func (tkv *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a TraceKVStore")
 }
 

--- a/store/tracekv/store_test.go
+++ b/store/tracekv/store_test.go
@@ -284,15 +284,15 @@ func TestTraceKVStoreGetStoreType(t *testing.T) {
 
 func TestTraceKVStoreCacheWrap(t *testing.T) {
 	store := newEmptyTraceKVStore(nil)
-	require.Panics(t, func() { store.CacheWrap(nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { store.CacheWrap(nil) })
 }
 
 func TestTraceKVStoreCacheWrapWithTrace(t *testing.T) {
 	store := newEmptyTraceKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { store.CacheWrapWithTrace(nil, nil, nil) })
 }
 
 func TestTraceKVStoreCacheWrapWithListeners(t *testing.T) {
 	store := newEmptyTraceKVStore(nil)
-	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil, types.DefaultCacheSizeLimit) })
+	require.Panics(t, func() { store.CacheWrapWithListeners(nil, nil) })
 }

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -107,11 +107,11 @@ type MultiStore interface {
 	// Branches MultiStore into a cached storage object.
 	// NOTE: Caller should probably not call .Write() on each, but
 	// call CacheMultiStore.Write().
-	CacheMultiStore(size int) CacheMultiStore
+	CacheMultiStore() CacheMultiStore
 
 	// CacheMultiStoreWithVersion branches the underlying MultiStore where
 	// each stored is loaded at a specific version (height).
-	CacheMultiStoreWithVersion(version int64, size int) (CacheMultiStore, error)
+	CacheMultiStoreWithVersion(version int64) (CacheMultiStore, error)
 
 	// Convenience for fetching substores.
 	// If the store does not exist, panics.
@@ -279,24 +279,24 @@ type CacheWrap interface {
 	GetEvents() []abci.Event
 
 	// CacheWrap recursively wraps again.
-	CacheWrap(storeKey StoreKey, size int) CacheWrap
+	CacheWrap(storeKey StoreKey) CacheWrap
 
 	// CacheWrapWithTrace recursively wraps again with tracing enabled.
-	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext, size int) CacheWrap
+	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext) CacheWrap
 
 	// CacheWrapWithListeners recursively wraps again with listening enabled
-	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener, size int) CacheWrap
+	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener) CacheWrap
 }
 
 type CacheWrapper interface {
 	// CacheWrap branches a store.
-	CacheWrap(storeKey StoreKey, size int) CacheWrap
+	CacheWrap(storeKey StoreKey) CacheWrap
 
 	// CacheWrapWithTrace branches a store with tracing enabled.
-	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext, size int) CacheWrap
+	CacheWrapWithTrace(storeKey StoreKey, w io.Writer, tc TraceContext) CacheWrap
 
 	// CacheWrapWithListeners recursively wraps again with listening enabled
-	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener, size int) CacheWrap
+	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener) CacheWrap
 }
 
 func (cid CommitID) IsZero() bool {

--- a/types/context.go
+++ b/types/context.go
@@ -323,8 +323,8 @@ func (c Context) TransientStore(key StoreKey) KVStore {
 // CacheContext returns a new Context with the multi-store cached and a new
 // EventManager. The cached context is written to the context when writeCache
 // is called.
-func (c Context) CacheContext(cacheSize int) (cc Context, writeCache func()) {
-	cms := c.MultiStore().CacheMultiStore(cacheSize)
+func (c Context) CacheContext() (cc Context, writeCache func()) {
+	cms := c.MultiStore().CacheMultiStore()
 	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())
 	return cc, cms.Write
 }

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -11,7 +11,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/tests/mocks"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/types"
@@ -38,7 +37,7 @@ func (s *contextTestSuite) TestCacheContext() {
 	s.Require().Equal(v1, store.Get(k1))
 	s.Require().Nil(store.Get(k2))
 
-	cctx, write := ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
+	cctx, write := ctx.CacheContext()
 	cstore := cctx.KVStore(key)
 	s.Require().Equal(v1, cstore.Get(k1))
 	s.Require().Nil(cstore.Get(k2))

--- a/x/bank/handler_test.go
+++ b/x/bank/handler_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/simapp"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -72,7 +71,7 @@ func TestSendToModuleAccount(t *testing.T) {
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		app.AppCodec(), app.GetKey(types.StoreKey), app.AccountKeeper, app.GetSubspace(types.ModuleName), map[string]bool{
 			moduleAccAddr.String(): true,
-		}, storetypes.DefaultCacheSizeLimit,
+		},
 	)
 	handler := bank.NewHandler(app.BankKeeper)
 

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -110,7 +110,6 @@ func NewBaseKeeper(
 	ak types.AccountKeeper,
 	paramSpace paramtypes.Subspace,
 	blockedAddrs map[string]bool,
-	cacheSize int,
 ) BaseKeeper {
 
 	// set KeyTable if it has not already been set
@@ -125,7 +124,6 @@ func NewBaseKeeper(
 		storeKey:               storeKey,
 		paramSpace:             paramSpace,
 		mintCoinsRestrictionFn: func(ctx sdk.Context, coins sdk.Coins) error { return nil },
-		cacheSize:              cacheSize,
 	}
 }
 
@@ -365,7 +363,7 @@ func (k BaseKeeper) DeferredSendCoinsFromModuleToAccount(
 	if !ok {
 		// Branch Context for validation and fail if the module doesn't have enough coins
 		// but don't write this to the underlying store
-		validationContext, _ := ctx.CacheContext(k.cacheSize)
+		validationContext, _ := ctx.CacheContext()
 		err := k.subUnlockedCoins(validationContext, moduleAddr, amount)
 		if err != nil {
 			return err
@@ -653,7 +651,7 @@ func (k BaseKeeper) DeferredBurnCoins(ctx sdk.Context, moduleName string, amount
 
 		// Branch Context for validation and fail if the module doesn't have enough coins
 		// but don't write this to the underlying store
-		validationContext, _ := ctx.CacheContext(k.cacheSize)
+		validationContext, _ := ctx.CacheContext()
 		moduleAcc := k.ak.GetModuleAccount(ctx, moduleName)
 
 		// Try subtract from the in mem var first, prevents the condition where

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -87,7 +87,6 @@ func (suite *IntegrationTestSuite) initKeepersWithmAccPerms(blockedAddrs map[str
 	keeper := keeper.NewBaseKeeper(
 		appCodec, app.GetKey(types.StoreKey), authKeeper,
 		app.GetSubspace(types.ModuleName), blockedAddrs,
-		100,
 	)
 
 	return authKeeper, keeper
@@ -1160,7 +1159,7 @@ func (suite *IntegrationTestSuite) TestBalanceTrackingEvents() {
 	)
 
 	suite.app.BankKeeper = keeper.NewBaseKeeper(suite.app.AppCodec(), suite.app.GetKey(types.StoreKey),
-		suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil, 100)
+		suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil)
 
 	// set account with multiple permissions
 	suite.app.AccountKeeper.SetModuleAccount(suite.ctx, multiPermAcc)
@@ -1320,7 +1319,7 @@ func (suite *IntegrationTestSuite) TestMintCoinRestrictions() {
 
 	for _, test := range tests {
 		suite.app.BankKeeper = keeper.NewBaseKeeper(suite.app.AppCodec(), suite.app.GetKey(types.StoreKey),
-			suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil, 100).WithMintCoinsRestriction(keeper.MintingRestrictionFn(test.restrictionFn))
+			suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil).WithMintCoinsRestriction(keeper.MintingRestrictionFn(test.restrictionFn))
 		for _, testCase := range test.testCases {
 			if testCase.expectPass {
 				suite.Require().NoError(

--- a/x/bank/keeper/view.go
+++ b/x/bank/keeper/view.go
@@ -33,9 +33,10 @@ type ViewKeeper interface {
 
 // BaseViewKeeper implements a read only keeper implementation of ViewKeeper.
 type BaseViewKeeper struct {
-	cdc      codec.BinaryCodec
-	storeKey sdk.StoreKey
-	ak       types.AccountKeeper
+	cdc       codec.BinaryCodec
+	storeKey  sdk.StoreKey
+	ak        types.AccountKeeper
+	cacheSize int
 }
 
 // NewBaseViewKeeper returns a new BaseViewKeeper.

--- a/x/capability/capability_test.go
+++ b/x/capability/capability_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -73,7 +72,7 @@ func (suite *CapabilityTestSuite) TestInitializeMemStore() {
 
 	// Mock the first transaction getting capability and subsequently failing
 	// by using a cached context and discarding all cached writes.
-	cacheCtx, _ := ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
+	cacheCtx, _ := ctx.CacheContext()
 	_, ok := newSk1.GetCapability(cacheCtx, "transfer")
 	suite.Require().True(ok)
 

--- a/x/capability/genesis_test.go
+++ b/x/capability/genesis_test.go
@@ -6,7 +6,6 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/capability"
@@ -41,7 +40,7 @@ func (suite *CapabilityTestSuite) TestGenesis() {
 	newKeeper := keeper.NewKeeper(suite.cdc, newApp.GetKey(types.StoreKey), newApp.GetMemKey(types.MemStoreKey))
 	newSk1 := newKeeper.ScopeToModule(banktypes.ModuleName)
 	newSk2 := newKeeper.ScopeToModule(stakingtypes.ModuleName)
-	deliverCtx, _ := newApp.BaseApp.NewUncachedContext(false, tmproto.Header{}).WithBlockGasMeter(sdk.NewInfiniteGasMeter()).CacheContext(storetypes.DefaultCacheSizeLimit)
+	deliverCtx, _ := newApp.BaseApp.NewUncachedContext(false, tmproto.Header{}).WithBlockGasMeter(sdk.NewInfiniteGasMeter()).CacheContext()
 
 	capability.InitGenesis(deliverCtx, *newKeeper, *genState)
 

--- a/x/capability/keeper/keeper_test.go
+++ b/x/capability/keeper/keeper_test.go
@@ -8,7 +8,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/capability/keeper"
@@ -280,7 +279,7 @@ func (suite KeeperTestSuite) TestRevertCapability() {
 
 	ms := suite.ctx.MultiStore()
 
-	msCache := ms.CacheMultiStore(storetypes.DefaultCacheSizeLimit)
+	msCache := ms.CacheMultiStore()
 	cacheCtx := suite.ctx.WithMultiStore(msCache)
 
 	capName := "revert"

--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 )
@@ -23,7 +22,7 @@ func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvar
 	}
 
 	// use a cached context to avoid gas costs during invariants
-	cacheCtx, _ := ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
+	cacheCtx, _ := ctx.CacheContext()
 
 	found := false
 	msgFullRoute := msg.FullInvariantRoute()

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -66,7 +66,7 @@ func CanWithdrawInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 
 		// cache, we don't want to write changes
-		ctx, _ = ctx.CacheContext(k.cacheSize)
+		ctx, _ = ctx.CacheContext()
 
 		var remaining sdk.DecCoins
 

--- a/x/distribution/keeper/keeper.go
+++ b/x/distribution/keeper/keeper.go
@@ -24,14 +24,13 @@ type Keeper struct {
 	blockedAddrs map[string]bool
 
 	feeCollectorName string // name of the FeeCollector ModuleAccount
-	cacheSize        int
 }
 
 // NewKeeper creates a new distribution Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	ak types.AccountKeeper, bk types.BankKeeper, sk types.StakingKeeper,
-	feeCollectorName string, blockedAddrs map[string]bool, cacheSize int,
+	feeCollectorName string, blockedAddrs map[string]bool,
 ) Keeper {
 
 	// ensure distribution module account is set
@@ -53,7 +52,6 @@ func NewKeeper(
 		stakingKeeper:    sk,
 		feeCollectorName: feeCollectorName,
 		blockedAddrs:     blockedAddrs,
-		cacheSize:        cacheSize,
 	}
 }
 

--- a/x/distribution/keeper/querier.go
+++ b/x/distribution/keeper/querier.go
@@ -130,7 +130,7 @@ func queryDelegationRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext(k.cacheSize)
+	ctx, _ = ctx.CacheContext()
 
 	val := k.stakingKeeper.Validator(ctx, params.ValidatorAddress)
 	if val == nil {
@@ -164,7 +164,7 @@ func queryDelegatorTotalRewards(ctx sdk.Context, _ []string, req abci.RequestQue
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext(k.cacheSize)
+	ctx, _ = ctx.CacheContext()
 
 	total := sdk.DecCoins{}
 
@@ -202,7 +202,7 @@ func queryDelegatorValidators(ctx sdk.Context, _ []string, req abci.RequestQuery
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext(k.cacheSize)
+	ctx, _ = ctx.CacheContext()
 
 	var validators []sdk.ValAddress
 
@@ -230,7 +230,7 @@ func queryDelegatorWithdrawAddress(ctx sdk.Context, _ []string, req abci.Request
 	}
 
 	// branch the context to isolate state changes
-	ctx, _ = ctx.CacheContext(k.cacheSize)
+	ctx, _ = ctx.CacheContext()
 	withdrawAddr := k.GetDelegatorWithdrawAddr(ctx, params.DelegatorAddress)
 
 	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, withdrawAddr)

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -57,7 +57,7 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 
 		if passes {
 			handler := keeper.Router().GetRoute(proposal.ProposalRoute())
-			cacheCtx, writeCache := ctx.CacheContext(keeper.CacheSize)
+			cacheCtx, writeCache := ctx.CacheContext()
 
 			// The proposal handler may execute state mutating logic depending
 			// on the proposal content. If the handler fails, no state mutation

--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -34,8 +34,6 @@ type Keeper struct {
 
 	// Proposal router
 	router types.Router
-
-	CacheSize int
 }
 
 // NewKeeper returns a governance keeper. It handles:
@@ -47,7 +45,7 @@ type Keeper struct {
 // CONTRACT: the parameter Subspace must have the param key table already initialized
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace types.ParamSubspace,
-	authKeeper types.AccountKeeper, bankKeeper types.BankKeeper, sk types.StakingKeeper, rtr types.Router, cacheSize int,
+	authKeeper types.AccountKeeper, bankKeeper types.BankKeeper, sk types.StakingKeeper, rtr types.Router,
 ) Keeper {
 
 	// ensure governance module account is set
@@ -68,7 +66,6 @@ func NewKeeper(
 		sk:         sk,
 		cdc:        cdc,
 		router:     rtr,
-		CacheSize:  cacheSize,
 	}
 }
 

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -18,7 +18,7 @@ func (keeper Keeper) SubmitProposal(ctx sdk.Context, content types.Content) (typ
 	// Execute the proposal content in a new context branch (with branched store)
 	// to validate the actual parameter changes before the proposal proceeds
 	// through the governance process. State is not persisted.
-	cacheCtx, _ := ctx.CacheContext(keeper.CacheSize)
+	cacheCtx, _ := ctx.CacheContext()
 	handler := keeper.router.GetRoute(content.ProposalRoute())
 	if err := handler(cacheCtx, content); err != nil {
 		return types.Proposal{}, sdkerrors.Wrap(types.ErrInvalidProposalContent, err.Error())

--- a/x/staking/keeper/test_common.go
+++ b/x/staking/keeper/test_common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"math/rand"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -42,7 +41,7 @@ func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Vali
 	keeper.SetValidatorByPowerIndex(ctx, validator)
 
 	if !apply {
-		ctx, _ = ctx.CacheContext(storetypes.DefaultCacheSizeLimit)
+		ctx, _ = ctx.CacheContext()
 	}
 	_, err := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Since external packages like wasmd and ibc depends on cosmos's store interface, we cannot introduce interface-breaking changes. This makes passing custom cache limit impossible, so here we change it to be a default value for now (1 million).

We would likely need to fork wasmd and ibc if we want the ability to specify custom cache limit, or introduce any change that breaks interface in general.

## Testing performed to validate your change
built with sei-chain
