### PR TITLE
[baseapp] Bubble up events when concurrent fails for inspection by app

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -244,10 +244,10 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTx) (res a
 		telemetry.SetGauge(float32(gInfo.GasWanted), "tx", "gas", "wanted")
 	}()
 
-	gInfo, result, anteEvents, _, err := app.runTx(ctx.WithTxBytes(req.Tx).WithVoteInfos(app.voteInfos), runTxModeDeliver, req.Tx)
+	gInfo, result, _, _, err := app.runTx(ctx.WithTxBytes(req.Tx).WithVoteInfos(app.voteInfos), runTxModeDeliver, req.Tx)
 	if err != nil {
 		resultStr = "failed"
-		return sdkerrors.ResponseDeliverTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, sdk.MarkEventsToIndex(anteEvents, app.indexEvents), app.trace)
+		return sdkerrors.ResponseDeliverTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, sdk.MarkEventsToIndex(result.Events, app.indexEvents), app.trace)
 	}
 
 	return abci.ResponseDeliverTx{

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -857,7 +857,7 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 
 	}
 	// we do this since we will only be looking at result in DeliverTx
-	if len(anteEvents) > 0 {
+	if result != nil && len(anteEvents) > 0 {
 		// append the events in the order of occurrence
 		result.Events = append(anteEvents, result.Events...)
 	}

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -855,12 +855,12 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 
 		msCache.Write()
 
-		if len(anteEvents) > 0 {
-			// append the events in the order of occurrence
-			result.Events = append(anteEvents, result.Events...)
-		}
 	}
-
+	// we do this since we will only be looking at result in DeliverTx
+	if len(anteEvents) > 0 {
+		// append the events in the order of occurrence
+		result.Events = append(anteEvents, result.Events...)
+	}
 	return gInfo, result, anteEvents, priority, err
 }
 
@@ -951,7 +951,11 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 				op.EmitValidationFailMetrics()
 			}
 			errMessage := fmt.Sprintf("Invalid Concurrent Execution messageIndex=%d, missing %d access operations", i, len(missingAccessOps))
-			return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidConcurrencyExecution, errMessage)
+			// we need to bubble up the events for inspection
+			return &sdk.Result{
+				Log:    strings.TrimSpace(msgLogs.String()),
+				Events: events.ToABCIEvents(),
+			}, sdkerrors.Wrap(sdkerrors.ErrInvalidConcurrencyExecution, errMessage)
 		}
 	}
 

--- a/x/accesscontrol/constants/context.go
+++ b/x/accesscontrol/constants/context.go
@@ -2,6 +2,6 @@ package constants
 
 type BadWasmDependencyAddressesKeyType string
 
-const BadWasmDependencyAddressesKey = BadWasmDependencyAddressesKeyType("key")
+const BadWasmDependencyAddressesKey = BadWasmDependencyAddressesKeyType("bad-wasm-dependency-addresses-key")
 
 const ResetReasonBadWasmDependency = "incorrectly specified dependency access list"


### PR DESCRIPTION
## Describe your changes and provide context
This bubbles up the events from deliverTx when we have a concurrent execution error. This way the app can extract the contract addresses that had the error and appropriately reset their dependencies.

One potential issue that this doesn't resolve is a malicious contract with dependencies intentionally improperly defined calling another contract to force its dependencies to be reset. We can look into this a bit more to identify a solution, but this is unlikely given that a contract needs governance to parallelize its dependencies, meaning that a malicious contract can be socially gatekept in this manner.

## Testing performed to validate your change

