### PR TITLE
CacheKv optimizations 

### DIFF
--- a/FORKED_CHANGELOG.md
+++ b/FORKED_CHANGELOG.md
@@ -48,6 +48,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [\#1](https://github.com/sei-protocol/sei-cosmos/pull/1) Integrate Cosmos with sei-tendermint and ABCI++
 * [\#14](https://github.com/sei-protocol/sei-cosmos/pull/14) Integrate Cosmos with Tendermint tracing
 * (x/auth/vesting) [\#11652](https://github.com/cosmos/cosmos-sdk/pull/11652) Add util functions for `Period(s)`
+* [\#14168](https://github.com/cosmos/cosmos-sdk/pull/14168) perf: store/cachekv: preallocate kvL in dirtyItems which gets appended too
+* [\#10024](https://github.com/cosmos/cosmos-sdk/pull/10024) fix!: store/cachekv: reduce growth factor for iterator ranging using binary searches #10024
 
 ### Features
 * [\#17](https://github.com/sei-protocol/sei-cosmos/pull/17) Support SR25519 algorithm for client transaction signing

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.96
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.101
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.101
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.102
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.94
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.96
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.sum
+++ b/go.sum
@@ -684,8 +684,8 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.96 h1:W90BxK3Wu1OjvX30izu7XyZ5Y62ulkwj/sOIrLlAnKI=
-github.com/sei-protocol/sei-tendermint v0.1.96/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
+github.com/sei-protocol/sei-tendermint v0.1.100 h1:4D2nGdbU+pezqxwvhJI8eWZ/Bify14rBcYraOZCOhSY=
+github.com/sei-protocol/sei-tendermint v0.1.100/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -684,8 +684,8 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.100 h1:4D2nGdbU+pezqxwvhJI8eWZ/Bify14rBcYraOZCOhSY=
-github.com/sei-protocol/sei-tendermint v0.1.100/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
+github.com/sei-protocol/sei-tendermint v0.1.102 h1:YwUfpwuZiUvyxhQTvTp/NV0fZWDG+QvemLB+3wTjE1k=
+github.com/sei-protocol/sei-tendermint v0.1.102/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -684,8 +684,8 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.94 h1:YlAU7w2s7tDqPez8Xmg2d3ImrjTPeCyo8eTLtabjODY=
-github.com/sei-protocol/sei-tendermint v0.1.94/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
+github.com/sei-protocol/sei-tendermint v0.1.96 h1:W90BxK3Wu1OjvX30izu7XyZ5Y62ulkwj/sOIrLlAnKI=
+github.com/sei-protocol/sei-tendermint v0.1.96/go.mod h1:Olwbjyagrpoxj5DAUhHxMTWDVEfQ3FYdpypaJ3+6Hs8=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/store/cachekv/memiterator.go
+++ b/store/cachekv/memiterator.go
@@ -2,7 +2,6 @@ package cachekv
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 
 	dbm "github.com/tendermint/tm-db"
@@ -31,7 +30,6 @@ func newMemIterator(
 	eventManager *sdktypes.EventManager,
 	storeKey sdktypes.StoreKey,
 ) *memIterator {
-	fmt.Println("BWENG:newMemIterator")
 	var iter types.Iterator
 	var err error
 
@@ -55,7 +53,6 @@ func newMemIterator(
 }
 
 func (mi *memIterator) Value() []byte {
-	fmt.Println("BWENG:Value")
 	key := mi.Iterator.Key()
 	// We need to handle the case where deleted is modified and includes our current key
 	// We handle this by maintaining a lastKey object in the iterator.
@@ -63,12 +60,9 @@ func (mi *memIterator) Value() []byte {
 	// then we are calling value on the same thing as last time.
 	// Therefore we don't check the mi.deleted to see if this key is included in there.
 	reCallingOnOldLastKey := (mi.lastKey != nil) && bytes.Equal(key, mi.lastKey)
-	fmt.Println("BWENG:LOAD")
 	if _, ok := mi.deleted.Load(string(key)); ok && !reCallingOnOldLastKey {
-		fmt.Println("BWENG:NOTHING")
 		return nil
 	}
-	fmt.Println("BWENG:GOT VALUE")
 	value := mi.Iterator.Value()
 	mi.eventManager.EmitResourceAccessReadEvent("iterator", mi.storeKey, key, value)
 

--- a/store/cachekv/memiterator.go
+++ b/store/cachekv/memiterator.go
@@ -2,6 +2,7 @@ package cachekv
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	dbm "github.com/tendermint/tm-db"
@@ -30,6 +31,7 @@ func newMemIterator(
 	eventManager *sdktypes.EventManager,
 	storeKey sdktypes.StoreKey,
 ) *memIterator {
+	fmt.Println("BWENG:newMemIterator")
 	var iter types.Iterator
 	var err error
 
@@ -45,7 +47,6 @@ func newMemIterator(
 
 	return &memIterator{
 		Iterator: iter,
-
 		lastKey: nil,
 		deleted: deleted,
 		eventManager: eventManager,
@@ -54,6 +55,7 @@ func newMemIterator(
 }
 
 func (mi *memIterator) Value() []byte {
+	fmt.Println("BWENG:Value")
 	key := mi.Iterator.Key()
 	// We need to handle the case where deleted is modified and includes our current key
 	// We handle this by maintaining a lastKey object in the iterator.
@@ -61,10 +63,12 @@ func (mi *memIterator) Value() []byte {
 	// then we are calling value on the same thing as last time.
 	// Therefore we don't check the mi.deleted to see if this key is included in there.
 	reCallingOnOldLastKey := (mi.lastKey != nil) && bytes.Equal(key, mi.lastKey)
+	fmt.Println("BWENG:LOAD")
 	if _, ok := mi.deleted.Load(string(key)); ok && !reCallingOnOldLastKey {
+		fmt.Println("BWENG:NOTHING")
 		return nil
 	}
-
+	fmt.Println("BWENG:GOT VALUE")
 	value := mi.Iterator.Value()
 	mi.eventManager.EmitResourceAccessReadEvent("iterator", mi.storeKey, key, value)
 

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -325,7 +325,7 @@ const (
 	stateAlreadySorted
 )
 
-const minSortSize = 1024
+const minSortSize = 256
 
 // Constructs a slice of dirty items, to use w/ memIterator.
 func (store *Store) dirtyItems(start, end []byte) {


### PR DESCRIPTION
## Describe your changes and provide context
Cherry picking changes here:
* [\#14168](https://github.com/cosmos/cosmos-sdk/pull/14168) perf: store/cachekv: preallocate kvL in dirtyItems which gets appended too
* [\#10024](https://github.com/cosmos/cosmos-sdk/pull/10024) fix!: store/cachekv: reduce growth factor for iterator ranging using binary searches #10024 

## Testing performed to validate your change
Ran a cluster
![image](https://user-images.githubusercontent.com/18161326/207636380-1c404827-cdb4-4bdc-aade-bfc0294f6cd4.png)

