### PR TITLE
[acl] pass message info when getting wasm access ops

### DIFF
--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -158,14 +158,15 @@ func (k Keeper) GetWasmDependencyAccessOps(ctx sdk.Context, contractAddress sdk.
 
 	accessOps := dependencyMapping.BaseAccessOps
 	specificAccessOpsMapping := []*acltypes.WasmAccessOperations{}
-	if msgInfo.MessageType == acltypes.WasmMessageSubtype_EXECUTE && dependencyMapping.ExecuteAccessOps != nil {
+	if msgInfo.MessageType == acltypes.WasmMessageSubtype_EXECUTE && len(dependencyMapping.ExecuteAccessOps) > 0 {
 		specificAccessOpsMapping = dependencyMapping.ExecuteAccessOps
-	} else if msgInfo.MessageType == acltypes.WasmMessageSubtype_QUERY && dependencyMapping.QueryAccessOps != nil {
+	} else if msgInfo.MessageType == acltypes.WasmMessageSubtype_QUERY && len(dependencyMapping.QueryAccessOps) > 0 {
 		specificAccessOpsMapping = dependencyMapping.QueryAccessOps
 	}
 	for _, specificAccessOps := range specificAccessOpsMapping {
 		if specificAccessOps.MessageName == msgInfo.MessageName {
 			accessOps = append(accessOps, specificAccessOps.WasmOperations...)
+			break
 		}
 	}
 

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -139,7 +139,7 @@ func (k Keeper) GetRawWasmDependencyMapping(ctx sdk.Context, contractAddress sdk
 	return &dependencyMapping, nil
 }
 
-func (k Keeper) GetWasmDependencyAccessOps(ctx sdk.Context, contractAddress sdk.AccAddress, senderBech string, msgBody []byte, circularDepLookup ContractReferenceLookupMap) ([]acltypes.AccessOperation, error) {
+func (k Keeper) GetWasmDependencyAccessOps(ctx sdk.Context, contractAddress sdk.AccAddress, senderBech string, msgInfo *types.WasmMessageInfo, circularDepLookup ContractReferenceLookupMap) ([]acltypes.AccessOperation, error) {
 	uniqueIdentifier := contractAddress.String()
 	if _, ok := circularDepLookup[uniqueIdentifier]; ok {
 		// we've already seen this contract, we should simply return synchronous access Ops
@@ -156,15 +156,27 @@ func (k Keeper) GetWasmDependencyAccessOps(ctx sdk.Context, contractAddress sdk.
 		return nil, err
 	}
 
-	// TODO: extend base access op with message-specific ops once message type identifier is passed in
-	selectedAccessOps, err := k.BuildSelectorOps(ctx, contractAddress, dependencyMapping.BaseAccessOps, senderBech, msgBody, circularDepLookup)
+	accessOps := dependencyMapping.BaseAccessOps
+	specificAccessOpsMapping := []*acltypes.WasmAccessOperations{}
+	if msgInfo.MessageType == acltypes.WasmMessageSubtype_EXECUTE && dependencyMapping.ExecuteAccessOps != nil {
+		specificAccessOpsMapping = dependencyMapping.ExecuteAccessOps
+	} else if msgInfo.MessageType == acltypes.WasmMessageSubtype_QUERY && dependencyMapping.QueryAccessOps != nil {
+		specificAccessOpsMapping = dependencyMapping.QueryAccessOps
+	}
+	for _, specificAccessOps := range specificAccessOpsMapping {
+		if specificAccessOps.MessageName == msgInfo.MessageName {
+			accessOps = append(accessOps, specificAccessOps.WasmOperations...)
+		}
+	}
+
+	selectedAccessOps, err := k.BuildSelectorOps(ctx, contractAddress, accessOps, senderBech, msgInfo, circularDepLookup)
 	if err != nil {
 		return nil, err
 	}
 	return selectedAccessOps, nil
 }
 
-func (k Keeper) BuildSelectorOps(ctx sdk.Context, contractAddr sdk.AccAddress, accessOps []*acltypes.WasmAccessOperation, senderBech string, msgBody []byte, circularDepLookup ContractReferenceLookupMap) ([]acltypes.AccessOperation, error) {
+func (k Keeper) BuildSelectorOps(ctx sdk.Context, contractAddr sdk.AccAddress, accessOps []*acltypes.WasmAccessOperation, senderBech string, msgInfo *types.WasmMessageInfo, circularDepLookup ContractReferenceLookupMap) ([]acltypes.AccessOperation, error) {
 	selectedAccessOps := types.NewEmptyAccessOperationSet()
 	// when we build selector ops here, we want to generate "*" if the proper fields aren't present
 	// if size of circular dep map > 1 then it means we're in a contract reference
@@ -179,7 +191,7 @@ accessOpLoop:
 			if err != nil {
 				return nil, err
 			}
-			data, err := op.Apply(msgBody)
+			data, err := op.Apply(msgInfo.MessageFullBody)
 			if err != nil {
 				if withinContractReference {
 					opWithSelector.Operation.IdentifierTemplate = "*"
@@ -198,7 +210,7 @@ accessOpLoop:
 			if err != nil {
 				return nil, err
 			}
-			data, err := op.Apply(msgBody)
+			data, err := op.Apply(msgInfo.MessageFullBody)
 			if err != nil {
 				if withinContractReference {
 					opWithSelector.Operation.IdentifierTemplate = "*"
@@ -222,7 +234,7 @@ accessOpLoop:
 			if err != nil {
 				return nil, err
 			}
-			data, err := op.Apply(msgBody)
+			data, err := op.Apply(msgInfo.MessageFullBody)
 			if err != nil {
 				if withinContractReference {
 					opWithSelector.Operation.IdentifierTemplate = "*"
@@ -275,7 +287,7 @@ accessOpLoop:
 			if err != nil {
 				return nil, err
 			}
-			_, err = op.Apply(msgBody)
+			_, err = op.Apply(msgInfo.MessageFullBody)
 			// if we are in a contract reference, we have to assume that this is necessary
 			// TODO: after partitioning changes are merged, the MESSAGE_CONDITIONAL can be deprecated in favor of partitioned deps
 			if err != nil && !withinContractReference {
@@ -297,8 +309,11 @@ accessOpLoop:
 			// TODO: add a circular dependency check here to ignore if we've already seen this contract/identifier in our reference chain
 			// for now, we will just pass in the same message body, this needs to be changed later though
 			// TODO: build new msgbody for the new contract execute / query msg in later milestone tasks
-			emptyJSON := []byte("{}")
-			wasmDeps, err := k.GetWasmDependencyAccessOps(ctx, interContractAddress, contractAddr.String(), emptyJSON, circularDepLookup)
+			emptyJSON := []byte("{\"\":{}}")
+			// TODO: add separate enum for query reference vs execute reference and build msgInfo according to whether
+			//       the reference is a query one or an execute one. For now defaulting to execute.
+			emptyMsgInfo, _ := types.NewExecuteMessageInfo(emptyJSON)
+			wasmDeps, err := k.GetWasmDependencyAccessOps(ctx, interContractAddress, contractAddr.String(), emptyMsgInfo, circularDepLookup)
 
 			if err != nil {
 				// if we have an error fetching the dependency mapping or the mapping is disabled, we want to use the synchronous mappings instead
@@ -313,7 +328,7 @@ accessOpLoop:
 		}
 		selectedAccessOps.Add(*opWithSelector.Operation)
 	}
-	// TODO: add logic to deduplicate access operations that are the same
+
 	return selectedAccessOps.ToSlice(), nil
 }
 

--- a/x/accesscontrol/types/wasm.go
+++ b/x/accesscontrol/types/wasm.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+
+	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+)
+
+type WasmMessageInfo struct {
+	MessageType     acltypes.WasmMessageSubtype
+	MessageName     string
+	MessageBody     []byte
+	MessageFullBody []byte
+}
+
+func NewExecuteMessageInfo(fullBody []byte) (*WasmMessageInfo, error) {
+	return newMessageInfo(fullBody, acltypes.WasmMessageSubtype_EXECUTE)
+}
+
+func NewQueryMessageInfo(fullBody []byte) (*WasmMessageInfo, error) {
+	return newMessageInfo(fullBody, acltypes.WasmMessageSubtype_QUERY)
+}
+
+func newMessageInfo(fullBody []byte, messageType acltypes.WasmMessageSubtype) (*WasmMessageInfo, error) {
+	name, body, err := extractMessage(fullBody)
+	if err != nil {
+		return nil, err
+	}
+	return &WasmMessageInfo{
+		MessageType:     messageType,
+		MessageName:     name,
+		MessageBody:     body,
+		MessageFullBody: fullBody,
+	}, nil
+}
+
+// WASM message body is JSON-serialized and use the message name
+// as the only top-level key
+func extractMessage(fullBody []byte) (string, []byte, error) {
+	var deserialized map[string]json.RawMessage
+	if err := json.Unmarshal(fullBody, &deserialized); err != nil {
+		return "", nil, err
+	}
+	topLevelKeys := []string{}
+	for k := range deserialized {
+		topLevelKeys = append(topLevelKeys, k)
+	}
+	if len(topLevelKeys) != 1 {
+		return "", nil, fmt.Errorf("expected exactly one top-level key but found %s", topLevelKeys)
+	}
+	return topLevelKeys[0], deserialized[topLevelKeys[0]], nil
+}

--- a/x/accesscontrol/types/wasm.go
+++ b/x/accesscontrol/types/wasm.go
@@ -40,14 +40,14 @@ func newMessageInfo(fullBody []byte, messageType acltypes.WasmMessageSubtype) (*
 func extractMessage(fullBody []byte) (string, []byte, error) {
 	var deserialized map[string]json.RawMessage
 	if err := json.Unmarshal(fullBody, &deserialized); err != nil {
-		return "", nil, err
+		return "", fullBody, err
 	}
 	topLevelKeys := []string{}
 	for k := range deserialized {
 		topLevelKeys = append(topLevelKeys, k)
 	}
 	if len(topLevelKeys) != 1 {
-		return "", nil, fmt.Errorf("expected exactly one top-level key but found %s", topLevelKeys)
+		return "", fullBody, fmt.Errorf("expected exactly one top-level key but found %s", topLevelKeys)
 	}
 	return topLevelKeys[0], deserialized[topLevelKeys[0]], nil
 }

--- a/x/accesscontrol/types/wasm_test.go
+++ b/x/accesscontrol/types/wasm_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractMessage(t *testing.T) {
+	goodBody := []byte("{\"key\":{\"val\":{}}}")
+	name, body, err := extractMessage(goodBody)
+	require.Nil(t, err)
+	require.Equal(t, "key", name)
+	require.Equal(t, "{\"val\":{}}", string(body))
+
+	badJson := []byte("{\"key\":}")
+	_, _, err = extractMessage(badJson)
+	require.NotNil(t, err)
+
+	emptyBody := []byte("{}")
+	_, _, err = extractMessage(emptyBody)
+	require.NotNil(t, err)
+
+	multiKeyBody := []byte("{\"key1\":{},\"key2\":{}}")
+	_, _, err = extractMessage(multiKeyBody)
+	require.NotNil(t, err)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Callers to `GetWasmDependencyAccessOps` now needs to pass in a `WasmMessageInfo` instead of raw message bytes so that the function can identify whether the message is a query or execute. This PR introduced helpers under `types/wasm.go` to help creating such `WasmMessageInfo`. `GetWasmDependencyAccessOps` would then extend the access operations list with the appropriate specific access ops.

Next steps:
- Add separate selector enums for query reference and execute reference
- Handle new selector enums by passing the current WasmMessageInfo

## Testing performed to validate your change
unit tests
