### PR TITLE
Add eventManager to mergeIterator

### DIFF
--- a/store/cachekv/memiterator.go
+++ b/store/cachekv/memiterator.go
@@ -63,9 +63,7 @@ func (mi *memIterator) Value() []byte {
 	if _, ok := mi.deleted.Load(string(key)); ok && !reCallingOnOldLastKey {
 		return nil
 	}
-	value := mi.Iterator.Value()
-	mi.eventManager.EmitResourceAccessReadEvent("iterator", mi.storeKey, key, value)
-
 	mi.lastKey = key
-	return value
+	
+	return mi.Iterator.Value()
 }

--- a/store/cachekv/mergeiterator.go
+++ b/store/cachekv/mergeiterator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/cosmos/cosmos-sdk/store/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 )
 
 // cacheMergeIterator merges a parent Iterator and a cache Iterator.
@@ -18,15 +19,24 @@ type cacheMergeIterator struct {
 	parent    types.Iterator
 	cache     types.Iterator
 	ascending bool
+	eventManager  *sdktypes.EventManager
+	storeKey sdktypes.StoreKey
 }
 
 var _ types.Iterator = (*cacheMergeIterator)(nil)
 
-func NewCacheMergeIterator(parent, cache types.Iterator, ascending bool) *cacheMergeIterator {
+func NewCacheMergeIterator(
+	parent, cache types.Iterator, 
+	ascending bool,
+	eventManager *sdktypes.EventManager,
+	storeKey sdktypes.StoreKey,
+) *cacheMergeIterator {
 	iter := &cacheMergeIterator{
 		parent:    parent,
 		cache:     cache,
 		ascending: ascending,
+		eventManager: eventManager,
+		storeKey: storeKey,
 	}
 
 	return iter
@@ -132,7 +142,9 @@ func (iter *cacheMergeIterator) Value() []byte {
 
 	// If cache is invalid, get the parent value.
 	if !iter.cache.Valid() {
-		return iter.parent.Value()
+		value := iter.parent.Value()
+		iter.eventManager.EmitResourceAccessReadEvent("iterator", iter.storeKey, iter.parent.Key(), value)
+		return value
 	}
 
 	// Both are valid.  Compare keys.
@@ -141,7 +153,9 @@ func (iter *cacheMergeIterator) Value() []byte {
 	cmp := iter.compare(keyP, keyC)
 	switch cmp {
 	case -1: // parent < cache
-		return iter.parent.Value()
+		value := iter.parent.Value()
+		iter.eventManager.EmitResourceAccessReadEvent("iterator", iter.storeKey, iter.parent.Key(), value)
+		return value
 	case 0: // parent == cache
 		return iter.cache.Value()
 	case 1: // parent > cache

--- a/store/cachekv/mergeiterator_test.go
+++ b/store/cachekv/mergeiterator_test.go
@@ -1,0 +1,43 @@
+package cachekv_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store/cachekv"
+	"github.com/cosmos/cosmos-sdk/store/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/cosmos/cosmos-sdk/store/dbadapter"
+)
+
+func TestEmitEventMangerInParentIterator(t *testing.T) {
+	// initiate mock kvstore
+	mem := dbadapter.Store{DB: dbm.NewMemDB()}
+	kvstore := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
+	value := randSlice(defaultValueSizeBz)
+	startKey := randSlice(32)
+
+	keys := generateSequentialKeys(startKey, 3)
+	for _, k := range keys {
+		kvstore.Set(k, value)
+	}
+
+	// initialize mock mergeIterator
+	eventManager := sdktypes.NewEventManager()
+	parent := kvstore.Iterator(keys[0], keys[2])
+	cache := kvstore.Iterator(nil, nil)
+	for ; cache.Valid(); cache.Next() {
+	}
+	iter := cachekv.NewCacheMergeIterator(parent, cache, true, eventManager, types.NewKVStoreKey("CacheKvTest"))
+	
+	// get the next value
+	iter.Value()
+
+	// assert the resource access is still emitted correctly when the cache store is unavailable
+	require.Equal(t, "access_type", eventManager.Events()[0].Attributes[0].Key)
+	require.Equal(t, "read", eventManager.Events()[0].Attributes[0].Value)
+	require.Equal(t, "store_key", eventManager.Events()[0].Attributes[1].Key)
+	require.Equal(t, "CacheKvTest", eventManager.Events()[0].Attributes[1].Value)
+}

--- a/store/cachekv/mergeiterator_test.go
+++ b/store/cachekv/mergeiterator_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
 )
 
-func TestEmitEventMangerInParentIterator(t *testing.T) {
+func TestEmitEventMangerInIterator(t *testing.T) {
 	// initiate mock kvstore
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
 	kvstore := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
@@ -36,6 +36,19 @@ func TestEmitEventMangerInParentIterator(t *testing.T) {
 	iter.Value()
 
 	// assert the resource access is still emitted correctly when the cache store is unavailable
+	require.Equal(t, "access_type", eventManager.Events()[0].Attributes[0].Key)
+	require.Equal(t, "read", eventManager.Events()[0].Attributes[0].Value)
+	require.Equal(t, "store_key", eventManager.Events()[0].Attributes[1].Key)
+	require.Equal(t, "CacheKvTest", eventManager.Events()[0].Attributes[1].Value)
+
+	// assert event emission when cache is available
+	cache = kvstore.Iterator(keys[1], keys[2])
+	iter = cachekv.NewCacheMergeIterator(parent, cache, true, eventManager, types.NewKVStoreKey("CacheKvTest"))
+	
+	// get the next value
+	iter.Value()
+
+	// assert the resource access is still emitted correctly when the cache store is available
 	require.Equal(t, "access_type", eventManager.Events()[0].Attributes[0].Key)
 	require.Equal(t, "read", eventManager.Events()[0].Attributes[0].Value)
 	require.Equal(t, "store_key", eventManager.Events()[0].Attributes[1].Key)

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -239,7 +239,7 @@ func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	}
 	store.dirtyItems(start, end)
 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
-	return NewCacheMergeIterator(parent, cache, ascending)
+	return NewCacheMergeIterator(parent, cache, ascending, store.eventManager, store.storeKey)
 }
 
 func findStartIndex(strL []string, startQ string) int {


### PR DESCRIPTION
## Describe your changes and provide context
This PR adds eventMangaer to the mergeIterator to record resource access for READ operation that doesn't access to the cache iterator but the parent (often iavl) iterator.

## Testing performed to validate your change
- Load test
- Tested on local node
- unit test