### PR TITLE
Check if validator pubkey is nil before setting it

### DIFF
--- a/client/rpc/status.go
+++ b/client/rpc/status.go
@@ -50,11 +50,15 @@ func StatusCommand() *cobra.Command {
 				return err
 			}
 
+			var pk cryptotypes.PubKey
 			// `status` has TM pubkeys, we need to convert them to our pubkeys.
-			pk, err := cryptocodec.FromTmPubKeyInterface(status.ValidatorInfo.PubKey)
-			if err != nil {
-				return err
+			if status.ValidatorInfo.PubKey != nil {
+				pk, err = cryptocodec.FromTmPubKeyInterface(status.ValidatorInfo.PubKey)
+				if err != nil {
+					return err
+				}
 			}
+
 			statusWithPk := resultStatus{
 				NodeInfo: status.NodeInfo,
 				SyncInfo: status.SyncInfo,


### PR DESCRIPTION
## Describe your changes and provide context
`seid status` fails for non-validator nodes. It turns out that the check for `ValidatorInfo.Pubkey` here https://github.com/cosmos/cosmos-sdk/blob/main/client/rpc/status.go#L52 isn't in our branch, which causes it to fail with a nil pointer. 
## Testing performed to validate your change
Verified and tested on rpc node:
```
/home/ubuntu/sei-chain# seid status | jq
{
  "NodeInfo": {
    "protocol_version": {
      "p2p": "8",
      "block": "11",
...
```
