### PR TITLE
Fix application state rollback logic

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -316,7 +316,7 @@ func (app *BaseApp) Commit(ctx context.Context) (res *abci.ResponseCommit, err e
 	retainHeight := app.GetBlockRetentionHeight(header.Height)
 
 	app.WriteStateToCommitAndGetWorkingHash()
-	app.cms.Commit()
+	app.cms.Commit(true)
 
 	// Reset the Check state to the latest committed.
 	//

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -1813,7 +1813,7 @@ func initStore(t *testing.T, db dbm.DB, storeKey string, k, v []byte) {
 	kv, _ := rs.GetStore(key).(store.KVStore)
 	require.NotNil(t, kv)
 	kv.Set(k, v)
-	commitID := rs.Commit()
+	commitID := rs.Commit(true)
 	require.Equal(t, int64(1), commitID.Version)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -137,6 +137,8 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 
+	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.0.1
+
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,6 @@ github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
-github.com/cosmos/iavl v0.19.4 h1:t82sN+Y0WeqxDLJRSpNd8YFX5URIrT+p8n6oJbJ2Dok=
-github.com/cosmos/iavl v0.19.4/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76 h1:DdzS1m6o/pCqeZ8VOAit/gyATedRgjvkVI+UCrLpyuU=
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76/go.mod h1:0mkLWIoZuQ7uBoospo5Q9zIpqq6rYCPJDSUdeCJvPM8=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
@@ -690,6 +688,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-tendermint v0.1.147 h1:RMBxt+qU3fWU8REMmbjzxT1yeCjog5/34ReErP/Wr1I=
 github.com/sei-protocol/sei-tendermint v0.1.147/go.mod h1:odeOImx/S/mCKw9TIBSDjKUxoYkVVsitidaOnh0tyZI=
+github.com/sei-protocol/sei-iavl v0.0.1 h1:3i3m6T8JHlYBh5JT5A8CNa7hOih4loimwJs5qNYgqU8=
+github.com/sei-protocol/sei-iavl v0.0.1/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -61,7 +61,7 @@ func (ms multiStore) ListeningEnabled(key store.StoreKey) bool {
 	panic("not implemented")
 }
 
-func (ms multiStore) Commit() sdk.CommitID {
+func (ms multiStore) Commit(_ bool) sdk.CommitID {
 	panic("not implemented")
 }
 

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -128,10 +128,17 @@ func (st *Store) GetWorkingHash() ([]byte, error) {
 
 // Commit commits the current store state and returns a CommitID with the new
 // version and hash.
-func (st *Store) Commit() types.CommitID {
+func (st *Store) Commit(bumpVersion bool) types.CommitID {
 	defer telemetry.MeasureSince(time.Now(), "store", "iavl", "commit")
 
-	hash, version, err := st.tree.SaveVersion()
+	var hash []byte
+	var version int64
+	var err error
+	if bumpVersion {
+		hash, version, err = st.tree.SaveVersion()
+	} else {
+		hash, version, err = st.tree.SaveCurrentVersion()
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -128,6 +128,8 @@ func (st *Store) GetWorkingHash() ([]byte, error) {
 
 // Commit commits the current store state and returns a CommitID with the new
 // version and hash.
+// Normally commit should always bump version. Commit without version bump is
+// needed by use cases like rollback
 func (st *Store) Commit(bumpVersion bool) types.CommitID {
 	defer telemetry.MeasureSince(time.Now(), "store", "iavl", "commit")
 

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -143,7 +143,7 @@ func TestGetImmutable(t *testing.T) {
 
 	require.Panics(t, func() { newStore.Set(nil, nil) })
 	require.Panics(t, func() { newStore.Delete(nil) })
-	require.Panics(t, func() { newStore.Commit() })
+	require.Panics(t, func() { newStore.Commit(true) })
 }
 
 func TestTestGetImmutableIterator(t *testing.T) {
@@ -441,7 +441,7 @@ func nextVersion(iavl *Store) {
 	key := []byte(fmt.Sprintf("Key for tree: %d", iavl.LastCommitID().Version))
 	value := []byte(fmt.Sprintf("Value for tree: %d", iavl.LastCommitID().Version))
 	iavl.Set(key, value)
-	iavl.Commit()
+	iavl.Commit(true)
 }
 
 func TestIAVLNoPrune(t *testing.T) {
@@ -498,7 +498,7 @@ func TestIAVLStoreQuery(t *testing.T) {
 	valExpSub2, err := KVs2.Marshal()
 	require.NoError(t, err)
 
-	cid := iavlStore.Commit()
+	cid := iavlStore.Commit(true)
 	ver := cid.Version
 	query := abci.RequestQuery{Path: "/key", Data: k1, Height: ver}
 	querySub := abci.RequestQuery{Path: "/subspace", Data: ksub, Height: ver}
@@ -518,7 +518,7 @@ func TestIAVLStoreQuery(t *testing.T) {
 	require.Nil(t, qres.Value)
 
 	// commit it, but still don't see on old version
-	cid = iavlStore.Commit()
+	cid = iavlStore.Commit(true)
 	qres = iavlStore.Query(query)
 	require.Equal(t, uint32(0), qres.Code)
 	require.Nil(t, qres.Value)
@@ -536,7 +536,7 @@ func TestIAVLStoreQuery(t *testing.T) {
 
 	// modify
 	iavlStore.Set(k1, v3)
-	cid = iavlStore.Commit()
+	cid = iavlStore.Commit(true)
 
 	// query will return old values, as height is fixed
 	qres = iavlStore.Query(query)
@@ -638,7 +638,7 @@ func TestSetInitialVersion(t *testing.T) {
 				require.Panics(t, func() { store.SetInitialVersion(5) })
 			} else {
 				store.SetInitialVersion(5)
-				cid := store.Commit()
+				cid := store.Commit(true)
 				require.Equal(t, int64(5), cid.GetVersion())
 			}
 		})

--- a/store/iavl/tree.go
+++ b/store/iavl/tree.go
@@ -23,6 +23,7 @@ type (
 		Set(key, value []byte) (bool, error)
 		Remove(key []byte) ([]byte, bool, error)
 		SaveVersion() ([]byte, int64, error)
+		SaveCurrentVersion() ([]byte, int64, error)
 		DeleteVersion(version int64) error
 		DeleteVersions(versions ...int64) error
 		Version() int64
@@ -55,6 +56,10 @@ func (it *immutableTree) Set(_, _ []byte) (bool, error) {
 
 func (it *immutableTree) Remove(_ []byte) ([]byte, bool, error) {
 	panic("cannot call 'Remove' on an immutable IAVL tree")
+}
+
+func (it *immutableTree) SaveCurrentVersion() ([]byte, int64, error) {
+	panic("cannot call 'SaveVersion' on an immutable IAVL tree")
 }
 
 func (it *immutableTree) SaveVersion() ([]byte, int64, error) {

--- a/store/mem/mem_test.go
+++ b/store/mem/mem_test.go
@@ -43,7 +43,7 @@ func TestCommit(t *testing.T) {
 	key, value := []byte("key"), []byte("value")
 
 	db.Set(key, value)
-	id := db.Commit()
+	id := db.Commit(true)
 	require.True(t, id.IsZero())
 	require.True(t, db.LastCommitID().IsZero())
 	require.Equal(t, value, db.Get(key))

--- a/store/mem/store.go
+++ b/store/mem/store.go
@@ -52,7 +52,7 @@ func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types
 }
 
 // Commit performs a no-op as entries are persistent between commitments.
-func (s *Store) Commit() (id types.CommitID) { return }
+func (s *Store) Commit(_ bool) (id types.CommitID) { return }
 
 func (s *Store) SetPruning(pruning types.PruningOptions) {}
 

--- a/store/rootmulti/dbadapter.go
+++ b/store/rootmulti/dbadapter.go
@@ -16,7 +16,7 @@ type commitDBStoreAdapter struct {
 	dbadapter.Store
 }
 
-func (cdsa commitDBStoreAdapter) Commit() types.CommitID {
+func (cdsa commitDBStoreAdapter) Commit(_ bool) types.CommitID {
 	return types.CommitID{
 		Version: -1,
 		Hash:    commithash,

--- a/store/rootmulti/proof_test.go
+++ b/store/rootmulti/proof_test.go
@@ -19,7 +19,7 @@ func TestVerifyIAVLStoreQueryProof(t *testing.T) {
 	store := iStore.(*iavl.Store)
 	require.Nil(t, err)
 	store.Set([]byte("MYKEY"), []byte("MYVALUE"))
-	cid := store.Commit()
+	cid := store.Commit(true)
 
 	// Get Proof
 	res := store.Query(abci.RequestQuery{
@@ -66,7 +66,7 @@ func TestVerifyMultiStoreQueryProof(t *testing.T) {
 
 	iavlStore := store.GetCommitStore(iavlStoreKey).(*iavl.Store)
 	iavlStore.Set([]byte("MYKEY"), []byte("MYVALUE"))
-	cid := store.Commit()
+	cid := store.Commit(true)
 
 	// Get Proof
 	res := store.Query(abci.RequestQuery{
@@ -122,7 +122,7 @@ func TestVerifyMultiStoreQueryProofAbsence(t *testing.T) {
 
 	iavlStore := store.GetCommitStore(iavlStoreKey).(*iavl.Store)
 	iavlStore.Set([]byte("MYKEY"), []byte("MYVALUE"))
-	cid := store.Commit() // Commit with empty iavl store.
+	cid := store.Commit(true) // Commit with empty iavl store.
 
 	// Get Proof
 	res := store.Query(abci.RequestQuery{

--- a/store/rootmulti/snapshot_test.go
+++ b/store/rootmulti/snapshot_test.go
@@ -48,7 +48,7 @@ func newMultiStoreWithGeneratedData(db dbm.DB, stores uint8, storeKeys uint64) *
 		}
 	}
 
-	multiStore.Commit()
+	multiStore.Commit(true)
 	multiStore.LoadLatestVersion()
 
 	return multiStore
@@ -76,17 +76,17 @@ func newMultiStoreWithMixedMountsAndBasicData(db dbm.DB) *rootmulti.Store {
 	store2.Set([]byte("X"), []byte{255})
 	store2.Set([]byte("A"), []byte{101})
 	trans1.Set([]byte("x1"), []byte{91})
-	store.Commit()
+	store.Commit(true)
 
 	store1.Set([]byte("b"), []byte{2})
 	store1.Set([]byte("c"), []byte{3})
 	store2.Set([]byte("B"), []byte{102})
-	store.Commit()
+	store.Commit(true)
 
 	store2.Set([]byte("C"), []byte{103})
 	store2.Delete([]byte("X"))
 	trans1.Set([]byte("x2"), []byte{92})
-	store.Commit()
+	store.Commit(true)
 
 	return store
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -451,7 +451,7 @@ func (rs *Store) Commit(bumpVersion bool) types.CommitID {
 		// start from initialVersion.
 		version = rs.initialVersion
 
-	} else {
+	} else if bumpVersion {
 		// This case can means two things:
 		// - either there was already a previous commit in the store, in which
 		// case we increment the version from there,
@@ -459,6 +459,8 @@ func (rs *Store) Commit(bumpVersion bool) types.CommitID {
 		// in which case we start at version 1.
 		previousHeight = rs.lastCommitInfo.GetVersion()
 		version = previousHeight + 1
+	} else {
+		version = rs.lastCommitInfo.GetVersion()
 	}
 
 	rs.lastCommitInfo = commitStores(version, rs.stores, bumpVersion)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -82,7 +82,7 @@ func TestCacheMultiStoreWithVersion(t *testing.T) {
 	store1 := ms.GetStoreByName("store1").(types.KVStore)
 	store1.Set(k, v)
 
-	cID := ms.Commit()
+	cID := ms.Commit(true)
 	require.Equal(t, int64(1), cID.Version)
 
 	// require no failure when given an invalid or pruned version
@@ -119,12 +119,12 @@ func TestHashStableWithEmptyCommit(t *testing.T) {
 	store1 := ms.GetStoreByName("store1").(types.KVStore)
 	store1.Set(k, v)
 
-	cID := ms.Commit()
+	cID := ms.Commit(true)
 	require.Equal(t, int64(1), cID.Version)
 	hash := cID.Hash
 
 	// make an empty commit, it should update version, but not affect hash
-	cID = ms.Commit()
+	cID = ms.Commit(true)
 	require.Equal(t, int64(2), cID.Version)
 	require.Equal(t, hash, cID.Hash)
 }
@@ -150,7 +150,7 @@ func TestMultistoreCommitLoad(t *testing.T) {
 	// Make a few commits and check them.
 	nCommits := int64(3)
 	for i := int64(0); i < nCommits; i++ {
-		commitID = store.Commit()
+		commitID = store.Commit(true)
 		expectedCommitID := getExpectedCommitID(store, i+1)
 		checkStore(t, store, expectedCommitID, commitID)
 	}
@@ -163,7 +163,7 @@ func TestMultistoreCommitLoad(t *testing.T) {
 	checkStore(t, store, commitID, commitID)
 
 	// Commit and check version.
-	commitID = store.Commit()
+	commitID = store.Commit(true)
 	expectedCommitID := getExpectedCommitID(store, nCommits+1)
 	checkStore(t, store, expectedCommitID, commitID)
 
@@ -202,7 +202,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Nil(t, s4)
 
 	// do one commit
-	commitID := store.Commit()
+	commitID := store.Commit(true)
 	expectedCommitID := getExpectedCommitID(store, 1)
 	checkStore(t, store, expectedCommitID, commitID)
 
@@ -268,7 +268,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, v2, rs2.Get(k2))
 
 	// store this migrated data, and load it again without migrations
-	migratedID := restore.Commit()
+	migratedID := restore.Commit(true)
 	require.Equal(t, migratedID.Version, int64(2))
 
 	reload, _ := newMultiStoreWithModifiedMounts(db, types.PruneNothing)
@@ -348,7 +348,7 @@ func TestMultiStoreRestart(t *testing.T) {
 		store3 := multi.GetStoreByName("store3").(types.KVStore)
 		store3.Set([]byte(k3), []byte(fmt.Sprintf("%s:%d", v3, i)))
 
-		multi.Commit()
+		multi.Commit(true)
 
 		cinfo, err := getCommitInfo(multi.db, int64(i))
 		require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestMultiStoreRestart(t *testing.T) {
 	store2 := multi.GetStoreByName("store2").(types.KVStore)
 	store2.Set([]byte(k2), []byte(fmt.Sprintf("%s:%d", v2, 3)))
 
-	multi.Commit()
+	multi.Commit(true)
 
 	flushedCinfo, err := getCommitInfo(multi.db, 3)
 	require.Nil(t, err)
@@ -373,7 +373,7 @@ func TestMultiStoreRestart(t *testing.T) {
 	store3 := multi.GetStoreByName("store3").(types.KVStore)
 	store3.Set([]byte(k3), []byte(fmt.Sprintf("%s:%d", v3, 3)))
 
-	multi.Commit()
+	multi.Commit(true)
 
 	postFlushCinfo, err := getCommitInfo(multi.db, 4)
 	require.NoError(t, err)
@@ -411,7 +411,7 @@ func TestMultiStoreQuery(t *testing.T) {
 	k2, v2 := []byte("water"), []byte("flows")
 	// v3 := []byte("is cold")
 
-	cid1 := multi.Commit()
+	cid1 := multi.Commit(true)
 
 	// Make sure we can get by name.
 	garbage := multi.GetStoreByName("bad-name")
@@ -426,7 +426,7 @@ func TestMultiStoreQuery(t *testing.T) {
 	store2.Set(k2, v2)
 
 	// Commit the multistore.
-	cid2 := multi.Commit()
+	cid2 := multi.Commit(true)
 	ver := cid2.Version
 
 	// Reload multistore from database
@@ -515,7 +515,7 @@ func TestMultiStore_Pruning(t *testing.T) {
 			require.NoError(t, ms.LoadLatestVersion())
 
 			for i := int64(0); i < tc.numVersions; i++ {
-				ms.Commit()
+				ms.Commit(true)
 			}
 
 			for _, v := range tc.saved {
@@ -539,7 +539,7 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 	// Commit enough to build up heights to prune, where on the next block we should
 	// batch delete.
 	for i := int64(0); i < 10; i++ {
-		ms.Commit()
+		ms.Commit(true)
 	}
 
 	pruneHeights := []int64{1, 2, 4, 5, 7}
@@ -556,7 +556,7 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 	require.Equal(t, pruneHeights, ms.pruneHeights)
 
 	// commit one more block and ensure the heights have been pruned
-	ms.Commit()
+	ms.Commit(true)
 	require.Empty(t, ms.pruneHeights)
 
 	for _, v := range pruneHeights {
@@ -574,7 +574,7 @@ func TestSetInitialVersion(t *testing.T) {
 	multi.SetInitialVersion(5)
 	require.Equal(t, int64(5), multi.initialVersion)
 
-	multi.Commit()
+	multi.Commit(true)
 	require.Equal(t, int64(5), multi.LastCommitID().Version)
 
 	ckvs := multi.GetCommitKVStore(multi.keysByName["store1"])

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -127,6 +127,11 @@ func TestHashStableWithEmptyCommit(t *testing.T) {
 	cID = ms.Commit(true)
 	require.Equal(t, int64(2), cID.Version)
 	require.Equal(t, hash, cID.Hash)
+
+	// make an empty commit, it should not update version, and not affect hash
+	cID = ms.Commit(false)
+	require.Equal(t, int64(2), cID.Version)
+	require.Equal(t, hash, cID.Hash)
 }
 
 func TestMultistoreCommitLoad(t *testing.T) {

--- a/store/transient/store.go
+++ b/store/transient/store.go
@@ -22,7 +22,7 @@ func NewStore() *Store {
 
 // Implements CommitStore
 // Commit cleans up Store.
-func (ts *Store) Commit() (id types.CommitID) {
+func (ts *Store) Commit(_ bool) (id types.CommitID) {
 	ts.Store = dbadapter.Store{DB: dbm.NewMemDB()}
 	return
 }

--- a/store/transient/store_test.go
+++ b/store/transient/store_test.go
@@ -21,7 +21,7 @@ func TestTransientStore(t *testing.T) {
 
 	require.Equal(t, v, tstore.Get(k))
 
-	tstore.Commit()
+	tstore.Commit(true)
 
 	require.Nil(t, tstore.Get(k))
 

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -19,7 +19,7 @@ type Store interface {
 
 // something that can persist to disk
 type Committer interface {
-	Commit() CommitID
+	Commit(bool) CommitID
 	LastCommitID() CommitID
 
 	SetPruning(PruningOptions)

--- a/x/upgrade/types/storeloader_test.go
+++ b/x/upgrade/types/storeloader_test.go
@@ -43,7 +43,7 @@ func initStore(t *testing.T, db dbm.DB, storeKey string, k, v []byte) {
 	kv, _ := rs.GetStore(key).(store.KVStore)
 	require.NotNil(t, kv)
 	kv.Set(k, v)
-	commitID := rs.Commit()
+	commitID := rs.Commit(true)
 	require.Equal(t, int64(1), commitID.Version)
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
- Fix rollback logic so that states of up to `target` height, instead of `target - 1`, are kept, since we want application state height to be on the same height of tendermint state height (which equals `target`) post rollback
- Commit state without bumping version. Otherwise the application state will end up in `target + 1` (and of the exact same data as height `target`) 

## Testing performed to validate your change
tested with local sei
