### PR TITLE
Reset interblock cache after statesync completes

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -566,7 +566,7 @@ func (app *BaseApp) ApplySnapshotChunk(context context.Context, req *abci.Reques
 	switch {
 	case err == nil:
 		if done {
-			app.shouldResetInterBlockCache = true
+			app.interBlockCache.Reset()
 		}
 		return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil
 
@@ -942,11 +942,6 @@ func (app *BaseApp) PrepareProposal(ctx context.Context, req *abci.RequestPrepar
 
 func (app *BaseApp) ProcessProposal(ctx context.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
 	defer telemetry.MeasureSince(time.Now(), "abci", "process_proposal")
-
-	if app.shouldResetInterBlockCache {
-		app.resetInterBlockCache()
-		app.shouldResetInterBlockCache = false
-	}
 
 	header := tmproto.Header{ChainID: app.ChainID, Height: req.Height, Time: req.Time, ProposerAddress: req.ProposerAddress}
 	if app.processProposalState == nil {

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -562,9 +562,12 @@ func (app *BaseApp) ApplySnapshotChunk(context context.Context, req *abci.Reques
 		return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ABORT}, nil
 	}
 
-	_, err := app.snapshotManager.RestoreChunk(req.Chunk)
+	done, err := app.snapshotManager.RestoreChunk(req.Chunk)
 	switch {
 	case err == nil:
+		if done {
+			app.resetInterBlockCache()
+		}
 		return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil
 
 	case errors.Is(err, snapshottypes.ErrChunkHashMismatch):

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -566,7 +566,7 @@ func (app *BaseApp) ApplySnapshotChunk(context context.Context, req *abci.Reques
 	switch {
 	case err == nil:
 		if done {
-			app.resetInterBlockCache()
+			app.shouldResetInterBlockCache = true
 		}
 		return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil
 
@@ -942,6 +942,11 @@ func (app *BaseApp) PrepareProposal(ctx context.Context, req *abci.RequestPrepar
 
 func (app *BaseApp) ProcessProposal(ctx context.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
 	defer telemetry.MeasureSince(time.Now(), "abci", "process_proposal")
+
+	if app.shouldResetInterBlockCache {
+		app.resetInterBlockCache()
+		app.shouldResetInterBlockCache = false
+	}
 
 	header := tmproto.Header{ChainID: app.ChainID, Height: req.Height, Time: req.Time, ProposerAddress: req.ProposerAddress}
 	if app.processProposalState == nil {

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -566,7 +566,9 @@ func (app *BaseApp) ApplySnapshotChunk(context context.Context, req *abci.Reques
 	switch {
 	case err == nil:
 		if done {
-			app.interBlockCache.Reset()
+			if app.interBlockCache != nil {
+				app.interBlockCache.Reset()
+			}
 		}
 		return &abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -141,6 +141,10 @@ type BaseApp struct { //nolint: maligned
 	// and exposing the requests and responses to external consumers
 	abciListeners []ABCIListener
 
+	// set to true after state sync completes. The first block proposal will cause
+	// the cache to be reset if this flag is true, and set it back to false.
+	shouldResetInterBlockCache bool
+
 	ChainID string
 }
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -141,10 +141,6 @@ type BaseApp struct { //nolint: maligned
 	// and exposing the requests and responses to external consumers
 	abciListeners []ABCIListener
 
-	// set to true after state sync completes. The first block proposal will cause
-	// the cache to be reset if this flag is true, and set it back to false.
-	shouldResetInterBlockCache bool
-
 	ChainID string
 }
 
@@ -432,16 +428,6 @@ func (app *BaseApp) setMinRetainBlocks(minRetainBlocks uint64) {
 
 func (app *BaseApp) setInterBlockCache(cache sdk.MultiStorePersistentCache) {
 	app.interBlockCache = cache
-}
-
-func (app *BaseApp) resetInterBlockCache() {
-	if app.interBlockCache == nil {
-		// interblock cache is disabled
-		return
-	}
-	newCache := store.NewCommitKVStoreCacheManager()
-	app.setInterBlockCache(newCache)
-	app.cms.SetInterBlockCache(app.interBlockCache)
 }
 
 func (app *BaseApp) setTrace(trace bool) {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -430,6 +430,16 @@ func (app *BaseApp) setInterBlockCache(cache sdk.MultiStorePersistentCache) {
 	app.interBlockCache = cache
 }
 
+func (app *BaseApp) resetInterBlockCache() {
+	if app.interBlockCache == nil {
+		// interblock cache is disabled
+		return
+	}
+	newCache := store.NewCommitKVStoreCacheManager()
+	app.setInterBlockCache(newCache)
+	app.cms.SetInterBlockCache(app.interBlockCache)
+}
+
 func (app *BaseApp) setTrace(trace bool) {
 	app.trace = trace
 }

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -93,7 +93,8 @@ func (cmgr *CommitKVStoreCacheManager) Reset() {
 	// Clear the map.
 	// Please note that we are purposefully using the map clearing idiom.
 	// See https://github.com/cosmos/cosmos-sdk/issues/6681.
-	for key := range cmgr.caches {
+	for key, ckv := range cmgr.caches {
+		ckv.(*CommitKVStoreCache).Reset()
 		delete(cmgr.caches, key)
 	}
 }
@@ -147,4 +148,11 @@ func (ckv *CommitKVStoreCache) Delete(key []byte) {
 
 	ckv.cache.Remove(string(key))
 	ckv.CommitKVStore.Delete(key)
+}
+
+func (ckv *CommitKVStoreCache) Reset() {
+	ckv.mtx.Lock()
+	defer ckv.mtx.Unlock()
+
+	ckv.cache.Purge()
 }

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -90,12 +90,10 @@ func (cmgr *CommitKVStoreCacheManager) Unwrap(key types.StoreKey) types.CommitKV
 
 // Reset resets in the internal caches.
 func (cmgr *CommitKVStoreCacheManager) Reset() {
-	// Clear the map.
-	// Please note that we are purposefully using the map clearing idiom.
-	// See https://github.com/cosmos/cosmos-sdk/issues/6681.
-	for key, ckv := range cmgr.caches {
+	for _, ckv := range cmgr.caches {
+		// not deleting CommitKVStoreCache themselves from the manager to prevent
+		// Unwrap returning nil
 		ckv.(*CommitKVStoreCache).Reset()
-		delete(cmgr.caches, key)
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Interblock cache might be polluted with pre-statesync entries that are sticky after statesync completes. Resetting the cache to empty once statesync finishes would solve this issue.

## Testing performed to validate your change
tested on ec2-3-73-76-195.eu-central-1.compute.amazonaws.com with steps in https://linear.app/seilabs/issue/SEI-2800/%5Bdevnet-3-internal%5D-investigate-state-sync-error-xdistribution

