### PR TITLE
[store] bump CommitKVStoreCache limit and switch to 2Q from arc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.161
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.162
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.147
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.129
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.129
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.161
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.0.1 h1:3i3m6T8JHlYBh5JT5A8CNa7hOih4loimwJs5qNYgqU8=
 github.com/sei-protocol/sei-iavl v0.0.1/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/sei-protocol/sei-tendermint v0.1.129 h1:UoCfd5MXb9RofGuyehTKNPzF/xMUqo1vLNGKJPRA1DU=
-github.com/sei-protocol/sei-tendermint v0.1.129/go.mod h1:ubqjn2T/nvqmQYjgpOTV7uSyUvdfvJCepc7zNYL2mkw=
+github.com/sei-protocol/sei-tendermint v0.1.161 h1:rp2x4qRtFSuY0yeCHCs20fpqedt31yNjYPLLO9Ozr7A=
+github.com/sei-protocol/sei-tendermint v0.1.161/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -686,10 +686,10 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-tendermint v0.1.147 h1:RMBxt+qU3fWU8REMmbjzxT1yeCjog5/34ReErP/Wr1I=
-github.com/sei-protocol/sei-tendermint v0.1.147/go.mod h1:odeOImx/S/mCKw9TIBSDjKUxoYkVVsitidaOnh0tyZI=
 github.com/sei-protocol/sei-iavl v0.0.1 h1:3i3m6T8JHlYBh5JT5A8CNa7hOih4loimwJs5qNYgqU8=
 github.com/sei-protocol/sei-iavl v0.0.1/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
+github.com/sei-protocol/sei-tendermint v0.1.129 h1:UoCfd5MXb9RofGuyehTKNPzF/xMUqo1vLNGKJPRA1DU=
+github.com/sei-protocol/sei-tendermint v0.1.129/go.mod h1:ubqjn2T/nvqmQYjgpOTV7uSyUvdfvJCepc7zNYL2mkw=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.0.1 h1:3i3m6T8JHlYBh5JT5A8CNa7hOih4loimwJs5qNYgqU8=
 github.com/sei-protocol/sei-iavl v0.0.1/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/sei-protocol/sei-tendermint v0.1.161 h1:rp2x4qRtFSuY0yeCHCs20fpqedt31yNjYPLLO9Ozr7A=
-github.com/sei-protocol/sei-tendermint v0.1.161/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.1.162 h1:ZKzzHq7ILfVw9Z5fQNy0okHnSxiIVOlcuXKBBr577/Q=
+github.com/sei-protocol/sei-tendermint v0.1.162/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -28,7 +28,7 @@ type (
 	// CommitKVStore and below is completely irrelevant to this layer.
 	CommitKVStoreCache struct {
 		types.CommitKVStore
-		cache       *lru.ARCCache
+		cache       *lru.TwoQueueCache
 		cacheKVSize int
 
 		// the same CommitKVStoreCache may be accessed concurrently by multiple
@@ -48,7 +48,7 @@ type (
 )
 
 func NewCommitKVStoreCache(store types.CommitKVStore, size uint, cacheKVSize int) *CommitKVStoreCache {
-	cache, err := lru.NewARC(int(size))
+	cache, err := lru.New2Q(int(size))
 	if err != nil {
 		panic(fmt.Errorf("failed to create KVStore cache: %s", err))
 	}

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -16,7 +16,7 @@ var (
 
 	// DefaultCommitKVStoreCacheSize defines the persistent ARC cache size for a
 	// CommitKVStoreCache.
-	DefaultCommitKVStoreCacheSize uint = 1000
+	DefaultCommitKVStoreCacheSize uint = 10000
 )
 
 type (

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -16,7 +16,7 @@ var (
 
 	// DefaultCommitKVStoreCacheSize defines the persistent ARC cache size for a
 	// CommitKVStoreCache.
-	DefaultCommitKVStoreCacheSize uint = 10000
+	DefaultCommitKVStoreCacheSize uint = 100000
 )
 
 type (
@@ -28,7 +28,7 @@ type (
 	// CommitKVStore and below is completely irrelevant to this layer.
 	CommitKVStoreCache struct {
 		types.CommitKVStore
-		cache       *lru.TwoQueueCache
+		cache       *lru.ARCCache
 		cacheKVSize int
 
 		// the same CommitKVStoreCache may be accessed concurrently by multiple
@@ -48,7 +48,7 @@ type (
 )
 
 func NewCommitKVStoreCache(store types.CommitKVStore, size uint, cacheKVSize int) *CommitKVStoreCache {
-	cache, err := lru.New2Q(int(size))
+	cache, err := lru.NewARC(int(size))
 	if err != nil {
 		panic(fmt.Errorf("failed to create KVStore cache: %s", err))
 	}

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -130,6 +130,9 @@ func (store *Store) Set(key []byte, value []byte) {
 
 // Has implements types.KVStore.
 func (store *Store) Has(key []byte) bool {
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
+
 	value := store.Get(key)
 	store.eventManager.EmitResourceAccessReadEvent("has", store.storeKey, key, value)
 	return value != nil

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -130,9 +130,6 @@ func (store *Store) Set(key []byte, value []byte) {
 
 // Has implements types.KVStore.
 func (store *Store) Has(key []byte) bool {
-	store.mtx.Lock()
-	defer store.mtx.Unlock()
-
 	value := store.Get(key)
 	store.eventManager.EmitResourceAccessReadEvent("has", store.storeKey, key, value)
 	return value != nil


### PR DESCRIPTION
## Describe your changes and provide context
IRRC we had discussions around bumping the limit for the inter-block cache since 1k is pretty little for our volume of TXs per block. Im setting it to 100k to be the same as the BoundedCacheKv store 

While I was investigating the race condition issue in the LRU cache, I saw that several repos brought up concerns around using ArcCache in their code as it's been patented by IBM (and later sold to Intel)

https://github.com/hashicorp/golang-lru/issues/31 
https://github.com/hashicorp/golang-lru/issues/73 

https://github.com/ipfs/kubo/issues/6590
https://github.com/ipfs/go-ipfs-blockstore/pull/20

Postgres and IPFS replaced it with 2Q, which based on the whitepaper should have the same performance as ARC. 
## Testing performed to validate your change
Deployed a LT cluster with these changes and saw no impact to consensus and the performance (with LT clients running) is similar 
![image](https://user-images.githubusercontent.com/18161326/216499319-be5ae693-242f-453c-8073-414bf5f810bd.png)
 
