### PR TITLE
Fix data race for check state

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -678,7 +678,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
-		cacheMS, app.checkState.ctx.BlockHeader(), true, app.logger,
+		cacheMS, app.checkState.Context().BlockHeader(), true, app.logger,
 	).WithMinGasPrices(app.minGasPrices).WithBlockHeight(height)
 
 	return ctx, nil
@@ -1029,9 +1029,9 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 	// we also set block gas meter to checkState in case the application needs to
 	// verify gas consumption during (Re)CheckTx
 	if app.checkState != nil {
-		app.checkState.ctx = app.checkState.ctx.
+		app.checkState.SetContext(app.checkState.Context().
 			WithBlockGasMeter(gasMeter).
-			WithHeaderHash(req.Hash)
+			WithHeaderHash(req.Hash))
 	}
 
 	if app.finalizeBlocker != nil {

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -1,12 +1,15 @@
 package baseapp
 
 import (
+	"sync"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type state struct {
 	ms  sdk.CacheMultiStore
 	ctx sdk.Context
+	mtx sync.Mutex
 }
 
 // CacheMultiStore calls and returns a CacheMultiStore on the state's underling
@@ -17,5 +20,14 @@ func (st *state) CacheMultiStore() sdk.CacheMultiStore {
 
 // Context returns the Context of the state.
 func (st *state) Context() sdk.Context {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	return st.ctx
+}
+
+// Update the context of the state
+func (st *state) SetContext(ctx sdk.Context) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	st.ctx = ctx
 }


### PR DESCRIPTION
## Describe your changes and provide context
Based on the logs, the data race is between QueryContext and the Finalizeblock for `app.checkState.ctx`. 

I narrowed it cause and it seems like with `UnsafeBypassCommitTimeoutOverride=true` on by default, the single node consensus is much faster as it doesn't need to wait for timeout, all the datarace failures are happening in the query cli unit tests so i suspect that the queries and the async network are handled in different gorountines and thus have async access to checkState.Ctx (one is updating through finalizeBlock while the unit test is querying it)

## Testing performed to validate your change
unit tests
