### PR TITLE
Update staking default params

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -10,9 +10,8 @@ const (
 	// Max percentage of the total voting power a single validator can have
 	DefaultMaxVotingPowerRatio = "0.1"
 
-	// Maximum amount of staking power we allow per validator
-	// before the max voting power ratio is enforced
-	// Treshold for number of token staked = DefaultPowerReduction * DefaultMaxVotingPowerEnforcementThreshold
+	// Maximum amount of staking power we allow per validator before the max voting power ratio is enforced
+	// Threshold for number of token staked = DefaultPowerReduction * DefaultMaxVotingPowerEnforcementThreshold
 	DefaultMaxVotingPowerEnforcementThreshold uint64 = 10000
 
 	// Delay, in blocks, between when validator updates are returned to the

--- a/types/staking.go
+++ b/types/staking.go
@@ -13,7 +13,7 @@ const (
 	// Maximum amount of staking power we allow per validator
 	// before the max voting power ratio is enforced
 	// Treshold for number of token staked = DefaultPowerReduction * DefaultMaxVotingPowerEnforcementThreshold
-	DefaultMaxVotingPowerEnforcementThreshold uint64 = 100
+	DefaultMaxVotingPowerEnforcementThreshold uint64 = 10000
 
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if

--- a/types/staking.go
+++ b/types/staking.go
@@ -7,10 +7,13 @@ const (
 	DefaultBondDenom = "usei"
 
 	// default maximal voting power ratio
+	// Max percentage of the total voting power a single validator can have
 	DefaultMaxVotingPowerRatio = "0.1"
 
-	// default voting power enforcement threshold
-	DefaultMaxVotingPowerEnforcementThreshold uint64 = 10000000000000
+	// Maximum amount of staking power we allow per validator
+	// before the max voting power ratio is enforced
+	// Treshold for number of token staked = DefaultPowerReduction * DefaultMaxVotingPowerEnforcementThreshold
+	DefaultMaxVotingPowerEnforcementThreshold uint64 = 100
 
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if

--- a/x/auth/legacy/v043/store_test.go
+++ b/x/auth/legacy/v043/store_test.go
@@ -553,6 +553,9 @@ func TestMigrateVestingAccounts(t *testing.T) {
 			ctx := app.BaseApp.NewContext(false, tmproto.Header{
 				Time: time.Now(),
 			})
+			params := app.StakingKeeper.GetParams(ctx)
+			params.MaxVotingPowerEnforcementThreshold = sdk.NewIntFromUint64(10000000000000)
+			app.StakingKeeper.SetParams(ctx, params)
 
 			addrs := simapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(tc.tokenAmount))
 			delegatorAddr := addrs[0]

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -42,7 +42,7 @@ func bootstrapHandlerGenesisTest(t *testing.T, power int64, numAddrs int, accAmo
 }
 
 func TestValidatorByPowerIndex(t *testing.T) {
-	initPower := int64(1000000)
+	initPower := int64(1000)
 	app, ctx, _, valAddrs := bootstrapHandlerGenesisTest(t, initPower, 10, sdk.TokensFromConsensusPower(initPower, sdk.DefaultPowerReduction))
 	validatorAddr, validatorAddr3 := valAddrs[0], valAddrs[1]
 	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)


### PR DESCRIPTION
## Describe your changes and provide context
Lowering the threshold for which the power ratio is enforced to make sure we have a power cap in place.

Note this means we can't emergency delegate ourselves majority voting power in newer chains 

## Testing performed to validate your change
Tested on local chain 
![image](https://user-images.githubusercontent.com/18161326/217944253-1d3276ac-3db2-407b-92b1-70332aeba559.png)