### PR TITLE
Add flag for ports when creating validators 

### DIFF
--- a/x/staking/client/cli/flags.go
+++ b/x/staking/client/cli/flags.go
@@ -31,6 +31,7 @@ const (
 	FlagGenesisFormat = "genesis-format"
 	FlagNodeID        = "node-id"
 	FlagIP            = "ip"
+	FlagPort          = "port"
 )
 
 // common flagsets to add to various functions

--- a/x/staking/client/cli/flags.go
+++ b/x/staking/client/cli/flags.go
@@ -31,7 +31,7 @@ const (
 	FlagGenesisFormat = "genesis-format"
 	FlagNodeID        = "node-id"
 	FlagIP            = "ip"
-	FlagPort          = "port"
+	FlagP2PPort       = "p2p-port"
 )
 
 // common flagsets to add to various functions

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -77,7 +77,7 @@ func NewCreateValidatorCmd() *cobra.Command {
 	cmd.Flags().AddFlagSet(FlagSetMinSelfDelegation())
 
 	cmd.Flags().String(FlagIP, "", fmt.Sprintf("The node's public IP. It takes effect only when used in combination with --%s", flags.FlagGenerateOnly))
-	cmd.Flags().String(FlagPort, "", fmt.Sprintf("The node's public port. It takes effect only when used in combination with --%s", flags.FlagGenerateOnly))
+	cmd.Flags().String(FlagP2PPort, "", fmt.Sprintf("The node's public port. It takes effect only when used in combination with --%s", flags.FlagGenerateOnly))
 	cmd.Flags().String(FlagNodeID, "", "The node's ID")
 	flags.AddTxFlagsToCmd(cmd)
 

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -340,11 +340,11 @@ func newBuildCreateValidatorMsg(clientCtx client.Context, txf tx.Factory, fs *fl
 	genOnly, _ := fs.GetBool(flags.FlagGenerateOnly)
 	if genOnly {
 		ip, _ := fs.GetString(FlagIP)
-		port, _ := fs.GetString(FlagPort)
+		p2pPort, _ := fs.GetString(FlagP2PPort)
 		nodeID, _ := fs.GetString(FlagNodeID)
 
 		if nodeID != "" && ip != "" {
-			txf = txf.WithMemo(fmt.Sprintf("%s@%s:%s", nodeID, ip, port))
+			txf = txf.WithMemo(fmt.Sprintf("%s@%s:%s", nodeID, ip, p2pPort))
 		}
 	}
 
@@ -356,7 +356,7 @@ func newBuildCreateValidatorMsg(clientCtx client.Context, txf tx.Factory, fs *fl
 func CreateValidatorMsgFlagSet(ipDefault string) (fs *flag.FlagSet, defaultsDesc string) {
 	fsCreateValidator := flag.NewFlagSet("", flag.ContinueOnError)
 	fsCreateValidator.String(FlagIP, ipDefault, "The node's public IP")
-	fsCreateValidator.String(FlagPort, "26656", "The node's public IP port")
+	fsCreateValidator.String(FlagP2PPort, "26656", "The node's public IP port")
 	fsCreateValidator.String(FlagNodeID, "", "The node's NodeID")
 	fsCreateValidator.String(FlagMoniker, "", "The validator's (optional) moniker")
 	fsCreateValidator.String(FlagWebsite, "", "The validator's (optional) website")
@@ -396,7 +396,7 @@ type TxCreateValidatorConfig struct {
 	PubKey cryptotypes.PubKey
 
 	IP              string
-	Port            string
+	P2PPort         string
 	Website         string
 	SecurityContact string
 	Details         string
@@ -416,11 +416,11 @@ func PrepareConfigForTxCreateValidator(flagSet *flag.FlagSet, moniker, nodeID, c
 	}
 	c.IP = ip
 
-	port, err := flagSet.GetString(FlagPort)
+	port, err := flagSet.GetString(FlagP2PPort)
 	if err != nil {
 		return c, err
 	}
-	c.Port = port
+	c.P2PPort = port
 
 	website, err := flagSet.GetString(FlagWebsite)
 	if err != nil {
@@ -547,11 +547,11 @@ func BuildCreateValidatorMsg(clientCtx client.Context, config TxCreateValidatorC
 	}
 	if generateOnly {
 		ip := config.IP
-		port := config.Port
+		p2pPort := config.P2PPort
 		nodeID := config.NodeID
 
-		if nodeID != "" && ip != "" {
-			txBldr = txBldr.WithMemo(fmt.Sprintf("%s@%s:%s", nodeID, ip, port))
+		if nodeID != "" && ip != "" && p2pPort != "" {
+			txBldr = txBldr.WithMemo(fmt.Sprintf("%s@%s:%s", nodeID, ip, p2pPort))
 		}
 	}
 

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -420,10 +420,6 @@ func PrepareConfigForTxCreateValidator(flagSet *flag.FlagSet, moniker, nodeID, c
 	if err != nil {
 		return c, err
 	}
-	if port == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "couldn't retrieve an external IP; "+
-			"the tx's memo field will be unset")
-	}
 	c.Port = port
 
 	website, err := flagSet.GetString(FlagWebsite)

--- a/x/staking/client/cli/tx_test.go
+++ b/x/staking/client/cli/tx_test.go
@@ -20,6 +20,7 @@ func TestPrepareConfigForTxCreateValidator(t *testing.T) {
 	mkTxValCfg := func(amount, commission, commissionMax, commissionMaxChange, minSelfDelegation string) TxCreateValidatorConfig {
 		return TxCreateValidatorConfig{
 			IP:                      ip,
+			P2PPort:                 "26656",
 			ChainID:                 chainID,
 			NodeID:                  nodeID,
 			PubKey:                  valPubKey,


### PR DESCRIPTION
## Describe your changes and provide context

Cherry picking this change insteaD: https://github.com/cosmos/cosmos-sdk/commit/3504dd387cbd2671cf4b107ae92453c3fabff97e#diff-6d806c46e036c95248b9cf8b2257e8442ca5063d8d7a0005bd2e11546fd4c540R416

Add flags for creatign validators or gentx to specify a port so validators can properly configure their memo in the validator message 
## Testing performed to validate your change
![image](https://user-images.githubusercontent.com/18161326/217953184-2392aae9-8345-45b1-bf29-bab200289080.png)
