### PR TITLE
make chain-id optional for seid start

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -241,7 +241,7 @@ func NewBaseApp(
 	app.runTxRecoveryMiddleware = newDefaultRecoveryMiddleware()
 	app.ChainID = cast.ToString(appOpts.Get(FlagChainID))
 	if app.ChainID == "" {
-		panic("must pass --chain-id during startup")
+		panic("must pass --chain-id when calling 'seid start' or set in ~/.sei/config/client.toml")
 	}
 
 	return app

--- a/client/config/cmd.go
+++ b/client/config/cmd.go
@@ -29,7 +29,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	clientCtx := client.GetClientContextFromCmd(cmd)
 	configPath := filepath.Join(clientCtx.HomeDir, "config")
 
-	conf, err := getClientConfig(configPath, clientCtx.Viper)
+	conf, err := GetClientConfig(configPath, clientCtx.Viper)
 	if err != nil {
 		return fmt.Errorf("couldn't get client config: %v", err)
 	}
@@ -66,27 +66,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	case 2:
 		// it's set
 		key, value := args[0], args[1]
-
-		switch key {
-		case flags.FlagChainID:
-			conf.SetChainID(value)
-		case flags.FlagKeyringBackend:
-			conf.SetKeyringBackend(value)
-		case tmcli.OutputFlag:
-			conf.SetOutput(value)
-		case flags.FlagNode:
-			conf.SetNode(value)
-		case flags.FlagBroadcastMode:
-			conf.SetBroadcastMode(value)
-		default:
-			return errUnknownConfigKey(key)
-		}
-
-		confFile := filepath.Join(configPath, "client.toml")
-		if err := writeConfigToFile(confFile, conf); err != nil {
-			return fmt.Errorf("could not write client config to the file: %v", err)
-		}
-
+		SetClientConfig(key, value, configPath, conf)
 	default:
 		panic("cound not execute config command")
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -67,7 +67,7 @@ func ReadFromClientConfig(ctx client.Context) (client.Context, error) {
 		}
 	}
 
-	conf, err := getClientConfig(configPath, ctx.Viper)
+	conf, err := GetClientConfig(configPath, ctx.Viper)
 	if err != nil {
 		return ctx, fmt.Errorf("couldn't get client config: %v", err)
 	}

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -35,7 +35,6 @@ broadcast-mode = "{{ .BroadcastMode }}"
 func SetClientConfig(key string, value string, configPath string, config *ClientConfig) error {
 	switch key {
 	case flags.FlagChainID:
-		println(value)
 		config.SetChainID(value)
 	case flags.FlagKeyringBackend:
 		config.SetKeyringBackend(value)

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -2,11 +2,15 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"text/template"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/viper"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
 )
 
 const defaultConfigTemplate = `# This is a TOML config file.
@@ -27,6 +31,30 @@ node = "{{ .Node }}"
 # Transaction broadcasting mode (sync|async|block)
 broadcast-mode = "{{ .BroadcastMode }}"
 `
+
+func SetClientConfig(key string, value string, configPath string, config *ClientConfig) error {
+	switch key {
+	case flags.FlagChainID:
+		println(value)
+		config.SetChainID(value)
+	case flags.FlagKeyringBackend:
+		config.SetKeyringBackend(value)
+	case tmcli.OutputFlag:
+		config.SetOutput(value)
+	case flags.FlagNode:
+		config.SetNode(value)
+	case flags.FlagBroadcastMode:
+		config.SetBroadcastMode(value)
+	default:
+		return errUnknownConfigKey(key)
+	}
+
+	confFile := filepath.Join(configPath, "client.toml")
+	if err := writeConfigToFile(confFile, config); err != nil {
+		return fmt.Errorf("could not write client config to the file: %v", err)
+	}
+	return nil
+}
 
 // writeConfigToFile parses defaultConfigTemplate, renders config using the template and writes it to
 // configFilePath.
@@ -52,7 +80,7 @@ func ensureConfigPath(configPath string) error {
 }
 
 // getClientConfig reads values from client.toml file and unmarshalls them into ClientConfig
-func getClientConfig(configPath string, v *viper.Viper) (*ClientConfig, error) {
+func GetClientConfig(configPath string, v *viper.Viper) (*ClientConfig, error) {
 	v.AddConfigPath(configPath)
 	v.SetConfigName("client")
 	v.SetConfigType("toml")

--- a/docs/core/baseapp.md
+++ b/docs/core/baseapp.md
@@ -224,7 +224,7 @@ transaction is received by a full-node. The role of `CheckTx` is to guard the fu
 Unconfirmed transactions are relayed to peers only if they pass `CheckTx`.
 
 `CheckTx()` can perform both _stateful_ and _stateless_ checks, but developers should strive to
-make the checks **lightweight** because gas fees are not charged for the resources (CPU, data load...) used during the `CheckTx`. 
+make the checks **lightweight** because gas fees are not charged for the resources (CPU, data load...) used during the `CheckTx`.
 
 In the Cosmos SDK, after [decoding transactions](./encoding.md), `CheckTx()` is implemented
 to do the following checks:

--- a/server/export.go
+++ b/server/export.go
@@ -112,7 +112,6 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 	cmd.Flags().Int64(FlagHeight, -1, "Export state from a particular height (-1 means latest height)")
 	cmd.Flags().Bool(FlagForZeroHeight, false, "Export state to start at height zero (perform preproccessing)")
 	cmd.Flags().StringSlice(FlagJailAllowedAddrs, []string{}, "Comma-separated list of operator addresses of jailed validators to unjail")
-	cmd.Flags().String(FlagChainID, "", "Chain ID")
 
 	return cmd
 }

--- a/server/init.go
+++ b/server/init.go
@@ -59,5 +59,5 @@ func GenerateSaveCoinKey(
 		return sdk.AccAddress{}, "", err
 	}
 
-	return sdk.AccAddress(k.GetAddress()), mnemonic, nil
+	return k.GetAddress(), mnemonic, nil
 }

--- a/server/start.go
+++ b/server/start.go
@@ -10,6 +10,7 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/server"
@@ -21,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server/api"
@@ -126,13 +128,26 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 			if err != nil {
 				return err
 			}
+			clientCtx, err = clientconfig.ReadFromClientConfig(clientCtx)
+			if err != nil {
+				return err
+			}
+
+			chainID := clientCtx.ChainID
+			flagChainID, _ := cmd.Flags().GetString(FlagChainID)
+			if flagChainID != "" {
+				if flagChainID != chainID {
+					panic(fmt.Sprintf("chain-id mismatch: %s vs %s. The chain-id passed in is different from the value in ~/.sei/config/client.toml \n", flagChainID, chainID))
+				}
+				chainID = flagChainID
+			}
+			serverCtx.Viper.Set(flags.FlagChainID, chainID)
 
 			withTM, _ := cmd.Flags().GetBool(flagWithTendermint)
 			if !withTM {
 				serverCtx.Logger.Info("starting ABCI without Tendermint")
 				return startStandAlone(serverCtx, appCreator)
 			}
-
 			// amino is needed here for backwards compatibility of REST routes
 			err = startInProcess(serverCtx, clientCtx, appCreator, tracerProviderOptions)
 			errCode, ok := err.(ErrorCode)
@@ -276,7 +291,8 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 			"This defaults to 0 in the current version, but will error in the next version " +
 			"(SDK v0.45). Please explicitly put the desired minimum-gas-prices in your app.toml.")
 	}
-
+	println("Calling")
+	println(cast.ToString(clientCtx.Viper.Get(flags.FlagChainID)))
 	app := appCreator(ctx.Logger, db, traceWriter, ctx.Viper)
 
 	var (

--- a/server/start.go
+++ b/server/start.go
@@ -10,7 +10,6 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/server"
@@ -291,8 +290,6 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 			"This defaults to 0 in the current version, but will error in the next version " +
 			"(SDK v0.45). Please explicitly put the desired minimum-gas-prices in your app.toml.")
 	}
-	println("Calling")
-	println(cast.ToString(clientCtx.Viper.Get(flags.FlagChainID)))
 	app := appCreator(ctx.Logger, db, traceWriter, ctx.Viper)
 
 	var (


### PR DESCRIPTION
## Describe your changes and provide context
On init, save chain-id to client.toml (used to other commands to run seid commands to bypass requirement for --chain-id already)

Then on startup, just read from client.toml's value if chainId isn't passed


## Testing performed to validate your change
[
](https://github.com/sei-protocol/sei-chain/pull/561)