### PR TITLE
[acl] Remove map iteration and reduce amount of iteration

### DIFF
--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -500,15 +500,17 @@ func (k Keeper) BuildDependencyDag(ctx sdk.Context, txDecoder sdk.TxDecoder, ant
 		}
 		// get the ante dependencies and add them to the dag
 		anteDeps, err := anteDepGen([]acltypes.AccessOperation{}, tx)
-		anteDepSet := make(map[acltypes.AccessOperation]struct{})
-		for _, dep := range anteDeps {
-			anteDepSet[dep] = struct{}{}
-		}
-		// pass through set to dedup
 		if err != nil {
 			return nil, err
 		}
-		for accessOp := range anteDepSet {
+
+		anteDepSet := make(map[acltypes.AccessOperation]struct{})
+		for _, accessOp := range anteDeps {
+			// if found in set, we've already included this access Op in out ante dependencies, so skip it
+			if _, found := anteDepSet[accessOp]; found {
+				continue
+			}
+			anteDepSet[accessOp] = struct{}{}
 			err = types.ValidateAccessOp(accessOp)
 			if err != nil {
 				return nil, err

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -338,8 +338,8 @@ func (isd IncrementSequenceDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperat
 		}
 		deps = append(deps, sdkacltypes.AccessOperation{
 			AccessType:         sdkacltypes.AccessType_WRITE,
-			ResourceType:       sdkacltypes.ResourceType_KV, // TODO: change to ResourceType_KV_AUTH once merged
-			IdentifierTemplate: addr.String(),
+			ResourceType:       sdkacltypes.ResourceType_KV_AUTH_ADDRESS_STORE,
+			IdentifierTemplate: hex.EncodeToString(types.AddressStoreKey(addr)),
 		})
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
This fixes the issue of iterating a map in a non-sorted order by removing the map iteration entirely, and using the set as a skip list in the original iteration instead, additionally reducing number of loops.

## Testing performed to validate your change
Needs more rigorous testing for better coverage, tests in progress
