### PR TITLE
Add flag for profiling

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -186,6 +186,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Bool(FlagInterBlockCache, true, "Enable inter-block caching")
 	cmd.Flags().String(flagCPUProfile, "", "Enable CPU profiling and write to the provided file")
 	cmd.Flags().Bool(FlagTrace, false, "Provide full stack traces for errors in ABCI Log")
+	// TODO(bweng):: disable by default for mainnet
 	cmd.Flags().Bool(FlagProfile, true, "Enable Profiling in the application")
 	cmd.Flags().String(FlagPruning, storetypes.PruningOptionDefault, "Pruning strategy (default|nothing|everything|custom)")
 	cmd.Flags().Uint64(FlagPruningKeepRecent, 0, "Number of recent heights to keep on disk (ignored if pruning is not 'custom')")

--- a/server/start.go
+++ b/server/start.go
@@ -20,6 +20,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/grpc"
 
+	//nolint:gosec,G108
+	_ "net/http/pprof"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -46,6 +49,7 @@ const (
 	FlagInterBlockCache    = "inter-block-cache"
 	FlagUnsafeSkipUpgrades = "unsafe-skip-upgrades"
 	FlagTrace              = "trace"
+	FlagProfile             = "profile"
 	FlagInvCheckPeriod     = "inv-check-period"
 
 	FlagPruning           = "pruning"
@@ -123,6 +127,17 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			serverCtx := GetServerContextFromCmd(cmd)
+
+			if _, err := cmd.Flags().GetBool(FlagProfile);  err == nil {
+				go func() {
+					serverCtx.Logger.Info("Listening for profiling at http://localhost:6060/debug/pprof/")
+					err := http.ListenAndServe(":6060", nil)
+					if err != nil {
+						serverCtx.Logger.Error("Error from profiling server", "error", err)
+					}
+				}()
+			}
+
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
@@ -171,6 +186,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Bool(FlagInterBlockCache, true, "Enable inter-block caching")
 	cmd.Flags().String(flagCPUProfile, "", "Enable CPU profiling and write to the provided file")
 	cmd.Flags().Bool(FlagTrace, false, "Provide full stack traces for errors in ABCI Log")
+	cmd.Flags().Bool(FlagProfile, true, "Enable Profiling in the application")
 	cmd.Flags().String(FlagPruning, storetypes.PruningOptionDefault, "Pruning strategy (default|nothing|everything|custom)")
 	cmd.Flags().Uint64(FlagPruningKeepRecent, 0, "Number of recent heights to keep on disk (ignored if pruning is not 'custom')")
 	cmd.Flags().Uint64(FlagPruningKeepEvery, 0, "Offset heights to keep on disk after 'keep-every' (ignored if pruning is not 'custom')")

--- a/server/start.go
+++ b/server/start.go
@@ -128,7 +128,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			serverCtx := GetServerContextFromCmd(cmd)
 
-			if _, err := cmd.Flags().GetBool(FlagProfile);  err == nil {
+			if enableProfile, _ := cmd.Flags().GetBool(FlagProfile); enableProfile {
 				go func() {
 					serverCtx.Logger.Info("Listening for profiling at http://localhost:6060/debug/pprof/")
 					err := http.ListenAndServe(":6060", nil)

--- a/server/start.go
+++ b/server/start.go
@@ -186,8 +186,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Bool(FlagInterBlockCache, true, "Enable inter-block caching")
 	cmd.Flags().String(flagCPUProfile, "", "Enable CPU profiling and write to the provided file")
 	cmd.Flags().Bool(FlagTrace, false, "Provide full stack traces for errors in ABCI Log")
-	// TODO(bweng):: disable by default for mainnet
-	cmd.Flags().Bool(FlagProfile, true, "Enable Profiling in the application")
+	cmd.Flags().Bool(FlagProfile, false, "Enable Profiling in the application")
 	cmd.Flags().String(FlagPruning, storetypes.PruningOptionDefault, "Pruning strategy (default|nothing|everything|custom)")
 	cmd.Flags().Uint64(FlagPruningKeepRecent, 0, "Number of recent heights to keep on disk (ignored if pruning is not 'custom')")
 	cmd.Flags().Uint64(FlagPruningKeepEvery, 0, "Offset heights to keep on disk after 'keep-every' (ignored if pruning is not 'custom')")


### PR DESCRIPTION
## Describe your changes and provide context


## Testing performed to validate your change
```
> seid start --profile
9:08AM INF Listening for profiling at http://localhost:6060/debug/pprof/
9:08AM INF starting node with ABCI Tendermint in-process
9:08AM INF starting service impl=Node service=Node
9:08AM INF starting service impl=proxyClient module=proxy service=proxyClient
9:08AM INF starting service impl=localClient service=localClient
```


```
> seid start --profile=false
9:08AM INF starting node with ABCI Tendermint in-process
9:08AM INF starting service impl=Node service=Node
9:08AM INF starting service impl=proxyClient module=proxy service=proxyClient
9:08AM INF starting service impl=localClient service=localClient
9:08AM INF starting service impl=EventBus module=eventbus service=EventBus
```