### PR TITLE
[staking] max voting threshold fix

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -8,7 +8,7 @@ const (
 
 	// default maximal voting power ratio
 	// Max percentage of the total voting power a single validator can have
-	DefaultMaxVotingPowerRatio = "0.1"
+	DefaultMaxVotingPowerRatio = "0.2"
 
 	// Maximum amount of staking power we allow per validator before the max voting power ratio is enforced
 	// Threshold for number of token staked = DefaultPowerReduction * DefaultMaxVotingPowerEnforcementThreshold

--- a/types/staking.go
+++ b/types/staking.go
@@ -12,7 +12,7 @@ const (
 
 	// Maximum amount of staking power we allow per validator before the max voting power ratio is enforced
 	// Threshold for number of token staked = DefaultPowerReduction * DefaultMaxVotingPowerEnforcementThreshold
-	DefaultMaxVotingPowerEnforcementThreshold uint64 = 10000
+	DefaultMaxVotingPowerEnforcementThreshold uint64 = 1000000
 
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -653,9 +653,8 @@ func (k Keeper) Delegate(
 		// Validator's new total power cannot exceed the max power ratio that's allowed
 		newVotingPowerRatio := validatorNewTotalPower.ToDec().Quo(newTotalPower.ToDec())
 		maxVotingPowerRatio := k.MaxVotingPowerRatio(ctx)
-		k.Logger(ctx).Debug("new total power ratio exceeds the max allowed ratio: %f > %f\n", newVotingPowerRatio, maxVotingPowerRatio)
 		if newVotingPowerRatio.GT(maxVotingPowerRatio) {
-			k.Logger(ctx).Error("validator's voting power ratio exceeds the max allowed ratio: %s > %s\n", newVotingPowerRatio, maxVotingPowerRatio)
+			k.Logger(ctx).Error("validator's voting power ratio exceeds the max allowed ratio: %s > %s\n", newVotingPowerRatio.TruncateInt().ToDec().String(), maxVotingPowerRatio.TruncateInt().ToDec().String())
 			return sdk.ZeroDec(), types.ErrExceedMaxVotingPowerRatio
 		}
 	}

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -650,6 +650,7 @@ func (k Keeper) Delegate(
 
 	// If it's beyond genesis then enforce power ratio per validator if there's more than maxVotingPowerEnforcementThreshold
 	if newTotalPower.GTE(maxVotingPowerEnforcementThreshold) && ctx.BlockHeight() > 0 {
+		// Convert bond amount to power first
 		validatorNewTotalPower := validator.Tokens.Add(bondAmt).Quo(k.PowerReduction(ctx))
 		// Validator's new total power cannot exceed the max power ratio that's allowed
 		newVotingPowerRatio := validatorNewTotalPower.ToDec().Quo(newTotalPower.ToDec())

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -653,7 +653,7 @@ func (k Keeper) Delegate(
 		// Validator's new total power cannot exceed the max power ratio that's allowed
 		newVotingPowerRatio := validatorNewTotalPower.ToDec().Quo(newTotalPower.ToDec())
 		maxVotingPowerRatio := k.MaxVotingPowerRatio(ctx)
-		k.Logger(ctx).Debug("new total power ratio exceeds the max allowed ratio: %s > %s\n", newVotingPowerRatio, maxVotingPowerRatio)
+		k.Logger(ctx).Debug("new total power ratio exceeds the max allowed ratio: %f > %f\n", newVotingPowerRatio, maxVotingPowerRatio)
 		if newVotingPowerRatio.GT(maxVotingPowerRatio) {
 			k.Logger(ctx).Error("validator's voting power ratio exceeds the max allowed ratio: %s > %s\n", newVotingPowerRatio, maxVotingPowerRatio)
 			return sdk.ZeroDec(), types.ErrExceedMaxVotingPowerRatio

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -136,7 +136,7 @@ func TestSetDelegation(t *testing.T) {
 	require.Equal(t, 0, len(resBonds))
 }
 func TestDelegation(t *testing.T) {
-	_, app, ctx := createTestInput()	
+	_, app, ctx := createTestInput()
 
 	addrDels := simapp.AddTestAddrsIncremental(app, ctx, 3, app.StakingKeeper.TokensFromConsensusPower(ctx, 5100000000000))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrDels)
@@ -163,17 +163,33 @@ func TestDelegation(t *testing.T) {
 	app.StakingKeeper.SetNewValidatorByPowerIndex(ctx, validators[1])
 	app.StakingKeeper.SetNewValidatorByPowerIndex(ctx, validators[2])
 
-	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[0], app.StakingKeeper.TokensFromConsensusPower(ctx, 3500000000000), types.Unbonded, validators[0], true)
-	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[1], app.StakingKeeper.TokensFromConsensusPower(ctx, 3000000000000), types.Unbonded, validators[1], true)
-	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[2], app.StakingKeeper.TokensFromConsensusPower(ctx, 3500000000000), types.Unbonded, validators[2], true)
+	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[0], app.StakingKeeper.TokensFromConsensusPower(ctx, 10000), types.Unbonded, validators[0], true)
+	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[1], app.StakingKeeper.TokensFromConsensusPower(ctx, 10000), types.Unbonded, validators[1], true)
+	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[2], app.StakingKeeper.TokensFromConsensusPower(ctx, 20000), types.Unbonded, validators[2], true)
 	_ = staking.EndBlocker(ctx, app.StakingKeeper)
 
 	// delegate until max voting power limit
 	allBonds := app.StakingKeeper.GetAllDelegations(ctx)
 	require.Equal(t, 3, len(allBonds))
 
-	// delegate until max voting power limit
-	_, err := app.StakingKeeper.Delegate(ctx, addrDels[1], app.StakingKeeper.TokensFromConsensusPower(ctx, 1), types.Unbonded, validators[0], true)
+	// delegate past threshold will fail
+	_, err := app.StakingKeeper.Delegate(ctx, addrDels[1], app.StakingKeeper.TokensFromConsensusPower(ctx, 1000000), types.Unbonded, validators[0], true)
+	_ = staking.EndBlocker(ctx, app.StakingKeeper)
+	require.Equal(t, types.ErrExceedMaxVotingPowerRatio, err)
+
+	// delegate more than ratio but under threshold will also succeed
+	_, err = app.StakingKeeper.Delegate(ctx, addrDels[1], app.StakingKeeper.TokensFromConsensusPower(ctx, 950000), types.Unbonded, validators[0], true)
+	_ = staking.EndBlocker(ctx, app.StakingKeeper)
+	require.Nil(t, err)
+
+	// delegate more than total power but less than ratio
+	_, err = app.StakingKeeper.Delegate(ctx, addrDels[2], app.StakingKeeper.TokensFromConsensusPower(ctx, 100000), types.Unbonded, validators[0], true)
+	_ = staking.EndBlocker(ctx, app.StakingKeeper)
+	require.Nil(t, err)
+
+	// delegate more than total power exceed ratio
+	_, err = app.StakingKeeper.Delegate(ctx, addrDels[2], app.StakingKeeper.TokensFromConsensusPower(ctx, 900000), types.Unbonded, validators[0], true)
+	_ = staking.EndBlocker(ctx, app.StakingKeeper)
 	require.Equal(t, types.ErrExceedMaxVotingPowerRatio, err)
 }
 

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -135,6 +135,39 @@ func TestSetDelegation(t *testing.T) {
 	resBonds = app.StakingKeeper.GetDelegatorDelegations(ctx, addrDels[1], 5)
 	require.Equal(t, 0, len(resBonds))
 }
+
+
+func TestDelegationGentx(t *testing.T) {
+	_, app, ctx := createTestInput()
+
+	addrDels := simapp.AddTestAddrsIncremental(app, ctx, 3, app.StakingKeeper.TokensFromConsensusPower(ctx, 5100000000000))
+	valAddrs := simapp.ConvertAddrsToValAddrs(addrDels)
+
+	//construct the validators
+	amts := []sdk.Int{sdk.NewInt(0)}
+	var validators [1]types.Validator
+	for i, amt := range amts {
+		validators[i] = teststaking.NewValidator(t, valAddrs[i], PKs[i])
+		validators[i], _ = validators[i].AddTokensFromDel(amt)
+	}
+
+	validators[0] = keeper.TestingUpdateValidator(app.StakingKeeper, ctx, validators[0], true)
+
+	app.StakingKeeper.SetValidator(ctx, validators[0])
+	app.StakingKeeper.SetValidatorByConsAddr(ctx, validators[0])
+	app.StakingKeeper.SetNewValidatorByPowerIndex(ctx, validators[0])
+
+	// Test Genesis gentx delegation
+	ctx = ctx.WithBlockHeight(0)
+	_, err := app.StakingKeeper.Delegate(ctx, addrDels[0], app.StakingKeeper.TokensFromConsensusPower(ctx, 100000000000), types.Unbonded, validators[0], true)
+	_ = staking.EndBlocker(ctx, app.StakingKeeper)
+
+	require.Nil(t, err)
+	allBonds := app.StakingKeeper.GetAllDelegations(ctx)
+	require.Equal(t, 1, len(allBonds))
+}
+
+
 func TestDelegation(t *testing.T) {
 	_, app, ctx := createTestInput()
 
@@ -163,12 +196,13 @@ func TestDelegation(t *testing.T) {
 	app.StakingKeeper.SetNewValidatorByPowerIndex(ctx, validators[1])
 	app.StakingKeeper.SetNewValidatorByPowerIndex(ctx, validators[2])
 
+	// Test post genesis state
+	ctx = ctx.WithBlockHeight(10)
 	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[0], app.StakingKeeper.TokensFromConsensusPower(ctx, 10000), types.Unbonded, validators[0], true)
 	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[1], app.StakingKeeper.TokensFromConsensusPower(ctx, 10000), types.Unbonded, validators[1], true)
 	_, _ = app.StakingKeeper.Delegate(ctx, addrDels[2], app.StakingKeeper.TokensFromConsensusPower(ctx, 20000), types.Unbonded, validators[2], true)
 	_ = staking.EndBlocker(ctx, app.StakingKeeper)
 
-	// delegate until max voting power limit
 	allBonds := app.StakingKeeper.GetAllDelegations(ctx)
 	require.Equal(t, 3, len(allBonds))
 


### PR DESCRIPTION
## Describe your changes and provide context
* fix exploit where first delegation can be as high as they want
* fix calculation where we need to take the power reduction of the new bond amount into account or else it will always be much larger than the ratio so it'll always fail once we cross the threshold

## Testing performed to validate your change
Additional unit test and verified it's able to start chain locally 
