### PR TITLE
Add long msg to acl

### DIFF
--- a/x/accesscontrol/client/cli/query.go
+++ b/x/accesscontrol/client/cli/query.go
@@ -35,6 +35,7 @@ func GetParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params [flags]",
 		Short: "Get the params for the x/accesscontrol module",
+		Long:  "Get the params for the x/accesscontrol module",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -61,7 +62,9 @@ func GetResourceDependencyMapping() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resource-dependency-mapping [messageKey] [flags]",
 		Short: "Get the resource dependency mapping for a specific message key",
-		Args:  cobra.ExactArgs(1),
+		Long: "Get the resource dependency mapping for a specific message key. E.g.\n" +
+			"$ seid q accesscontrol resource-dependency-mapping [messageKey] [flags]",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
@@ -90,6 +93,7 @@ func ListResourceDependencyMapping() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-resource-dependency-mapping [flags]",
 		Short: "List all resource dependency mappings",
+		Long:  "List all resource dependency mappings",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -119,7 +123,9 @@ func GetWasmDependencyAccessOps() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wasm-dependency-mapping [contractAddr] [flags]",
 		Short: "Get the wasm contract dependency mapping for a specific contract address",
-		Args:  cobra.ExactArgs(1),
+		Long: "Get the wasm contract dependency mapping for a specific contract address. E.g.\n" +
+			"$ seid q accesscontrol wasm-dependency-mapping [contractAddr] [flags]",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
@@ -148,6 +154,7 @@ func ListWasmDependencyMapping() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-wasm-dependency-mapping [flags]",
 		Short: "List all wasm contract dependency mappings",
+		Long:  "List all wasm contract dependency mappings",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)

--- a/x/accesscontrol/client/cli/tx.go
+++ b/x/accesscontrol/client/cli/tx.go
@@ -42,6 +42,15 @@ func MsgUpdateResourceDependencyMappingProposalCmd() *cobra.Command {
 		Use:   "update-resource-dependency-mapping [proposal-file]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Submit an UpdateResourceDependencyMapping proposal",
+		Long: "Submit a proposal to update resource dependencies between objects. \n" +
+			"E.g. $ seid update-resource-dependency-mapping <proposal-file>\n" +
+			"The proposal file should contain the following:\n" +
+			"{\n" +
+			"\t title: <title>,\n" +
+			"\t description: <description>,\n" +
+			"\t deposit: <deposit>,\n" +
+			"\t message_dependency_mapping: [<list of message dependency mappings>]\n" +
+			"}",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -84,6 +93,12 @@ func MsgRegisterWasmDependencyMappingCmd() *cobra.Command {
 		Use:   "register-wasm-dependency-mapping [mapping-json-file]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Register dependencies for a wasm contract",
+		Long: "Registers dependencies for a wasm contrcat\n" +
+			"E.g. $seid register-wasm-dependency-mapping <mapping-json-file>\n" +
+			"The mapping JSON file should contain the following:\n" +
+			"{\n" +
+			"\t wasm_dependency_mapping: <wasm dependency mapping>\n" +
+			"}",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {

--- a/x/accesscontrol/client/cli/tx.go
+++ b/x/accesscontrol/client/cli/tx.go
@@ -43,12 +43,12 @@ func MsgUpdateResourceDependencyMappingProposalCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Submit an UpdateResourceDependencyMapping proposal",
 		Long: "Submit a proposal to update resource dependencies between objects. \n" +
-			"E.g. $ seid update-resource-dependency-mapping <proposal-file>\n" +
+			"E.g. $ seid update-resource-dependency-mapping [proposal-file]\n" +
 			"The proposal file should contain the following:\n" +
 			"{\n" +
-			"\t title: <title>,\n" +
-			"\t description: <description>,\n" +
-			"\t deposit: <deposit>,\n" +
+			"\t title: [title],\n" +
+			"\t description: [description],\n" +
+			"\t deposit: [deposit],\n" +
 			"\t message_dependency_mapping: [<list of message dependency mappings>]\n" +
 			"}",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -93,8 +93,8 @@ func MsgRegisterWasmDependencyMappingCmd() *cobra.Command {
 		Use:   "register-wasm-dependency-mapping [mapping-json-file]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Register dependencies for a wasm contract",
-		Long: "Registers dependencies for a wasm contrcat\n" +
-			"E.g. $seid register-wasm-dependency-mapping <mapping-json-file>\n" +
+		Long: "Registers dependencies for a wasm contract\n" +
+			"E.g. $seid register-wasm-dependency-mapping [mapping-json-file]\n" +
 			"The mapping JSON file should contain the following:\n" +
 			"{\n" +
 			"\t wasm_dependency_mapping: <wasm dependency mapping>\n" +


### PR DESCRIPTION
## Describe your changes and provide context
Adds informative long messages to acl module
## Testing performed to validate your change
Tested locally:
```
 ~/sei-chain | acl-long-msg *3 !1  seid tx accesscontrol update-resource-dependency-mapping --help          ok | 9s | 04:29:52 PM
Submit a proposal to update resource dependencies between objects.
E.g. $ seid update-resource-dependency-mapping <proposal-file>
The proposal file should contain the following:
{
	 title: <title>,
	 description: <description>,
	 deposit: <deposit>,
	 message_dependency_mapping: [<list of message dependency mappings>]
}
 ~/sei-chain | acl-long-msg *3 !1  seid tx accesscontrol register-wasm-dependency-mapping --help                 ok | 04:29:53 PM
Registers dependencies for a wasm contrcat
E.g. $seid register-wasm-dependency-mapping <mapping-json-file>
The mapping JSON file should contain the following:
{
	 wasm_dependency_mapping: <wasm dependency mapping>
}

```

