### PR TITLE
Do not evict dirty cache entries

### DIFF
--- a/store/types/cache.go
+++ b/store/types/cache.go
@@ -63,7 +63,10 @@ func (c *BoundedCache) Set(key string, val *CValue) {
 	if c.Len() >= c.limit {
 		len := c.Len()
 		keysToEvict := []string{}
-		c.CacheBackend.Range(func(key string, _ *CValue) bool {
+		c.CacheBackend.Range(func(key string, val *CValue) bool {
+			if val.dirty {
+				return true
+			}
 			keysToEvict = append(keysToEvict, key)
 			len--
 			return len >= c.limit


### PR DESCRIPTION
## Describe your changes and provide context
We do not want to evict cache entry that represents a dirty write even if it goes beyond cache limit. An OOM is better than wrong result

## Testing performed to validate your change
TODO
