### PR TITLE
[oak audit] Coding style fix

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -41,7 +41,7 @@ func (app *BaseApp) InitChain(ctx context.Context, req *abci.RequestInitChain) (
 		initHeader = tmproto.Header{ChainID: req.ChainId, Height: req.InitialHeight, Time: req.Time}
 		err := app.cms.SetInitialVersion(req.InitialHeight)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 
@@ -79,12 +79,11 @@ func (app *BaseApp) InitChain(ctx context.Context, req *abci.RequestInitChain) (
 	// sanity check
 	if len(req.Validators) > 0 {
 		if len(req.Validators) != len(res.Validators) {
-			panic(
+			return nil,
 				fmt.Errorf(
 					"len(RequestInitChain.Validators) != len(GenesisValidators) (%d != %d)",
 					len(req.Validators), len(res.Validators),
-				),
-			)
+				)
 		}
 
 		sort.Sort(abci.ValidatorUpdates(req.Validators))
@@ -92,7 +91,7 @@ func (app *BaseApp) InitChain(ctx context.Context, req *abci.RequestInitChain) (
 
 		for i := range res.Validators {
 			if !proto.Equal(&res.Validators[i], &req.Validators[i]) {
-				panic(fmt.Errorf("genesisValidators[%d] != req.Validators[%d] ", i, i))
+				return nil, fmt.Errorf("genesisValidators[%d] != req.Validators[%d] ", i, i)
 			}
 		}
 	}

--- a/types/accesscontrol/access_operation_map.go
+++ b/types/accesscontrol/access_operation_map.go
@@ -36,7 +36,7 @@ func GetMessageAccessOps(
 ) []AccessOperation {
 	accessOps := []AccessOperation{}
 
-	for accessOp, _ := range messageAccessOpsChannelMapping[messageIndex] {
+	for accessOp := range messageAccessOpsChannelMapping[messageIndex] {
 		accessOps = append(accessOps, accessOp)
 	}
 	return accessOps

--- a/x/accesscontrol/module.go
+++ b/x/accesscontrol/module.go
@@ -62,7 +62,6 @@ func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
 	var data types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &data); err != nil {
-		println("Validate Failed", bz)
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
The following are some recommendations to improve the overall code quality and readability:

- Range expression in types/accesscontrol/access_operation_map.go:39 can be simplified by omitting the , _.
- The InitChain function in baseapp/abci.go:31 is supposed to throw an error, but it does not.
- The println function in x/accesscontrol/module.go:62 can be removed as it is there for testing

## Testing performed to validate your change
Unit Test should cover it
