### PR TITLE
Fix delete resource access event to be a Write

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -143,7 +143,7 @@ func (store *Store) Delete(key []byte) {
 
 	types.AssertValidKey(key)
 	store.setCacheValue(key, nil, true, true)
-	store.eventManager.EmitResourceAccessReadEvent("delete", store.storeKey, key, []byte{})
+	store.eventManager.EmitResourceAccessWriteEvent("delete", store.storeKey, key, []byte{})
 }
 
 // Implements Cachetypes.KVStore.


### PR DESCRIPTION
## Describe your changes and provide context
This fixes the delete operation's resource access event to be a Write for validation instead of a Read that it was set as preivously.

## Testing performed to validate your change

