### PR TITLE
Turn on fsync for iavl store

### DIFF
--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -51,7 +51,10 @@ func LoadStore(db dbm.DB, logger log.Logger, key types.StoreKey, id types.Commit
 // provided DB. An error is returned if the version fails to load, or if called with a positive
 // version on an empty tree.
 func LoadStoreWithInitialVersion(db dbm.DB, logger log.Logger, key types.StoreKey, id types.CommitID, lazyLoading bool, initialVersion uint64, cacheSize int, disableFastNode bool) (types.CommitKVStore, error) {
-	tree, err := iavl.NewMutableTreeWithOpts(db, cacheSize, &iavl.Options{InitialVersion: initialVersion}, disableFastNode)
+	tree, err := iavl.NewMutableTreeWithOpts(db, cacheSize, &iavl.Options{
+		InitialVersion: initialVersion,
+		Sync:           true,
+	}, disableFastNode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Testing performance impact for turning fsync on and decide next step.
This change will prevent data loss when we encounter and power failure or disk failures.
## Testing performed to validate your change
Performance tested using loadtest client, didn't observe any noticeable regression