### PR TITLE
Event Manager Data Race

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -46,9 +46,13 @@ const (
 )
 
 func NewEventManager() *EventManager {
-	return &EventManager{
-		events: EmptyEvents(),
+	em := EventManager{
+		mtx: sync.RWMutex{},
 	}
+	em.mtx.Lock()
+	defer em.mtx.Unlock()
+	em.events = EmptyEvents()
+	return &em
 }
 
 func (em *EventManager) Events() Events { return em.events }


### PR DESCRIPTION
## Describe your changes and provide context
When initializing EventManager, events is set. However, this could cause a race condition, so we should lock when initializing.
## Testing performed to validate your change
Deployed to race detector and verified it is no longer an issue
