### PR TITLE
Add locking for sdk.context and baseapp.state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
         if: env.GIT_DIFF
       - name: test & coverage report creation
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -race -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='ledger test_ledger_mock'
+          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -race -timeout 5m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='ledger test_ledger_mock'
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1028,9 +1028,7 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 	// we also set block gas meter to checkState in case the application needs to
 	// verify gas consumption during (Re)CheckTx
 	if app.checkState != nil {
-		app.checkState.ctx = app.checkState.ctx.
-			WithBlockGasMeter(gasMeter).
-			WithHeaderHash(req.Hash)
+		app.checkState.SetContext(app.checkState.ctx.WithBlockGasMeter(gasMeter).WithHeaderHash(req.Hash))
 	}
 
 	if app.finalizeBlocker != nil {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/gogo/protobuf/proto"
 	sdbm "github.com/sei-protocol/sei-tm-db/backends"
@@ -471,6 +472,7 @@ func (app *BaseApp) setCheckState(header tmproto.Header) {
 	app.checkState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, true, app.logger).WithMinGasPrices(app.minGasPrices),
+		mtx: &sync.RWMutex{},
 	}
 }
 
@@ -483,6 +485,7 @@ func (app *BaseApp) setDeliverState(header tmproto.Header) {
 	app.deliverState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
+		mtx: &sync.RWMutex{},
 	}
 }
 
@@ -491,6 +494,7 @@ func (app *BaseApp) setPrepareProposalState(header tmproto.Header) {
 	app.prepareProposalState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
+		mtx: &sync.RWMutex{},
 	}
 }
 
@@ -499,6 +503,7 @@ func (app *BaseApp) setProcessProposalState(header tmproto.Header) {
 	app.processProposalState = &state{
 		ms:  ms,
 		ctx: sdk.NewContext(ms, header, false, app.logger),
+		mtx: &sync.RWMutex{},
 	}
 }
 

--- a/baseapp/grpcrouter_test.go
+++ b/baseapp/grpcrouter_test.go
@@ -2,6 +2,7 @@ package baseapp_test
 
 import (
 	"context"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestGRPCGatewayRouter(t *testing.T) {
 	testdata.RegisterQueryServer(qr, testdata.QueryImpl{})
 	helper := &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: qr,
-		Ctx:             sdk.Context{}.WithContext(context.Background()),
+		Ctx:             sdk.NewContext(nil, tmproto.Header{}, false, nil).WithContext(context.Background()),
 	}
 	client := testdata.NewQueryClient(helper)
 

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -2,20 +2,33 @@ package baseapp
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"sync"
 )
 
 type state struct {
 	ms  sdk.CacheMultiStore
 	ctx sdk.Context
+	mtx *sync.RWMutex
 }
 
 // CacheMultiStore calls and returns a CacheMultiStore on the state's underling
 // CacheMultiStore.
 func (st *state) CacheMultiStore() sdk.CacheMultiStore {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.ms.CacheMultiStore()
 }
 
 // Context returns the Context of the state.
 func (st *state) Context() sdk.Context {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.ctx
+}
+
+func (st *state) SetContext(ctx sdk.Context) *state {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	st.ctx = ctx
+	return st
 }

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -1,10 +1,9 @@
 package baseapp
 
 import (
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 func (app *BaseApp) Check(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *sdk.Result, error) {

--- a/types/context.go
+++ b/types/context.go
@@ -276,8 +276,6 @@ func (c Context) WithHeaderHash(hash []byte) Context {
 
 // WithBlockTime returns a Context with an updated tendermint block header time in UTC time
 func (c Context) WithBlockTime(newTime time.Time) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	newHeader := c.BlockHeader()
 	// https://github.com/gogo/protobuf/issues/519
 	newHeader.Time = newTime.UTC()
@@ -286,8 +284,6 @@ func (c Context) WithBlockTime(newTime time.Time) Context {
 
 // WithProposer returns a Context with an updated proposer consensus address.
 func (c Context) WithProposer(addr ConsAddress) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	newHeader := c.BlockHeader()
 	newHeader.ProposerAddress = addr.Bytes()
 	return c.WithBlockHeader(newHeader)
@@ -441,8 +437,6 @@ func (c Context) WithContextMemCache(contextMemCache *ContextMemCache) Context {
 
 // TODO: remove???
 func (c Context) IsZero() bool {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.ms == nil
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -26,7 +26,7 @@ and standard additions here would be better just to add to the Context struct
 */
 type Context struct {
 	ctx           context.Context
-	mtx           sync.RWMutex
+	mtx           *sync.RWMutex
 	ms            MultiStore
 	header        tmproto.Header
 	headerHash    tmbytes.HexBytes
@@ -220,7 +220,7 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 	header.Time = header.Time.UTC()
 	return Context{
 		ctx:             context.Background(),
-		mtx:             sync.RWMutex{},
+		mtx:             &sync.RWMutex{},
 		ms:              ms,
 		header:          header,
 		chainID:         header.ChainID,
@@ -295,8 +295,6 @@ func (c Context) WithProposer(addr ConsAddress) Context {
 
 // WithBlockHeight returns a Context with an updated block height.
 func (c Context) WithBlockHeight(height int64) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	newHeader := c.BlockHeader()
 	newHeader.Height = height
 	return c.WithBlockHeader(newHeader)

--- a/types/context.go
+++ b/types/context.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -25,6 +26,7 @@ and standard additions here would be better just to add to the Context struct
 */
 type Context struct {
 	ctx           context.Context
+	mtx           sync.RWMutex
 	ms            MultiStore
 	header        tmproto.Header
 	headerHash    tmbytes.HexBytes
@@ -55,52 +57,160 @@ type Context struct {
 type Request = Context
 
 // Read-only accessors
-func (c Context) Context() context.Context    { return c.ctx }
-func (c Context) MultiStore() MultiStore      { return c.ms }
-func (c Context) BlockHeight() int64          { return c.header.Height }
-func (c Context) BlockTime() time.Time        { return c.header.Time }
-func (c Context) ChainID() string             { return c.chainID }
-func (c Context) TxBytes() []byte             { return c.txBytes }
-func (c Context) Logger() log.Logger          { return c.logger }
-func (c Context) VoteInfos() []abci.VoteInfo  { return c.voteInfo }
-func (c Context) GasMeter() GasMeter          { return c.gasMeter }
-func (c Context) BlockGasMeter() GasMeter     { return c.blockGasMeter }
-func (c Context) IsCheckTx() bool             { return c.checkTx }
-func (c Context) IsReCheckTx() bool           { return c.recheckTx }
-func (c Context) MinGasPrices() DecCoins      { return c.minGasPrice }
-func (c Context) EventManager() *EventManager { return c.eventManager }
-func (c Context) Priority() int64             { return c.priority }
+func (c Context) Context() context.Context {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.ctx
+}
+
+func (c Context) MultiStore() MultiStore {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.ms
+}
+
+func (c Context) BlockHeight() int64 {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.header.Height
+}
+
+func (c Context) BlockTime() time.Time {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.header.Time
+}
+
+func (c Context) ChainID() string {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.chainID
+}
+
+func (c Context) TxBytes() []byte {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.txBytes
+}
+
+func (c Context) Logger() log.Logger {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.logger
+}
+
+func (c Context) VoteInfos() []abci.VoteInfo {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.voteInfo
+}
+
+func (c Context) GasMeter() GasMeter {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.gasMeter
+}
+
+func (c Context) BlockGasMeter() GasMeter {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.blockGasMeter
+}
+
+func (c Context) IsCheckTx() bool {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.checkTx
+}
+
+func (c Context) IsReCheckTx() bool {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.recheckTx
+}
+
+func (c Context) MinGasPrices() DecCoins {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.minGasPrice
+}
+
+func (c Context) EventManager() *EventManager {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.eventManager
+}
+
+func (c Context) Priority() int64 {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.priority
+}
+
 func (c Context) TxCompletionChannels() acltypes.MessageAccessOpsChannelMapping {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	return c.txCompletionChannels
 }
+
 func (c Context) TxBlockingChannels() acltypes.MessageAccessOpsChannelMapping {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	return c.txBlockingChannels
 }
-func (c Context) TxMsgAccessOps() map[int][]acltypes.AccessOperation { return c.txMsgAccessOps }
-func (c Context) MessageIndex() int                                  { return c.messageIndex }
-func (c Context) MsgValidator() *acltypes.MsgValidator               { return c.msgValidator }
-func (c Context) ContextMemCache() *ContextMemCache                  { return c.contextMemCache }
+
+func (c Context) TxMsgAccessOps() map[int][]acltypes.AccessOperation {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.txMsgAccessOps
+}
+
+func (c Context) MessageIndex() int {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.messageIndex
+}
+
+func (c Context) MsgValidator() *acltypes.MsgValidator {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.msgValidator
+}
+
+func (c Context) ContextMemCache() *ContextMemCache {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.contextMemCache
+}
 
 // clone the header before returning
 func (c Context) BlockHeader() tmproto.Header {
-	var msg = proto.Clone(&c.header).(*tmproto.Header)
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	msg := proto.Clone(&c.header).(*tmproto.Header)
 	return *msg
 }
 
 // WithEventManager returns a Context with an updated tx priority
 func (c Context) WithPriority(p int64) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.priority = p
 	return c
 }
 
 // HeaderHash returns a copy of the header hash obtained during abci.RequestBeginBlock
 func (c Context) HeaderHash() tmbytes.HexBytes {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	hash := make([]byte, len(c.headerHash))
 	copy(hash, c.headerHash)
 	return hash
 }
 
 func (c Context) ConsensusParams() *tmproto.ConsensusParams {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	return proto.Clone(c.consParams).(*tmproto.ConsensusParams)
 }
 
@@ -110,6 +220,7 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 	header.Time = header.Time.UTC()
 	return Context{
 		ctx:             context.Background(),
+		mtx:             sync.RWMutex{},
 		ms:              ms,
 		header:          header,
 		chainID:         header.ChainID,
@@ -128,18 +239,24 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 
 // WithContext returns a Context with an updated context.Context.
 func (c Context) WithContext(ctx context.Context) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.ctx = ctx
 	return c
 }
 
 // WithMultiStore returns a Context with an updated MultiStore.
 func (c Context) WithMultiStore(ms MultiStore) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.ms = ms
 	return c
 }
 
 // WithBlockHeader returns a Context with an updated tendermint block header in UTC time.
 func (c Context) WithBlockHeader(header tmproto.Header) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	// https://github.com/gogo/protobuf/issues/519
 	header.Time = header.Time.UTC()
 	c.header = header
@@ -151,12 +268,16 @@ func (c Context) WithHeaderHash(hash []byte) Context {
 	temp := make([]byte, len(hash))
 	copy(temp, hash)
 
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.headerHash = temp
 	return c
 }
 
 // WithBlockTime returns a Context with an updated tendermint block header time in UTC time
 func (c Context) WithBlockTime(newTime time.Time) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	newHeader := c.BlockHeader()
 	// https://github.com/gogo/protobuf/issues/519
 	newHeader.Time = newTime.UTC()
@@ -165,6 +286,8 @@ func (c Context) WithBlockTime(newTime time.Time) Context {
 
 // WithProposer returns a Context with an updated proposer consensus address.
 func (c Context) WithProposer(addr ConsAddress) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	newHeader := c.BlockHeader()
 	newHeader.ProposerAddress = addr.Bytes()
 	return c.WithBlockHeader(newHeader)
@@ -172,6 +295,8 @@ func (c Context) WithProposer(addr ConsAddress) Context {
 
 // WithBlockHeight returns a Context with an updated block height.
 func (c Context) WithBlockHeight(height int64) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	newHeader := c.BlockHeader()
 	newHeader.Height = height
 	return c.WithBlockHeader(newHeader)
@@ -179,42 +304,56 @@ func (c Context) WithBlockHeight(height int64) Context {
 
 // WithChainID returns a Context with an updated chain identifier.
 func (c Context) WithChainID(chainID string) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.chainID = chainID
 	return c
 }
 
 // WithTxBytes returns a Context with an updated txBytes.
 func (c Context) WithTxBytes(txBytes []byte) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.txBytes = txBytes
 	return c
 }
 
 // WithLogger returns a Context with an updated logger.
 func (c Context) WithLogger(logger log.Logger) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.logger = logger
 	return c
 }
 
 // WithVoteInfos returns a Context with an updated consensus VoteInfo.
 func (c Context) WithVoteInfos(voteInfo []abci.VoteInfo) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.voteInfo = voteInfo
 	return c
 }
 
 // WithGasMeter returns a Context with an updated transaction GasMeter.
 func (c Context) WithGasMeter(meter GasMeter) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.gasMeter = meter
 	return c
 }
 
 // WithBlockGasMeter returns a Context with an updated block GasMeter
 func (c Context) WithBlockGasMeter(meter GasMeter) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.blockGasMeter = meter
 	return c
 }
 
 // WithIsCheckTx enables or disables CheckTx value for verifying transactions and returns an updated Context
 func (c Context) WithIsCheckTx(isCheckTx bool) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.checkTx = isCheckTx
 	return c
 }
@@ -222,6 +361,8 @@ func (c Context) WithIsCheckTx(isCheckTx bool) Context {
 // WithIsRecheckTx called with true will also set true on checkTx in order to
 // enforce the invariant that if recheckTx = true then checkTx = true as well.
 func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	if isRecheckTx {
 		c.checkTx = true
 	}
@@ -231,78 +372,108 @@ func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
 
 // WithMinGasPrices returns a Context with an updated minimum gas price value
 func (c Context) WithMinGasPrices(gasPrices DecCoins) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.minGasPrice = gasPrices
 	return c
 }
 
 // WithConsensusParams returns a Context with an updated consensus params
 func (c Context) WithConsensusParams(params *tmproto.ConsensusParams) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.consParams = params
 	return c
 }
 
 // WithEventManager returns a Context with an updated event manager
 func (c Context) WithEventManager(em *EventManager) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.eventManager = em
 	return c
 }
 
 // TxMsgAccessOps returns a Context with an updated list of completion channel
 func (c Context) WithTxMsgAccessOps(accessOps map[int][]acltypes.AccessOperation) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.txMsgAccessOps = accessOps
 	return c
 }
 
 // WithTxCompletionChannels returns a Context with an updated list of completion channel
 func (c Context) WithTxCompletionChannels(completionChannels acltypes.MessageAccessOpsChannelMapping) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.txCompletionChannels = completionChannels
 	return c
 }
 
 // WithTxBlockingChannels returns a Context with an updated list of blocking channels for completion signals
 func (c Context) WithTxBlockingChannels(blockingChannels acltypes.MessageAccessOpsChannelMapping) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.txBlockingChannels = blockingChannels
 	return c
 }
 
 // WithMessageIndex returns a Context with the current message index that's being processed
 func (c Context) WithMessageIndex(messageIndex int) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.messageIndex = messageIndex
 	return c
 }
 
 func (c Context) WithMsgValidator(msgValidator *acltypes.MsgValidator) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.msgValidator = msgValidator
 	return c
 }
 
 // WithContextMemCache returns a Context with a new context mem cache
 func (c Context) WithContextMemCache(contextMemCache *ContextMemCache) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.contextMemCache = contextMemCache
 	return c
 }
 
 // TODO: remove???
 func (c Context) IsZero() bool {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	return c.ms == nil
 }
 
 // WithValue is deprecated, provided for backwards compatibility
 // Please use
-//     ctx = ctx.WithContext(context.WithValue(ctx.Context(), key, false))
+//
+//	ctx = ctx.WithContext(context.WithValue(ctx.Context(), key, false))
+//
 // instead of
-//     ctx = ctx.WithValue(key, false)
+//
+//	ctx = ctx.WithValue(key, false)
 func (c Context) WithValue(key, value interface{}) Context {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.ctx = context.WithValue(c.ctx, key, value)
 	return c
 }
 
 // Value is deprecated, provided for backwards compatibility
 // Please use
-//     ctx.Context().Value(key)
+//
+//	ctx.Context().Value(key)
+//
 // instead of
-//     ctx.Value(key)
+//
+//	ctx.Value(key)
 func (c Context) Value(key interface{}) interface{} {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	return c.ctx.Value(key)
 }
 
@@ -340,6 +511,8 @@ const SdkContextKey ContextKey = "sdk-context"
 // stdlib context.Context parameter such as generated gRPC methods. To get the original
 // sdk.Context back, call UnwrapSDKContext.
 func WrapSDKContext(ctx Context) context.Context {
+	ctx.mtx.Lock()
+	defer ctx.mtx.Unlock()
 	return context.WithValue(ctx.ctx, SdkContextKey, ctx)
 }
 

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -146,10 +147,13 @@ func (s *contextTestSuite) TestContextHeader() {
 
 	ctx = types.NewContext(nil, tmproto.Header{}, false, nil)
 
+	fmt.Printf("Start ctx\n")
+
 	ctx = ctx.
 		WithBlockHeight(height).
 		WithBlockTime(time).
 		WithProposer(proposer)
+	fmt.Printf("Finished ctx\n")
 	s.Require().Equal(height, ctx.BlockHeight())
 	s.Require().Equal(height, ctx.BlockHeader().Height)
 	s.Require().Equal(time.UTC(), ctx.BlockHeader().Time)

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -3,6 +3,7 @@ package module_test
 import (
 	"encoding/json"
 	"errors"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -260,7 +261,7 @@ func TestManager_BeginBlock(t *testing.T) {
 
 	mockAppModule1.EXPECT().BeginBlock(gomock.Any(), gomock.Eq(req)).Times(1)
 	mockAppModule2.EXPECT().BeginBlock(gomock.Any(), gomock.Eq(req)).Times(1)
-	mm.BeginBlock(sdk.Context{}, req)
+	mm.BeginBlock(sdk.NewContext(nil, tmproto.Header{}, false, nil), req)
 }
 
 func TestManager_MidBlock(t *testing.T) {
@@ -280,7 +281,7 @@ func TestManager_MidBlock(t *testing.T) {
 
 	mockAppModule1.EXPECT().MidBlock(gomock.Any(), gomock.Eq(height)).Times(1)
 	mockAppModule2.EXPECT().MidBlock(gomock.Any(), gomock.Eq(height)).Times(1)
-	mm.MidBlock(sdk.Context{}, height)
+	mm.MidBlock(sdk.NewContext(nil, tmproto.Header{}, false, nil), height)
 }
 
 func TestManager_EndBlock(t *testing.T) {
@@ -299,11 +300,11 @@ func TestManager_EndBlock(t *testing.T) {
 
 	mockAppModule1.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
 	mockAppModule2.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1)
-	ret := mm.EndBlock(sdk.Context{}, req)
+	ret := mm.EndBlock(sdk.NewContext(nil, tmproto.Header{}, false, nil), req)
 	require.Equal(t, []abci.ValidatorUpdate{{}}, ret.ValidatorUpdates)
 
 	// test panic
 	mockAppModule1.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
 	mockAppModule2.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
-	require.Panics(t, func() { mm.EndBlock(sdk.Context{}, req) })
+	require.Panics(t, func() { mm.EndBlock(sdk.NewContext(nil, tmproto.Header{}, false, nil), req) })
 }

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"encoding/hex"
 	"fmt"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"strings"
 	"testing"
 
@@ -214,7 +215,7 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 }
 
 func TestWrapServiceResult(t *testing.T) {
-	ctx := sdk.Context{}
+	ctx := sdk.NewContext(nil, tmproto.Header{}, false, nil)
 
 	res, err := sdk.WrapServiceResult(ctx, nil, fmt.Errorf("test"))
 	require.Nil(t, res)


### PR DESCRIPTION
## Describe your changes and provide context
Context and state can have race conditions, so add locks.
## Testing performed to validate your change
Tested on psu-test-3. Verified throughput is still relatively good (>300tx / block)

