### PR TITLE
Fix race condition access event manager

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -94,6 +94,8 @@ func (store *Store) GetEvents() []abci.Event {
 
 // Implements Store
 func (store *Store) ResetEvents() {
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
 	store.eventManager = sdktypes.NewEventManager()
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Race condition between:
A:
  github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).ResetEvents()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-race-cond/store/cachekv/store.go:97

B:
github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).Set()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-race-cond/store/cachekv/store.go:133
## Testing performed to validate your change

