### PR TITLE
Reset Events

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -179,6 +179,9 @@ func (app *BaseApp) MidBlock(ctx sdk.Context, height int64) (events []abci.Event
 
 // EndBlock implements the ABCI interface.
 func (app *BaseApp) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) (res abci.ResponseEndBlock) {
+	// Clear DeliverTx Events
+	ctx.MultiStore().ResetEvents()
+
 	defer telemetry.MeasureSince(time.Now(), "abci", "end_block")
 
 	if app.endBlocker != nil {

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -269,6 +269,8 @@ func TestBaseApp_EndBlock(t *testing.T) {
 	app.setDeliverState(tmproto.Header{})
 	app.deliverState.ctx = app.deliverState.ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
 	res := app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{})
+	require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
+
 	require.Len(t, res.GetValidatorUpdates(), 1)
 	require.Equal(t, int64(100), res.GetValidatorUpdates()[0].Power)
 	require.Equal(t, cp.Block.MaxGas, res.ConsensusParamUpdates.Block.MaxGas)
@@ -551,6 +553,8 @@ func TestSimulateTx(t *testing.T) {
 		require.True(t, bytes.Equal(result.Data, simRes.Result.Data))
 
 		app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{})
+		require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
+
 		app.SetDeliverStateToCommit()
 		app.Commit(context.Background())
 	}
@@ -972,6 +976,8 @@ func TestBaseAppAnteHandler(t *testing.T) {
 
 	// commit
 	app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{})
+	require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
+
 	app.SetDeliverStateToCommit()
 	app.Commit(context.Background())
 }
@@ -1467,6 +1473,8 @@ func TestCheckTx(t *testing.T) {
 	require.NotEmpty(t, app.checkState.ctx.HeaderHash())
 
 	app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{})
+	require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
+
 	app.SetDeliverStateToCommit()
 	app.Commit(context.Background())
 
@@ -1521,6 +1529,7 @@ func TestDeliverTx(t *testing.T) {
 		}
 
 		app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{})
+		require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
 		app.SetDeliverStateToCommit()
 		app.Commit(context.Background())
 	}
@@ -1724,6 +1733,8 @@ func setupBaseAppWithSnapshots(t *testing.T, blocks uint, blockTxs int, options 
 			require.True(t, resp.IsOK(), "%v", resp.String())
 		}
 		app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{Height: height})
+		require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
+
 		app.SetDeliverStateToCommit()
 		app.Commit(context.Background())
 

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -41,10 +41,6 @@ func (app *BaseApp) Deliver(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *s
 	}
 	ctx := app.deliverState.ctx.WithTxBytes(bz).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.deliverState.ctx))
 	gasInfo, result, _, _, err := app.runTx(ctx, runTxModeDeliver, bz)
-
-	if len(ctx.MultiStore().GetEvents()) > 0 {
-		panic("Expected deliverTx events to be empty")
-	}
 	return gasInfo, result, err
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
See inline comments

My thought process was that the ctx passed to Enblock is shared in all of ProcessBlock. So any store in the begin/mid block would be branching from that ctx's store and cache misses in the child stores would go to the parent store and store a read event.

```
=
==================
WARNING: DATA RACE
Read at 0x00c00b1146f8 by goroutine 5537:
  github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).Set()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-race-cond/store/cachekv/store.go:133 +0x138
  github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).Write()

Previous write at 0x00c00b1146f8 by goroutine 5431:
  github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).ResetEvents()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-race-cond/store/cachekv/store.go:97 +0xd0

Goroutine 5537 (running) created at:
  github.com/sei-protocol/sei-chain/app.(*App).ProcessBlockConcurrent()
      /home/ubuntu/sei-chain/app/app.go:1107 +0x1fd

Goroutine 5431 (running) created at:
  github.com/sei-protocol/sei-chain/app.(*App).ProcessBlockConcurrent()
      /home/ubuntu/sei-chain/app/app.go:1107 +0x1fd
=================


```

## Testing performed to validate your change
Unit tests, and going deploy on a node that's stuck to verify OOOM issue 
