### PR TITLE
Fix race condition in ABCI calls

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -675,6 +675,8 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
+	app.abciMtx.RLock()
+	defer app.abciMtx.RUnlock()
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
 		cacheMS, app.checkState.ctx.BlockHeader(), true, app.logger,

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -676,10 +676,11 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 	}
 
 	app.abciMtx.RLock()
-	defer app.abciMtx.RUnlock()
+	checkStateCtx := app.checkState.ctx
+	app.abciMtx.RUnlock()
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
-		cacheMS, app.checkState.ctx.BlockHeader(), true, app.logger,
+		cacheMS, checkStateCtx.BlockHeader(), true, app.logger,
 	).WithMinGasPrices(app.minGasPrices).WithBlockHeight(height)
 
 	return ctx, nil

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -675,9 +675,9 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	app.abciMtx.RLock()
+	// app.abciMtx.RLock()
 	checkStateCtx := app.checkState.ctx
-	app.abciMtx.RUnlock()
+	// app.abciMtx.RUnlock()
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
 		cacheMS, checkStateCtx.BlockHeader(), true, app.logger,

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -327,10 +327,7 @@ func (app *BaseApp) Commit(ctx context.Context) (res *abci.ResponseCommit, err e
 	app.setCheckState(header)
 
 	// empty/reset the deliver state
-	app.prepareProposalState = nil
-	app.processProposalState = nil
-	app.deliverState = nil
-	app.stateToCommit = nil
+	app.resetStatesExceptCheckState()
 
 	var halt bool
 
@@ -922,13 +919,10 @@ func (app *BaseApp) PrepareProposal(ctx context.Context, req *abci.RequestPrepar
 	} else {
 		// In the first block, app.prepareProposalState.ctx will already be initialized
 		// by InitChain. Context is now updated with Header information.
-		app.prepareProposalState.ctx = app.prepareProposalState.ctx.
-			WithBlockHeader(header)
+		app.setPrepareProposalHeader(header)
 	}
 
-	if app.prepareProposalState.ms.TracingEnabled() {
-		app.prepareProposalState.ms = app.prepareProposalState.ms.SetTracingContext(nil).(sdk.CacheMultiStore)
-	}
+	app.preparePrepareProposalState()
 
 	if app.prepareProposalHandler != nil {
 		res, err := app.prepareProposalHandler(app.prepareProposalState.ctx, req)
@@ -953,8 +947,7 @@ func (app *BaseApp) ProcessProposal(ctx context.Context, req *abci.RequestProces
 	} else {
 		// In the first block, app.processProposalState.ctx will already be initialized
 		// by InitChain. Context is now updated with Header information.
-		app.processProposalState.ctx = app.processProposalState.ctx.
-			WithBlockHeader(header)
+		app.setProcessProposalHeader(header)
 	}
 
 	// add block gas meter
@@ -967,14 +960,7 @@ func (app *BaseApp) ProcessProposal(ctx context.Context, req *abci.RequestProces
 
 	// NOTE: header hash is not set in NewContext, so we manually set it here
 
-	app.processProposalState.ctx = app.processProposalState.ctx.
-		WithBlockGasMeter(gasMeter).
-		WithHeaderHash(req.Hash).
-		WithConsensusParams(app.GetConsensusParams(app.processProposalState.ctx))
-
-	if app.processProposalState.ms.TracingEnabled() {
-		app.processProposalState.ms = app.processProposalState.ms.SetTracingContext(nil).(sdk.CacheMultiStore)
-	}
+	app.prepareProcessProposalState(gasMeter, req.Hash)
 
 	if app.processProposalHandler != nil {
 		res, err := app.processProposalHandler(app.processProposalState.ctx, req)
@@ -1008,9 +994,7 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 	} else {
 		// In the first block, app.deliverState.ctx will already be initialized
 		// by InitChain. Context is now updated with Header information.
-		app.deliverState.ctx = app.deliverState.ctx.
-			WithBlockHeader(header).
-			WithBlockHeight(header.Height)
+		app.setDeliverStateHeader(header)
 	}
 
 	// add block gas meter
@@ -1023,10 +1007,7 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 
 	// NOTE: header hash is not set in NewContext, so we manually set it here
 
-	app.deliverState.ctx = app.deliverState.ctx.
-		WithBlockGasMeter(gasMeter).
-		WithHeaderHash(req.Hash).
-		WithConsensusParams(app.GetConsensusParams(app.deliverState.ctx))
+	app.prepareDeliverState(gasMeter, req.Hash)
 
 	// we also set block gas meter to checkState in case the application needs to
 	// verify gas consumption during (Re)CheckTx
@@ -1041,7 +1022,7 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 		}
 		res.Events = sdk.MarkEventsToIndex(res.Events, app.indexEvents)
 		// set the signed validators for addition to context in deliverTx
-		app.voteInfos = req.DecidedLastCommit.GetVotes()
+		app.setVotesInfo(req.DecidedLastCommit.GetVotes())
 
 		return res, nil
 	} else {

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -675,9 +675,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	// app.abciMtx.RLock()
-	checkStateCtx := app.checkState.ctx
-	// app.abciMtx.RUnlock()
+	checkStateCtx := app.checkState.Context()
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
 		cacheMS, checkStateCtx.BlockHeader(), true, app.logger,

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -1,8 +1,9 @@
 package baseapp
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"sync"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type state struct {
@@ -17,6 +18,19 @@ func (st *state) CacheMultiStore() sdk.CacheMultiStore {
 	st.mtx.RLock()
 	defer st.mtx.RUnlock()
 	return st.ms.CacheMultiStore()
+}
+
+func (st *state) MultiStore() sdk.CacheMultiStore {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	return st.ms
+}
+
+func (st *state) SetMultiStore(ms sdk.CacheMultiStore) *state {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	st.ms = ms
+	return st
 }
 
 // Context returns the Context of the state.

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -138,6 +138,8 @@ func (store *Store) Set(key []byte, value []byte) {
 // Has implements types.KVStore.
 func (store *Store) Has(key []byte) bool {
 	value := store.Get(key)
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
 	store.eventManager.EmitResourceAccessReadEvent("has", store.storeKey, key, value)
 	return value != nil
 }

--- a/types/context.go
+++ b/types/context.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -26,7 +25,6 @@ and standard additions here would be better just to add to the Context struct
 */
 type Context struct {
 	ctx           context.Context
-	mtx           *sync.RWMutex
 	ms            MultiStore
 	header        tmproto.Header
 	headerHash    tmbytes.HexBytes
@@ -58,159 +56,109 @@ type Request = Context
 
 // Read-only accessors
 func (c Context) Context() context.Context {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.ctx
 }
 
 func (c Context) MultiStore() MultiStore {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.ms
 }
 
 func (c Context) BlockHeight() int64 {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.header.Height
 }
 
 func (c Context) BlockTime() time.Time {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.header.Time
 }
 
 func (c Context) ChainID() string {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.chainID
 }
 
 func (c Context) TxBytes() []byte {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.txBytes
 }
 
 func (c Context) Logger() log.Logger {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.logger
 }
 
 func (c Context) VoteInfos() []abci.VoteInfo {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.voteInfo
 }
 
 func (c Context) GasMeter() GasMeter {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.gasMeter
 }
 
 func (c Context) BlockGasMeter() GasMeter {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.blockGasMeter
 }
 
 func (c Context) IsCheckTx() bool {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.checkTx
 }
 
 func (c Context) IsReCheckTx() bool {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.recheckTx
 }
 
 func (c Context) MinGasPrices() DecCoins {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.minGasPrice
 }
 
 func (c Context) EventManager() *EventManager {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.eventManager
 }
 
 func (c Context) Priority() int64 {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.priority
 }
 
 func (c Context) TxCompletionChannels() acltypes.MessageAccessOpsChannelMapping {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.txCompletionChannels
 }
 
 func (c Context) TxBlockingChannels() acltypes.MessageAccessOpsChannelMapping {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.txBlockingChannels
 }
 
 func (c Context) TxMsgAccessOps() map[int][]acltypes.AccessOperation {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.txMsgAccessOps
 }
 
 func (c Context) MessageIndex() int {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.messageIndex
 }
 
 func (c Context) MsgValidator() *acltypes.MsgValidator {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.msgValidator
 }
 
 func (c Context) ContextMemCache() *ContextMemCache {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.contextMemCache
 }
 
 // clone the header before returning
 func (c Context) BlockHeader() tmproto.Header {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	msg := proto.Clone(&c.header).(*tmproto.Header)
 	return *msg
 }
 
 // WithEventManager returns a Context with an updated tx priority
 func (c Context) WithPriority(p int64) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.priority = p
 	return c
 }
 
 // HeaderHash returns a copy of the header hash obtained during abci.RequestBeginBlock
 func (c Context) HeaderHash() tmbytes.HexBytes {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	hash := make([]byte, len(c.headerHash))
 	copy(hash, c.headerHash)
 	return hash
 }
 
 func (c Context) ConsensusParams() *tmproto.ConsensusParams {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return proto.Clone(c.consParams).(*tmproto.ConsensusParams)
 }
 
@@ -220,7 +168,6 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 	header.Time = header.Time.UTC()
 	return Context{
 		ctx:             context.Background(),
-		mtx:             &sync.RWMutex{},
 		ms:              ms,
 		header:          header,
 		chainID:         header.ChainID,
@@ -239,24 +186,18 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 
 // WithContext returns a Context with an updated context.Context.
 func (c Context) WithContext(ctx context.Context) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.ctx = ctx
 	return c
 }
 
 // WithMultiStore returns a Context with an updated MultiStore.
 func (c Context) WithMultiStore(ms MultiStore) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.ms = ms
 	return c
 }
 
 // WithBlockHeader returns a Context with an updated tendermint block header in UTC time.
 func (c Context) WithBlockHeader(header tmproto.Header) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	// https://github.com/gogo/protobuf/issues/519
 	header.Time = header.Time.UTC()
 	c.header = header
@@ -268,8 +209,6 @@ func (c Context) WithHeaderHash(hash []byte) Context {
 	temp := make([]byte, len(hash))
 	copy(temp, hash)
 
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.headerHash = temp
 	return c
 }
@@ -298,56 +237,42 @@ func (c Context) WithBlockHeight(height int64) Context {
 
 // WithChainID returns a Context with an updated chain identifier.
 func (c Context) WithChainID(chainID string) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.chainID = chainID
 	return c
 }
 
 // WithTxBytes returns a Context with an updated txBytes.
 func (c Context) WithTxBytes(txBytes []byte) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.txBytes = txBytes
 	return c
 }
 
 // WithLogger returns a Context with an updated logger.
 func (c Context) WithLogger(logger log.Logger) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.logger = logger
 	return c
 }
 
 // WithVoteInfos returns a Context with an updated consensus VoteInfo.
 func (c Context) WithVoteInfos(voteInfo []abci.VoteInfo) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.voteInfo = voteInfo
 	return c
 }
 
 // WithGasMeter returns a Context with an updated transaction GasMeter.
 func (c Context) WithGasMeter(meter GasMeter) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.gasMeter = meter
 	return c
 }
 
 // WithBlockGasMeter returns a Context with an updated block GasMeter
 func (c Context) WithBlockGasMeter(meter GasMeter) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.blockGasMeter = meter
 	return c
 }
 
 // WithIsCheckTx enables or disables CheckTx value for verifying transactions and returns an updated Context
 func (c Context) WithIsCheckTx(isCheckTx bool) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.checkTx = isCheckTx
 	return c
 }
@@ -355,8 +280,6 @@ func (c Context) WithIsCheckTx(isCheckTx bool) Context {
 // WithIsRecheckTx called with true will also set true on checkTx in order to
 // enforce the invariant that if recheckTx = true then checkTx = true as well.
 func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	if isRecheckTx {
 		c.checkTx = true
 	}
@@ -366,71 +289,53 @@ func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
 
 // WithMinGasPrices returns a Context with an updated minimum gas price value
 func (c Context) WithMinGasPrices(gasPrices DecCoins) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.minGasPrice = gasPrices
 	return c
 }
 
 // WithConsensusParams returns a Context with an updated consensus params
 func (c Context) WithConsensusParams(params *tmproto.ConsensusParams) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.consParams = params
 	return c
 }
 
 // WithEventManager returns a Context with an updated event manager
 func (c Context) WithEventManager(em *EventManager) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.eventManager = em
 	return c
 }
 
 // TxMsgAccessOps returns a Context with an updated list of completion channel
 func (c Context) WithTxMsgAccessOps(accessOps map[int][]acltypes.AccessOperation) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.txMsgAccessOps = accessOps
 	return c
 }
 
 // WithTxCompletionChannels returns a Context with an updated list of completion channel
 func (c Context) WithTxCompletionChannels(completionChannels acltypes.MessageAccessOpsChannelMapping) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.txCompletionChannels = completionChannels
 	return c
 }
 
 // WithTxBlockingChannels returns a Context with an updated list of blocking channels for completion signals
 func (c Context) WithTxBlockingChannels(blockingChannels acltypes.MessageAccessOpsChannelMapping) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.txBlockingChannels = blockingChannels
 	return c
 }
 
 // WithMessageIndex returns a Context with the current message index that's being processed
 func (c Context) WithMessageIndex(messageIndex int) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.messageIndex = messageIndex
 	return c
 }
 
 func (c Context) WithMsgValidator(msgValidator *acltypes.MsgValidator) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.msgValidator = msgValidator
 	return c
 }
 
 // WithContextMemCache returns a Context with a new context mem cache
 func (c Context) WithContextMemCache(contextMemCache *ContextMemCache) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.contextMemCache = contextMemCache
 	return c
 }
@@ -449,8 +354,6 @@ func (c Context) IsZero() bool {
 //
 //	ctx = ctx.WithValue(key, false)
 func (c Context) WithValue(key, value interface{}) Context {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
 	c.ctx = context.WithValue(c.ctx, key, value)
 	return c
 }
@@ -464,8 +367,6 @@ func (c Context) WithValue(key, value interface{}) Context {
 //
 //	ctx.Value(key)
 func (c Context) Value(key interface{}) interface{} {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
 	return c.ctx.Value(key)
 }
 
@@ -503,8 +404,6 @@ const SdkContextKey ContextKey = "sdk-context"
 // stdlib context.Context parameter such as generated gRPC methods. To get the original
 // sdk.Context back, call UnwrapSDKContext.
 func WrapSDKContext(ctx Context) context.Context {
-	ctx.mtx.Lock()
-	defer ctx.mtx.Unlock()
 	return context.WithValue(ctx.ctx, SdkContextKey, ctx)
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Move operations that mutate `app` fields into setter functions and protect by RWLock

## Testing performed to validate your change
WIP

