### PR TITLE
Add mutex lock for checkState

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -680,7 +680,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(
-		cacheMS, app.checkState.ctx.BlockHeader(), true, app.logger,
+		cacheMS, app.getCheckState().ctx.BlockHeader(), true, app.logger,
 	).WithMinGasPrices(app.minGasPrices).WithBlockHeight(height)
 
 	return ctx, nil
@@ -1030,8 +1030,10 @@ func (app *BaseApp) FinalizeBlock(ctx context.Context, req *abci.RequestFinalize
 
 	// we also set block gas meter to checkState in case the application needs to
 	// verify gas consumption during (Re)CheckTx
-	if app.checkState != nil {
-		app.checkState.SetContext(app.checkState.ctx.WithBlockGasMeter(gasMeter).WithHeaderHash(req.Hash))
+	checkState := app.getCheckState()
+	if checkState != nil {
+		contextWithGasMeter := checkState.ctx.WithBlockGasMeter(gasMeter).WithHeaderHash(req.Hash)
+		app.getCheckState().SetContext(contextWithGasMeter)
 	}
 
 	if app.finalizeBlocker != nil {

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -1108,7 +1108,7 @@ func TestInitChainer(t *testing.T) {
 	chainID := app.deliverState.ctx.ChainID()
 	require.Equal(t, "test-chain-id", chainID, "ChainID in deliverState not set correctly in InitChain")
 
-	chainID = app.checkState.ctx.ChainID()
+	chainID = app.getCheckState().ctx.ChainID()
 	require.Equal(t, "test-chain-id", chainID, "ChainID in checkState not set correctly in InitChain")
 
 	app.Commit(context.Background())
@@ -1456,7 +1456,7 @@ func TestCheckTx(t *testing.T) {
 		require.True(t, r.IsOK(), fmt.Sprintf("%v", r))
 	}
 
-	checkStateStore := app.checkState.ctx.KVStore(capKey1)
+	checkStateStore := app.getCheckState().ctx.KVStore(capKey1)
 	storedCounter := getIntFromStore(checkStateStore, counterKey)
 
 	// Ensure AnteHandler ran
@@ -1465,12 +1465,12 @@ func TestCheckTx(t *testing.T) {
 	// If a block is committed, CheckTx state should be reset.
 	header := tmproto.Header{Height: 1}
 	app.setDeliverState(header)
-	app.checkState.ctx = app.checkState.ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter()).WithHeaderHash([]byte("hash"))
+	app.getCheckState().ctx = app.getCheckState().ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter()).WithHeaderHash([]byte("hash"))
 	app.deliverState.ctx = app.deliverState.ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
 	app.BeginBlock(app.deliverState.ctx, abci.RequestBeginBlock{Header: header, Hash: []byte("hash")})
 
-	require.NotNil(t, app.checkState.ctx.BlockGasMeter(), "block gas meter should have been set to checkState")
-	require.NotEmpty(t, app.checkState.ctx.HeaderHash())
+	require.NotNil(t, app.getCheckState().ctx.BlockGasMeter(), "block gas meter should have been set to checkState")
+	require.NotEmpty(t, app.getCheckState().ctx.HeaderHash())
 
 	app.EndBlock(app.deliverState.ctx, abci.RequestEndBlock{})
 	require.Empty(t, app.deliverState.ctx.MultiStore().GetEvents())
@@ -1478,7 +1478,7 @@ func TestCheckTx(t *testing.T) {
 	app.SetDeliverStateToCommit()
 	app.Commit(context.Background())
 
-	checkStateStore = app.checkState.ctx.KVStore(capKey1)
+	checkStateStore = app.getCheckState().ctx.KVStore(capKey1)
 	storedBytes := checkStateStore.Get(counterKey)
 	require.Nil(t, storedBytes)
 }

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -14,7 +14,7 @@ func (app *BaseApp) Check(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *sdk
 	if err != nil {
 		return sdk.GasInfo{}, nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "%s", err)
 	}
-	ctx := app.checkState.ctx.WithTxBytes(bz).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.checkState.ctx))
+	ctx := app.getCheckState().ctx.WithTxBytes(bz).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.getCheckState().ctx))
 	gasInfo, result, _, _, err := app.runTx(ctx, runTxModeCheck, bz)
 	if len(ctx.MultiStore().GetEvents()) > 0 {
 		panic("Expected checkTx events to be empty")
@@ -23,7 +23,7 @@ func (app *BaseApp) Check(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *sdk
 }
 
 func (app *BaseApp) Simulate(txBytes []byte) (sdk.GasInfo, *sdk.Result, error) {
-	ctx := app.checkState.ctx.WithTxBytes(txBytes).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.checkState.ctx))
+	ctx := app.getCheckState().ctx.WithTxBytes(txBytes).WithVoteInfos(app.voteInfos).WithConsensusParams(app.GetConsensusParams(app.getCheckState().ctx))
 	ctx, _ = ctx.CacheContext()
 	gasInfo, result, _, _, err := app.runTx(ctx, runTxModeSimulate, txBytes)
 	if len(ctx.MultiStore().GetEvents()) > 0 {
@@ -46,7 +46,7 @@ func (app *BaseApp) Deliver(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *s
 // Context with current {check, deliver}State of the app used by tests.
 func (app *BaseApp) NewContext(isCheckTx bool, header tmproto.Header) sdk.Context {
 	if isCheckTx {
-		return sdk.NewContext(app.checkState.ms, header, true, app.logger).
+		return sdk.NewContext(app.getCheckState().ms, header, true, app.logger).
 			WithMinGasPrices(app.minGasPrices)
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
```
WARNING: DATA RACE
Read at 0x00c000562748 by goroutine 58319:
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).createQueryContext()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.2/baseapp/abci.go:683 +0x3be
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func1()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.2/baseapp/grpcserver.go:50 +0x2ca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      /root/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x8e
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      /root/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      /root/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x8e
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1()
      /root/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0x126
  github.com/cosmos/cosmos-sdk/x/staking/types._Query_Validators_Handler()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.2/x/staking/types/query.pb.go:1795 +0x1dd
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.2/baseapp/grpcserver.go:80 +0x13b
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /root/go/pkg/mod/google.golang.org/grpc@v1.33.2/server.go:1210 +0x132a
  google.golang.org/grpc.(*Server).handleStream()
      /root/go/pkg/mod/google.golang.org/grpc@v1.33.2/server.go:1533 +0xff8
  google.golang.org/grpc.(*Server).serveStreams.func1.2()
      /root/go/pkg/mod/google.golang.org/grpc@v1.33.2/server.go:871 +0xec

Previous write at 0x00c000562748 by goroutine 635:
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).setCheckState()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.2/baseapp/baseapp.go:472 +0x3b5
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Commit()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.2/baseapp/abci.go:327 +0x264
  github.com/sei-protocol/sei-chain/app.(*App).Commit()
      /home/ubuntu/sei-chain/app/abci.go:59 +0x2cb
  github.com/tendermint/tendermint/abci/client.(*localClient).Commit()
      <autogenerated>:1 +0x74
  github.com/tendermint/tendermint/internal/proxy.(*proxyClient).Commit()
```
## Testing performed to validate your change

Unit tests and local chain runs fine and handles queries

