### PR TITLE
Register missing Tendermint Commands

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/cmd/tendermint/commands"
+	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
 	tmcfg "github.com/tendermint/tendermint/config"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -276,11 +278,32 @@ func AddCommands(
 		Short: "Tendermint subcommands",
 	}
 
+	conf, err := commands.ParseConfig(tmcfg.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
+
+	logger, err := tmlog.NewDefaultLogger(conf.LogFormat, conf.LogLevel)
+	if err != nil {
+		panic(err)
+	}
 	tendermintCmd.AddCommand(
 		ShowNodeIDCmd(),
 		ShowValidatorCmd(),
 		ShowAddressCmd(),
 		VersionCmd(),
+		commands.MakeGenValidatorCommand(),
+		commands.MakeReindexEventCommand(conf, logger),
+		commands.MakeLightCommand(conf, logger),
+		commands.MakeReplayCommand(conf, logger),
+		commands.MakeReplayConsoleCommand(conf, logger),
+		commands.MakeResetCommand(conf, logger),
+		commands.MakeUnsafeResetAllCommand(conf, logger),
+		commands.GenNodeKeyCmd,
+		commands.MakeInspectCommand(conf, logger),
+		commands.MakeKeyMigrateCommand(conf, logger),
+		debug.GetDebugCommand(logger),
+		commands.NewCompletionCmd(tendermintCmd, true),
 	)
 
 	startCmd := StartCmd(appCreator, defaultNodeHome, tracerProviderOptions)


### PR DESCRIPTION
## Describe your changes and provide context
We also need to register the TM commands on the cosmos level, since it's re-creating the root cmd, it overwrites whatever is in sei-tendermint

## Testing performed to validate your change

```
> seid tendermint
Tendermint subcommands

Usage:
  seid tendermint [command]

Available Commands:
  debug            A utility to kill or watch a Tendermint process while aggregating debugging data
  gen-node-key     Generate a new node key
  gen-validator    Generate new validator keypair
  inspect          Run an inspect server for investigating Tendermint state
  key-migrate      Run Database key migration
  light            Run a light client proxy server, verifying Tendermint rpc
  reindex-event    reindex events to the event store backends
  replay           Replay messages from WAL
  replay-console   Replay messages from WAL in a console
  reset            Set of commands to conveniently reset tendermint related data
  show-address     Shows this node's tendermint validator consensus address
  show-node-id     Show this node's ID
  show-validator   Show this node's tendermint validator info
  unsafe-reset-all Removes all tendermint data including signing state
  version          Print tendermint libraries' version

Flags:
  -h, --help   help for tendermint

Global Flags:
      --home string         directory for config and data (default "/Users/brandon/.sei")
      --log_format string   The logging format (json|plain) (default "plain")
      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --trace               print out full stack trace on errors

Use "seid tendermint [command] --help" for more information about a command.
```