### PR TITLE
Add CLI for querying validator by hexed pubkey

### DIFF
--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -7,16 +7,15 @@ import (
 	"strings"
 	"time"
 
-	abci "github.com/tendermint/tendermint/abci/types"
-	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
-	"gopkg.in/yaml.v2"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -513,7 +512,6 @@ func (v Validator) GetConsAddr() (sdk.ConsAddress, error) {
 	if !ok {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expecting cryptotypes.PubKey, got %T", pk)
 	}
-
 	return sdk.ConsAddress(pk.Address()), nil
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Adding endpoint to translate the hex addr we get back in the dump consensus 

Used in conjunction with this PR: https://github.com/sei-protocol/sei-tendermint/pull/84

Hard to get this moniker in the consensus since it's in the internal package of tendermint and the moniker is a concept in cosmos sdk 
## Testing performed to validate your change

```
> seid q staking hex-address 9813971DD2FE41AAE4E638D9DEFD87F4D705A20A
validator:
  commission:
    commission_rates:
      max_change_rate: "0.010000000000000000"
      max_rate: "0.200000000000000000"
      rate: "0.100000000000000000"
    update_time: "2023-03-15T02:29:49.932583Z"
  consensus_pubkey:
    '@type': /cosmos.crypto.ed25519.PubKey
    key: Q5YekH1w5J0ff+fOcFiMB/1DGVvaei8n4NqGQBgw9/0=
  delegator_shares: "70000000000000000000.000000000000000000"
  description:
    details: ""
    identity: ""
    moniker: demo
    security_contact: ""
    website: ""
  jailed: false
  min_self_delegation: "1"
  operator_address: seivaloper1h6fgfcy6tfw32vj0gw245zv4wzqvk458qyr3q9
  status: BOND_STATUS_BONDED
  tokens: "70000000000000000000"
  unbonding_height: "0"
  unbonding_time: "1970-01-01T00:00:00Z"
```