### PR TITLE
Revert EventAttribute field types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.171
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.179-0.20230315064114-c903df251edf
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.1.2 h1:jEYkZv83DbTRapJtkT5gBFa2uEBwD4udw8AiYx0gcsI=
 github.com/sei-protocol/sei-iavl v0.1.2/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
-github.com/sei-protocol/sei-tendermint v0.1.171 h1:G3ZRnQgiLQ06/3iKrj5UicpHfRWJWruaJFxVYHFOcjA=
-github.com/sei-protocol/sei-tendermint v0.1.171/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.1.179-0.20230315064114-c903df251edf h1:iUAAHcTCy78zmoSmWQWWwxL8q/8qGyKQBI+wBbscp98=
+github.com/sei-protocol/sei-tendermint v0.1.179-0.20230315064114-c903df251edf/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/store/cachekv/mergeiterator_test.go
+++ b/store/cachekv/mergeiterator_test.go
@@ -36,10 +36,10 @@ func TestEmitEventMangerInIterator(t *testing.T) {
 	iter.Value()
 
 	// assert the resource access is still emitted correctly when the cache store is unavailable
-	require.Equal(t, "access_type", eventManager.Events()[0].Attributes[0].Key)
-	require.Equal(t, "read", eventManager.Events()[0].Attributes[0].Value)
-	require.Equal(t, "store_key", eventManager.Events()[0].Attributes[1].Key)
-	require.Equal(t, "CacheKvTest", eventManager.Events()[0].Attributes[1].Value)
+	require.Equal(t, "access_type", string(eventManager.Events()[0].Attributes[0].Key))
+	require.Equal(t, "read", string(eventManager.Events()[0].Attributes[0].Value))
+	require.Equal(t, "store_key", string(eventManager.Events()[0].Attributes[1].Key))
+	require.Equal(t, "CacheKvTest", string(eventManager.Events()[0].Attributes[1].Value))
 
 	// assert event emission when cache is available
 	cache = kvstore.Iterator(keys[1], keys[2])
@@ -49,8 +49,8 @@ func TestEmitEventMangerInIterator(t *testing.T) {
 	iter.Value()
 
 	// assert the resource access is still emitted correctly when the cache store is available
-	require.Equal(t, "access_type", eventManager.Events()[0].Attributes[0].Key)
-	require.Equal(t, "read", eventManager.Events()[0].Attributes[0].Value)
-	require.Equal(t, "store_key", eventManager.Events()[0].Attributes[1].Key)
-	require.Equal(t, "CacheKvTest", eventManager.Events()[0].Attributes[1].Value)
+	require.Equal(t, "access_type", string(eventManager.Events()[0].Attributes[0].Key))
+	require.Equal(t, "read", string(eventManager.Events()[0].Attributes[0].Value))
+	require.Equal(t, "store_key", string(eventManager.Events()[0].Attributes[1].Key))
+	require.Equal(t, "CacheKvTest", string(eventManager.Events()[0].Attributes[1].Value))
 }

--- a/types/accesscontrol/comparator.go
+++ b/types/accesscontrol/comparator.go
@@ -49,14 +49,14 @@ func BuildComparatorFromEvents(events []abci.Event, storeKeyToResourceTypePrefix
 		accessType := AccessType_UNKNOWN
 		storeKey := ""
 		for _, attribute := range attributes {
-			if attribute.Key == "key" {
-				identifier = attribute.Value
+			if string(attribute.Key) == "key" {
+				identifier = string(attribute.Value)
 			}
-			if attribute.Key == "access_type" {
-				accessType = AccessTypeStringToEnum(attribute.Value)
+			if string(attribute.Key) == "access_type" {
+				accessType = AccessTypeStringToEnum(string(attribute.Value))
 			}
-			if attribute.Key == "store_key" {
-				storeKey = attribute.Value
+			if string(attribute.Key) == "store_key" {
+				storeKey = string(attribute.Value)
 			}
 		}
 

--- a/types/accesscontrol/validation_test.go
+++ b/types/accesscontrol/validation_test.go
@@ -96,8 +96,8 @@ func TestValidateAccessOperations(t *testing.T) {
 							{
 								Type: "resource_access",
 								Attributes: []abci.EventAttribute{
-									{Key: "key", Value: "a/b/c/d/e"},
-									{Key: "access_type", Value: "write"},
+									{Key: []byte("key"), Value: []byte("a/b/c/d/e")},
+									{Key: []byte("access_type"), Value: []byte("write")},
 								},
 							},
 						},
@@ -114,9 +114,9 @@ func TestValidateAccessOperations(t *testing.T) {
 							{
 								Type: "resource_access",
 								Attributes: []abci.EventAttribute{
-									{Key: "key", Value: "a/b/c/d/e"},
-									{Key: "access_type", Value: "write"},
-									{Key: "store_key", Value: "storex"},
+									{Key: []byte("key"), Value: []byte("a/b/c/d/e")},
+									{Key: []byte("access_type"), Value: []byte("write")},
+									{Key: []byte("store_key"), Value: []byte("storex")},
 								},
 							},
 						},
@@ -145,8 +145,8 @@ func TestValidateAccessOperations(t *testing.T) {
 							{
 								Type: "resource_access",
 								Attributes: []abci.EventAttribute{
-									{Key: "key", Value: "abc/defg/e"},
-									{Key: "access_type", Value: "write"},
+									{Key: []byte("key"), Value: []byte("abc/defg/e")},
+									{Key: []byte("access_type"), Value: []byte("write")},
 								},
 							},
 						},
@@ -163,9 +163,9 @@ func TestValidateAccessOperations(t *testing.T) {
 							{
 								Type: "resource_access",
 								Attributes: []abci.EventAttribute{
-									{Key: "key", Value: "abc/defg/e"},
-									{Key: "access_type", Value: "write"},
-									{Key: "store_key", Value: "ParentNode"},
+									{Key: []byte("key"), Value: []byte("abc/defg/e")},
+									{Key: []byte("access_type"), Value: []byte("write")},
+									{Key: []byte("store_key"), Value: []byte("ParentNode")},
 								},
 							},
 						},
@@ -182,9 +182,9 @@ func TestValidateAccessOperations(t *testing.T) {
 							{
 								Type: "resource_access",
 								Attributes: []abci.EventAttribute{
-									{Key: "key", Value: "abc/defg/e"},
-									{Key: "access_type", Value: "write"},
-									{Key: "store_key", Value: "ParentNode"},
+									{Key: []byte("key"), Value: []byte("abc/defg/e")},
+									{Key: []byte("access_type"), Value: []byte("write")},
+									{Key: []byte("store_key"), Value: []byte("ParentNode")},
 								},
 							},
 						},
@@ -201,9 +201,9 @@ func TestValidateAccessOperations(t *testing.T) {
 							{
 								Type: "resource_access",
 								Attributes: []abci.EventAttribute{
-									{Key: "key", Value: "abc/defg/e"},
-									{Key: "access_type", Value: "write"},
-									{Key: "store_key", Value: "ParentNode"},
+									{Key: []byte("key"), Value: []byte("abc/defg/e")},
+									{Key: []byte("access_type"), Value: []byte("write")},
+									{Key: []byte("store_key"), Value: []byte("ParentNode")},
 								},
 							},
 						},

--- a/types/events.go
+++ b/types/events.go
@@ -154,8 +154,8 @@ func TypedEventToEvent(tev proto.Message) (Event, error) {
 	for _, k := range keys {
 		v := attrMap[k]
 		attrs = append(attrs, abci.EventAttribute{
-			Key:   k,
-			Value: string(v),
+			Key:   []byte(k),
+			Value: v,
 		})
 	}
 
@@ -242,7 +242,7 @@ func (a Attribute) String() string {
 
 // ToKVPair converts an Attribute object into a Tendermint key/value pair.
 func (a Attribute) ToKVPair() abci.EventAttribute {
-	return abci.EventAttribute{Key: a.Key, Value: a.Value}
+	return abci.EventAttribute{Key: []byte(a.Key), Value: []byte(a.Value)}
 }
 
 // AppendAttributes adds one or more attributes to an Event.

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -139,15 +139,15 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 		{
 			Type: "message",
 			Attributes: []abci.EventAttribute{
-				{Key: "sender", Value: "foo"},
-				{Key: "recipient", Value: "bar"},
+				{Key: []byte("sender"), Value: []byte("foo")},
+				{Key: []byte("recipient"), Value: []byte("bar")},
 			},
 		},
 		{
 			Type: "staking",
 			Attributes: []abci.EventAttribute{
-				{Key: "deposit", Value: "5"},
-				{Key: "unbond", Value: "10"},
+				{Key: []byte("deposit"), Value: []byte("5")},
+				{Key: []byte("unbond"), Value: []byte("10")},
 			},
 		},
 	}
@@ -163,15 +163,15 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 				{
 					Type: "message",
 					Attributes: []abci.EventAttribute{
-						{Key: "sender", Value: "foo", Index: true},
-						{Key: "recipient", Value: "bar", Index: true},
+						{Key: []byte("sender"), Value: []byte("foo"), Index: true},
+						{Key: []byte("recipient"), Value: []byte("bar"), Index: true},
 					},
 				},
 				{
 					Type: "staking",
 					Attributes: []abci.EventAttribute{
-						{Key: "deposit", Value: "5", Index: true},
-						{Key: "unbond", Value: "10", Index: true},
+						{Key: []byte("deposit"), Value: []byte("5"), Index: true},
+						{Key: []byte("unbond"), Value: []byte("10"), Index: true},
 					},
 				},
 			},
@@ -183,15 +183,15 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 				{
 					Type: "message",
 					Attributes: []abci.EventAttribute{
-						{Key: "sender", Value: "foo", Index: true},
-						{Key: "recipient", Value: "bar"},
+						{Key: []byte("sender"), Value: []byte("foo"), Index: true},
+						{Key: []byte("recipient"), Value: []byte("bar")},
 					},
 				},
 				{
 					Type: "staking",
 					Attributes: []abci.EventAttribute{
-						{Key: "deposit", Value: "5", Index: true},
-						{Key: "unbond", Value: "10"},
+						{Key: []byte("deposit"), Value: []byte("5"), Index: true},
+						{Key: []byte("unbond"), Value: []byte("10")},
 					},
 				},
 			},
@@ -206,15 +206,15 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 				{
 					Type: "message",
 					Attributes: []abci.EventAttribute{
-						{Key: "sender", Value: "foo", Index: true},
-						{Key: "recipient", Value: "bar", Index: true},
+						{Key: []byte("sender"), Value: []byte("foo"), Index: true},
+						{Key: []byte("recipient"), Value: []byte("bar"), Index: true},
 					},
 				},
 				{
 					Type: "staking",
 					Attributes: []abci.EventAttribute{
-						{Key: "deposit", Value: "5", Index: true},
-						{Key: "unbond", Value: "10", Index: true},
+						{Key: []byte("deposit"), Value: []byte("5"), Index: true},
+						{Key: []byte("unbond"), Value: []byte("10"), Index: true},
 					},
 				},
 			},

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -168,8 +168,8 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 					Type: "message",
 					Attributes: []abci.EventAttribute{
 						{
-							Key:   "action",
-							Value: "foo",
+							Key:   []byte("action"),
+							Value: []byte("foo"),
 							Index: true,
 						},
 					},
@@ -201,8 +201,8 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 				Type: "message",
 				Attributes: []abci.EventAttribute{
 					{
-						Key:   "action",
-						Value: "foo",
+						Key:   []byte("action"),
+						Value: []byte("foo"),
 						Index: true,
 					},
 				},

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -127,7 +127,7 @@ func (k Keeper) DispatchActions(ctx sdk.Context, grantee sdk.AccAddress, msgs []
 		sdkEvents := make([]sdk.Event, 0, len(events))
 		for _, event := range events {
 			e := event
-			e.Attributes = append(e.Attributes, abci.EventAttribute{Key: "authz_msg_index", Value: strconv.Itoa(i)})
+			e.Attributes = append(e.Attributes, abci.EventAttribute{Key: []byte("authz_msg_index"), Value: []byte(strconv.Itoa(i))})
 
 			sdkEvents = append(sdkEvents, sdk.Event(e))
 		}

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -667,15 +667,15 @@ func (suite *IntegrationTestSuite) TestMsgSendEvents() {
 	}
 	event1.Attributes = append(
 		event1.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeyRecipient, Value: addr2.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr2.String())},
 	)
 	event1.Attributes = append(
 		event1.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeySender, Value: addr.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
 	)
 	event1.Attributes = append(
 		event1.Attributes,
-		abci.EventAttribute{Key: sdk.AttributeKeyAmount, Value: newCoins.String()},
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(newCoins.String())},
 	)
 
 	event2 := sdk.Event{
@@ -684,7 +684,7 @@ func (suite *IntegrationTestSuite) TestMsgSendEvents() {
 	}
 	event2.Attributes = append(
 		event2.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeySender, Value: addr.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
 	)
 
 	// events are shifted due to the funding account events
@@ -738,7 +738,7 @@ func (suite *IntegrationTestSuite) TestMsgMultiSendEvents() {
 	}
 	event1.Attributes = append(
 		event1.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeySender, Value: addr.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
 	)
 	suite.Require().Equal(abci.Event(event1), events[7])
 
@@ -760,7 +760,7 @@ func (suite *IntegrationTestSuite) TestMsgMultiSendEvents() {
 	}
 	event2.Attributes = append(
 		event2.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeySender, Value: addr2.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr2.String())},
 	)
 	event3 := sdk.Event{
 		Type:       types.EventTypeTransfer,
@@ -768,22 +768,22 @@ func (suite *IntegrationTestSuite) TestMsgMultiSendEvents() {
 	}
 	event3.Attributes = append(
 		event3.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeyRecipient, Value: addr3.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr3.String())},
 	)
 	event3.Attributes = append(
 		event3.Attributes,
-		abci.EventAttribute{Key: sdk.AttributeKeyAmount, Value: newCoins.String()})
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(newCoins.String())})
 	event4 := sdk.Event{
 		Type:       types.EventTypeTransfer,
 		Attributes: []abci.EventAttribute{},
 	}
 	event4.Attributes = append(
 		event4.Attributes,
-		abci.EventAttribute{Key: types.AttributeKeyRecipient, Value: addr4.String()},
+		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr4.String())},
 	)
 	event4.Attributes = append(
 		event4.Attributes,
-		abci.EventAttribute{Key: sdk.AttributeKeyAmount, Value: newCoins2.String()},
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(newCoins2.String())},
 	)
 	// events are shifted due to the funding account events
 	suite.Require().Equal(abci.Event(event1), events[21])


### PR DESCRIPTION
## Describe your changes and provide context
This PR updates EventAttribute `key` and `value` data type. Please find details in this PR https://github.com/sei-protocol/sei-tendermint/pull/85

## Testing performed to validate your change
- unit test
