### PR TITLE
Fix IAVL Read/Write race conditions for Tree 

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -67,8 +67,6 @@ type Store struct {
 	interBlockCache types.MultiStorePersistentCache
 
 	listeners map[types.StoreKey][]types.WriteListener
-
-	storeMtx *sync.RWMutex
 }
 
 var (
@@ -105,7 +103,6 @@ func NewStore(db dbm.DB, logger log.Logger) *Store {
 		keysByName:          make(map[string]types.StoreKey),
 		pruneHeights:        make([]int64, 0),
 		listeners:           make(map[types.StoreKey][]types.WriteListener),
-		storeMtx: 			 &sync.RWMutex{},
 	}
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -67,6 +67,8 @@ type Store struct {
 	interBlockCache types.MultiStorePersistentCache
 
 	listeners map[types.StoreKey][]types.WriteListener
+
+	storeMtx *sync.RWMutex
 }
 
 var (
@@ -103,6 +105,7 @@ func NewStore(db dbm.DB, logger log.Logger) *Store {
 		keysByName:          make(map[string]types.StoreKey),
 		pruneHeights:        make([]int64, 0),
 		listeners:           make(map[types.StoreKey][]types.WriteListener),
+		storeMtx: 			 &sync.RWMutex{},
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Both are caused by creating readonly copies when there's an incoming query request, and caused by the check in getImmutable and commit, most likely the different goroutines that is handling the consensus updating the state and creating query contexts when the RPC endpoint gets requests 

```
==================
WARNING: DATA RACE
Read at 0x00c01fd0c9b0 by goroutine 1976126:
  github.com/cosmos/iavl.(*MutableTree).VersionExists()
      /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.3/mutable_tree.go:75 +0x79
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).VersionExists()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.3/store/iavl/store.go:184 +0x51
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).GetImmutable()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.3/store/iavl/store.go:114 +0x54
  github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).CacheMultiStoreWithVersion()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.3/store/rootmulti/store.go:574 +0x258

Previous write at 0x00c01fd0c9b0 by goroutine 41258:
  github.com/cosmos/iavl.(*ImmutableTree).clone()
      /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.3/immutable_tree.go:325 +0xf26
  github.com/cosmos/iavl.(*MutableTree).SaveVersion()
      /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.3/mutable_tree.go:931 +0xd3f
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).Commit()
      /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.3/store/iavl/store.go:143 +0xdd
  github.com/cosmos/cosmos-sdk/store/cache.(*CommitKVStoreCache).Commit()
```

```
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]: ==================
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]: WARNING: DATA RACE
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]: Write at 0x00c00028ad70 by goroutine 10269:
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/iavl.(*MutableTree).SaveVersion()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.2-tony-3/mutable_tree.go:931 +0xf67
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/iavl.(*Store).Commit()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/store/iavl/store.go:143 +0xdd
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/cache.(*CommitKVStoreCache).Commit()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       <autogenerated>:1 +0x5e
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/rootmulti.commitStores()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/store/rootmulti/store.go:1046 +0x190
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).Commit()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/store/rootmulti/store.go:466 +0x1e9
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Commit()

Mar 10 14:30:01 ip-172-31-38-203 seid[171486]: Previous read at 0x00c00028ad70 by goroutine 248759:
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/iavl.(*MutableTree).VersionExists()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.2-tony-3/mutable_tree.go:75 +0x58
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/iavl.(*Store).VersionExists()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/store/iavl/store.go:184 +0x51
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/iavl.(*Store).GetImmutable()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/store/iavl/store.go:114 +0x54
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).CacheMultiStoreWithVersion()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/store/rootmulti/store.go:565 +0x248
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).createQueryContext()
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:       /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.1-tony-2/baseapp/abci.go:669 +0x202
Mar 10 14:30:01 ip-172-31-38-203 seid[171486]:   github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func1()
```

## Testing performed to validate your change

Created test cluster, block times seem okay with 4 nodes
![image](https://user-images.githubusercontent.com/18161326/225358919-301cf4d4-fde2-4734-bd3c-8bb5554965d1.png)
