### PR TITLE
Hot fix for max gas change

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -680,15 +680,13 @@ func (app *BaseApp) getMaximumBlockGas(ctx sdk.Context) uint64 {
 
 	maxGas := cp.Block.MaxGas
 
+	// TODO::: This is a temporary fix, max gas causes non-deterministic behavior
+	// 			with parallel TX
 	switch {
 	case maxGas < -1:
 		panic(fmt.Sprintf("invalid maximum block gas: %d", maxGas))
-
-	case maxGas == -1:
-		return 0
-
 	default:
-		return uint64(maxGas)
+		return 0
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
parallel TX with max gas causes TX to fail nondeterministically once the limit is exceeded because they're being executed concurrently

This is a hotfix that should be rolled back 
## Testing performed to validate your change

