### PR TITLE
Bump default cache size to 4 mil

### DIFF
--- a/store/types/cache.go
+++ b/store/types/cache.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 )
 
-const DefaultCacheSizeLimit = 2000000 // TODO: revert back to 1000000
+const DefaultCacheSizeLimit = 4000000 // TODO: revert back to 1000000 after paritioning r/w caches
 
 // If value is nil but deleted is false, it means the parent doesn't have the
 // key.  (No need to delete upon Write())


### PR DESCRIPTION
## Describe your changes and provide context

Setting it to 4mil just to be entirely safe as this snapshot is a couple days behind and our atlantic-2 upgrade will be in a couple days 

```
root@ip-172-31-41-169:/home/ubuntu# cat ~/state_3710336/staking.data | tail
  P3710333 | HistoricalInfo | Height: 3710333
    DCC2084611C6A6B242347F14DD0B230DDAA6C9B5F038179E783A28E42E59D79B
  P3710334 | HistoricalInfo | Height: 3710334
    570C7F6DA9BE809B4A7336D788A5558D1773CEB6548674D3B8B9370241A17B01
  P3710335 | HistoricalInfo | Height: 3710335
    84CD8E6F6E4A8139640D5CAE24695D865FD0ECC032120C3375EE687891F25F41
  P3710336 | HistoricalInfo | Height: 3710336
    3BEEAF3B1A611A3B001A627581173932DEC22193C03D3D87EB5BDEBA68312CCA
Hash: B539FCFE14CDB88AFA7577163BF1FD60E47DE7DE6D87E3AE7CB6ED84C57C9CBF
Size: 26A20E
```

## Testing performed to validate your change

![image](https://user-images.githubusercontent.com/18161326/227998932-c9e7a5ca-0b24-4425-a742-d81fccef2be5.png)


