### PR TITLE
Make Fixes for event fields reverting to byte

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.171
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.182
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.1.2 h1:jEYkZv83DbTRapJtkT5gBFa2uEBwD4udw8AiYx0gcsI=
 github.com/sei-protocol/sei-iavl v0.1.2/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
-github.com/sei-protocol/sei-tendermint v0.1.171 h1:G3ZRnQgiLQ06/3iKrj5UicpHfRWJWruaJFxVYHFOcjA=
-github.com/sei-protocol/sei-tendermint v0.1.171/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.1.182 h1:nEeHd5LzdpA6CnFbXQuIoNE2an3eHwc9S7Wc0S7rUxs=
+github.com/sei-protocol/sei-tendermint v0.1.182/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/types/accesscontrol/comparator.go
+++ b/types/accesscontrol/comparator.go
@@ -49,14 +49,14 @@ func BuildComparatorFromEvents(events []abci.Event, storeKeyToResourceTypePrefix
 		accessType := AccessType_UNKNOWN
 		storeKey := ""
 		for _, attribute := range attributes {
-			if attribute.Key == "key" {
-				identifier = attribute.Value
+			if string(attribute.Key) == "key" {
+				identifier = string(attribute.Value)
 			}
-			if attribute.Key == "access_type" {
-				accessType = AccessTypeStringToEnum(attribute.Value)
+			if string(attribute.Key) == "access_type" {
+				accessType = AccessTypeStringToEnum(string(attribute.Value))
 			}
-			if attribute.Key == "store_key" {
-				storeKey = attribute.Value
+			if string(attribute.Key) == "store_key" {
+				storeKey = string(attribute.Value)
 			}
 		}
 

--- a/types/events.go
+++ b/types/events.go
@@ -154,8 +154,8 @@ func TypedEventToEvent(tev proto.Message) (Event, error) {
 	for _, k := range keys {
 		v := attrMap[k]
 		attrs = append(attrs, abci.EventAttribute{
-			Key:   k,
-			Value: string(v),
+			Key:   []byte(k),
+			Value: []byte(v),
 		})
 	}
 
@@ -242,7 +242,7 @@ func (a Attribute) String() string {
 
 // ToKVPair converts an Attribute object into a Tendermint key/value pair.
 func (a Attribute) ToKVPair() abci.EventAttribute {
-	return abci.EventAttribute{Key: a.Key, Value: a.Value}
+	return abci.EventAttribute{Key: []byte(a.Key), Value: []byte(a.Value)}
 }
 
 // AppendAttributes adds one or more attributes to an Event.

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -127,7 +127,7 @@ func (k Keeper) DispatchActions(ctx sdk.Context, grantee sdk.AccAddress, msgs []
 		sdkEvents := make([]sdk.Event, 0, len(events))
 		for _, event := range events {
 			e := event
-			e.Attributes = append(e.Attributes, abci.EventAttribute{Key: "authz_msg_index", Value: strconv.Itoa(i)})
+			e.Attributes = append(e.Attributes, abci.EventAttribute{Key: []byte("authz_msg_index"), Value: []byte(strconv.Itoa(i))})
 
 			sdkEvents = append(sdkEvents, sdk.Event(e))
 		}


### PR DESCRIPTION
## Describe your changes and provide context
This PR changes the fields back to []byte so this breaks some of the calls in the higher level repos:
https://github.com/sei-protocol/sei-tendermint/commit/4cf90c8c759d50a97aad8a6d5f26c6e8802cf31d

## Testing performed to validate your change
Builds 
