### PR TITLE
Fix seid export flag

### DIFF
--- a/server/export.go
+++ b/server/export.go
@@ -67,6 +67,11 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 			forZeroHeight, _ := cmd.Flags().GetBool(FlagForZeroHeight)
 			jailAllowedAddrs, _ := cmd.Flags().GetStringSlice(FlagJailAllowedAddrs)
 
+			chainID, err := getAndValidateChainId(cmd)
+			if err != nil {
+				return err
+			}
+			serverCtx.Viper.Set(flags.FlagChainID, chainID)
 			exported, err := appExporter(serverCtx.Logger, db, traceWriter, height, forZeroHeight, jailAllowedAddrs, serverCtx.Viper)
 			if err != nil {
 				return fmt.Errorf("error exporting state: %v", err)
@@ -112,6 +117,7 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 	cmd.Flags().Int64(FlagHeight, -1, "Export state from a particular height (-1 means latest height)")
 	cmd.Flags().Bool(FlagForZeroHeight, false, "Export state to start at height zero (perform preproccessing)")
 	cmd.Flags().StringSlice(FlagJailAllowedAddrs, []string{}, "Comma-separated list of operator addresses of jailed validators to unjail")
+	cmd.Flags().String(FlagChainID, "", "Chain ID")
 
 	return cmd
 }

--- a/server/export.go
+++ b/server/export.go
@@ -67,11 +67,6 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 			forZeroHeight, _ := cmd.Flags().GetBool(FlagForZeroHeight)
 			jailAllowedAddrs, _ := cmd.Flags().GetStringSlice(FlagJailAllowedAddrs)
 
-			chainID, err := getAndValidateChainId(cmd)
-			if err != nil {
-				return err
-			}
-			serverCtx.Viper.Set(flags.FlagChainID, chainID)
 			exported, err := appExporter(serverCtx.Logger, db, traceWriter, height, forZeroHeight, jailAllowedAddrs, serverCtx.Viper)
 			if err != nil {
 				return fmt.Errorf("error exporting state: %v", err)

--- a/server/start.go
+++ b/server/start.go
@@ -25,7 +25,6 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server/api"
@@ -140,25 +139,14 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 				}()
 			}
 
-			clientCtx, err := client.GetClientQueryContext(cmd)
+			chainID, err := getAndValidateChainId(cmd)
 			if err != nil {
 				return err
 			}
-			clientCtx, err = clientconfig.ReadFromClientConfig(clientCtx)
-			if err != nil {
-				return err
-			}
-
-			chainID := clientCtx.ChainID
-			flagChainID, _ := cmd.Flags().GetString(FlagChainID)
-			if flagChainID != "" {
-				if flagChainID != chainID {
-					panic(fmt.Sprintf("chain-id mismatch: %s vs %s. The chain-id passed in is different from the value in ~/.sei/config/client.toml \n", flagChainID, chainID))
-				}
-				chainID = flagChainID
-			}
+			
 			serverCtx.Viper.Set(flags.FlagChainID, chainID)
 
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			genesisFile, _ := tmtypes.GenesisDocFromFile(serverCtx.Config.GenesisFile())
 			if genesisFile.ChainID != clientCtx.ChainID {
 				panic(fmt.Sprintf("genesis file chain-id=%s does not equal config.toml chain-id=%s", genesisFile.ChainID, clientCtx.ChainID))

--- a/server/util.go
+++ b/server/util.go
@@ -3,8 +3,6 @@ package server
 import (
 	"errors"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client"
-	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
 	"io"
 	"net"
 	"os"
@@ -440,25 +438,4 @@ func openTraceWriter(traceWriterFile string) (w io.Writer, err error) {
 		os.O_WRONLY|os.O_APPEND|os.O_CREATE,
 		0666,
 	)
-}
-
-func getAndValidateChainId(cmd *cobra.Command) (chainID string, err error) {
-	clientCtx, err := client.GetClientQueryContext(cmd)
-	if err != nil {
-		return "", err
-	}
-	clientCtx, err = clientconfig.ReadFromClientConfig(clientCtx)
-	if err != nil {
-		return "", err
-	}
-
-	chainID = clientCtx.ChainID
-	flagChainID, _ := cmd.Flags().GetString(FlagChainID)
-	if flagChainID != "" {
-		if flagChainID != chainID {
-			panic(fmt.Sprintf("chain-id mismatch: %s vs %s. The chain-id passed in is different from the value in ~/.sei/config/client.toml \n", flagChainID, chainID))
-		}
-		chainID = flagChainID
-	}
-	return chainID, nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
Seid export was previously broken b/c it didn't detect the chainID. Refactor the logic for seid start to use in both
## Testing performed to validate your change
Verified the following:
- seid start
- seid start --chain-id
- seid export
- seid export --chain-id

