### PR TITLE
Check config.toml log-level and log-format

### DIFF
--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"context"
 
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
-	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -29,8 +27,9 @@ func Execute(rootCmd *cobra.Command, defaultHome string) error {
 	ctx = context.WithValue(ctx, client.ClientContextKey, &client.Context{})
 	ctx = context.WithValue(ctx, server.ServerContextKey, srvCtx)
 
-	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic)")
-	rootCmd.PersistentFlags().String(flags.FlagLogFormat, log.LogFormatPlain, "The logging format (json|plain)")
+	// Config.toml not yet initialized so we can't use the config file to set
+	rootCmd.PersistentFlags().String(flags.FlagLogLevel, "", "The logging level (trace|debug|info|warn|error|fatal|panic)")
+	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "", "The logging format (json|plain)")
 
 	executor := tmcli.PrepareBaseCmd(rootCmd, "", defaultHome)
 	return executor.ExecuteContext(ctx)

--- a/server/util.go
+++ b/server/util.go
@@ -141,13 +141,20 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 	}
 
 	var logWriter io.Writer
-	if strings.ToLower(serverCtx.Viper.GetString(flags.FlagLogFormat)) == tmlog.LogFormatPlain {
+	logLvlFormat := serverCtx.Viper.GetString(flags.FlagLogFormat)
+	if logLvlFormat == "" {
+		logLvlFormat = serverCtx.Config.LogFormat
+	}
+	if strings.ToLower(logLvlFormat) == tmlog.LogFormatPlain {
 		logWriter = zerolog.ConsoleWriter{Out: os.Stderr}
 	} else {
 		logWriter = os.Stderr
 	}
 
 	logLvlStr := serverCtx.Viper.GetString(flags.FlagLogLevel)
+	if logLvlStr == "" {
+		logLvlStr = serverCtx.Config.LogLevel
+	}
 	logLvl, err := zerolog.ParseLevel(logLvlStr)
 	if err != nil {
 		return fmt.Errorf("failed to parse log level (%s): %w", logLvlStr, err)


### PR DESCRIPTION
## Describe your changes and provide context
It defaults to info and plain so it never checks the config.toml log-level

## Testing performed to validate your change

![image](https://user-images.githubusercontent.com/18161326/231557725-15dc73fc-e5e3-4261-9aec-11fafb4ebacd.png)

![image](https://user-images.githubusercontent.com/18161326/231557804-1cb90ee0-6758-425a-8f00-cb72535bdbbc.png)

![image](https://user-images.githubusercontent.com/18161326/231557769-cbed9d35-7010-47d7-9fa7-bd902311d5a5.png)
