### PR TITLE
Restart node instead of panicing and exiting 

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1092,3 +1092,10 @@ func (app *BaseApp) startCompactionRoutine(db dbm.DB) {
 		}
 	}()
 }
+
+func (app *BaseApp) Close() error {
+	if err := app.appStore.db.Close(); err != nil {
+		return err
+	}
+	return app.snapshotManager.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.1
+	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/btcd v0.1.1
 	github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15
 	github.com/tendermint/go-amino v0.16.0
@@ -119,7 +120,6 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.0 // indirect
-	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -145,7 +145,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.1.181
+	github.com/tendermint/tendermint => ../sei-tendermint //github.com/sei-protocol/sei-tendermint v0.1.181
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => ../sei-tendermint //github.com/sei-protocol/sei-tendermint v0.1.181
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.6
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.6
+	github.com/tendermint/tendermint => github.com/sei-protocol/sei-tendermint v0.2.7
 
 	// latest grpc doesn't work with with our modified proto compiler, so we need to enforce
 	// the following version across all dependencies.

--- a/go.sum
+++ b/go.sum
@@ -689,6 +689,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.1.2 h1:jEYkZv83DbTRapJtkT5gBFa2uEBwD4udw8AiYx0gcsI=
 github.com/sei-protocol/sei-iavl v0.1.2/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
+github.com/sei-protocol/sei-tendermint v0.2.6 h1:1jY2Hjx48OFRKeu/Ae9PGk/cZpWjfEVXlPai56jxAV4=
+github.com/sei-protocol/sei-tendermint v0.2.6/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.1.2 h1:jEYkZv83DbTRapJtkT5gBFa2uEBwD4udw8AiYx0gcsI=
 github.com/sei-protocol/sei-iavl v0.1.2/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
-github.com/sei-protocol/sei-tendermint v0.2.6 h1:1jY2Hjx48OFRKeu/Ae9PGk/cZpWjfEVXlPai56jxAV4=
-github.com/sei-protocol/sei-tendermint v0.2.6/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
+github.com/sei-protocol/sei-tendermint v0.2.7 h1:uVweGrk1pa3Dla/i6fv/mJY0rGd18tgK+q4dxT6LxzM=
+github.com/sei-protocol/sei-tendermint v0.2.7/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sei-protocol/sei-iavl v0.1.2 h1:jEYkZv83DbTRapJtkT5gBFa2uEBwD4udw8AiYx0gcsI=
 github.com/sei-protocol/sei-iavl v0.1.2/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
-github.com/sei-protocol/sei-tendermint v0.1.181 h1:ycC21MKAorOGFhdzN5HjZlA0qtIAX4iMlXTSErTLqtM=
-github.com/sei-protocol/sei-tendermint v0.1.181/go.mod h1:+BtDvAwTkE64BlxzpH9ZP7S6vUYT9wRXiZa/WW8/o4g=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -89,16 +89,10 @@ func New(clientCtx client.Context, logger log.Logger) *Server {
 // JSON RPC server. Configuration options are provided via config.APIConfig
 // and are delegated to the Tendermint JSON RPC server. The process is
 // non-blocking, so an external signal handler must be used.
-func (s *Server) Start(cfg config.Config) error {
+func (s *Server) Start(cfg config.Config, apiMetrics *telemetry.Metrics) error {
 	s.mtx.Lock()
 	if cfg.Telemetry.Enabled {
-		m, err := telemetry.New(cfg.Telemetry)
-		if err != nil {
-			s.mtx.Unlock()
-			return err
-		}
-
-		s.metrics = m
+		s.metrics = apiMetrics
 		s.registerMetrics()
 	}
 

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -56,6 +56,9 @@ type (
 
 		// CommitMultiStore Returns the multistore instance
 		CommitMultiStore() sdk.CommitMultiStore
+
+		// Close any open resources
+		Close() error
 	}
 
 	// AppCreator is a function that allows us to lazily initialize an

--- a/server/util.go
+++ b/server/util.go
@@ -39,6 +39,9 @@ import (
 // a command's Context.
 const ServerContextKey = sdk.ContextKey("server.context")
 
+// Error code reserved for signalled
+const RestartErrorCode = 100
+
 // server context
 type Context struct {
 	Viper  *viper.Viper
@@ -391,7 +394,7 @@ func WaitForQuitSignals(restartCh chan struct{}) ErrorCode {
 			case sig := <-sigs:
 				return ErrorCode{Code: int(sig.(syscall.Signal)) + 128}
 			case <-restartCh:
-				return ErrorCode{Code: 1}
+				return ErrorCode{Code: RestartErrorCode}
 			}
 		}
 	} else {

--- a/snapshots/manager.go
+++ b/snapshots/manager.go
@@ -78,6 +78,10 @@ func NewManagerWithExtensions(store *Store, multistore types.Snapshotter, extens
 	}
 }
 
+func (m *Manager) Close() error {
+	return m.store.db.Close()
+}
+
 // RegisterExtensions register extension snapshotters to manager
 func (m *Manager) RegisterExtensions(extensions ...types.ExtensionSnapshotter) error {
 	for _, extension := range extensions {

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/codec"
 	tmtime "github.com/cosmos/cosmos-sdk/std"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/node"
@@ -59,6 +60,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		abciclient.NewLocalClient(logger, app),
 		defaultGensis,
 		[]trace.TracerProviderOption{},
+		node.NoOpMetricsProvider(),
 	)
 
 	if err != nil {
@@ -95,7 +97,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		errCh := make(chan error)
 
 		go func() {
-			if err := apiSrv.Start(*val.AppConfig); err != nil {
+			if err := apiSrv.Start(*val.AppConfig, &telemetry.Metrics{}); err != nil {
 				errCh <- err
 			}
 		}()


### PR DESCRIPTION
## Describe your changes and provide context
Currently the node will only switch into blocksync mode if the whole process is restarted, this change aims to add a detection go routine and restart the node if it's behind configurable 

## Testing performed to validate your change

Artificially introduced latency so that the node would fall behind, and see that it self restarted node 
![image](https://user-images.githubusercontent.com/18161326/232617966-22f628ba-a939-415d-a34a-e81bd218b6cd.png)

![image](https://user-images.githubusercontent.com/18161326/232618092-ce17acd5-24ff-45a0-8402-1d51f07fb4bb.png)
