### PR TITLE
[Oak Audit] Remove IsDefaultSynchronousAccessOps unused fn

### DIFF
--- a/x/accesscontrol/types/message_dependency_mapping.go
+++ b/x/accesscontrol/types/message_dependency_mapping.go
@@ -96,16 +96,6 @@ func SynchronousWasmDependencyMapping(contractAddress string) acltypes.WasmDepen
 	}
 }
 
-func IsDefaultSynchronousAccessOps(accessOps []acltypes.AccessOperation) bool {
-	defaultAccessOps := SynchronousAccessOps()
-	for index, accessOp := range accessOps {
-		if accessOp != defaultAccessOps[index] {
-			return false
-		}
-	}
-	return true
-}
-
 func IsDefaultSynchronousWasmAccessOps(accessOps []*acltypes.WasmAccessOperation) bool {
 	defaultAccessOps := SynchronousWasmAccessOps()
 	for index, accessOp := range accessOps {


### PR DESCRIPTION
## Describe your changes and provide context
- Remove `IsDefaultSynchronousAccessOps` unused fn
- Note this is different than package `accesscontrol` `IsDefaultSynchronousAccessOps`
## Testing performed to validate your change
- Tested on local chain
