### PR TITLE
Add checkTxResponse log to RPCResponse

### DIFF
--- a/types/result.go
+++ b/types/result.go
@@ -113,6 +113,7 @@ func newTxResponseCheckTx(res *ctypes.ResultBroadcastTxCommit) *TxResponse {
 		Codespace: res.CheckTx.Codespace,
 		Code:      res.CheckTx.Code,
 		Data:      strings.ToUpper(hex.EncodeToString(res.CheckTx.Data)),
+		RawLog:    res.CheckTx.Log,
 		GasWanted: res.CheckTx.GasWanted,
 	}
 }
@@ -154,6 +155,7 @@ func NewResponseFormatBroadcastTx(res *ctypes.ResultBroadcastTx) *TxResponse {
 		Code:      res.Code,
 		Codespace: res.Codespace,
 		Data:      res.Data.String(),
+		RawLog:    res.Log,
 		TxHash:    res.Hash.String(),
 	}
 }

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -150,6 +150,7 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 			Data:      nil,
 			GasWanted: 99,
 			Codespace: "codespace",
+			Log:       "rawlog",
 		},
 	}
 	deliverTxResult := &ctypes.ResultBroadcastTxCommit{
@@ -183,6 +184,7 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 		Codespace: "codespace",
 		Code:      90,
 		Data:      "",
+		RawLog:    "rawlog",
 		GasWanted: 99,
 	}
 	deliverWant := &sdk.TxResponse{


### PR DESCRIPTION
## Describe your changes and provide context
This change adds back the log string to the `rawLog` of the RPCResponse.

This and https://github.com/sei-protocol/sei-tendermint/pull/125 resolves the following issue:
```
On Cosmos Hub when a tx is broadcast with an incorrect sequence that endpoint will return a successful JSON RPC response with a payload that looks like this:

{"code":32,"codeSpace":"sdk","log":"account sequence mismatch, expected 3, got 4: incorrect account sequence","data":{},"events":[],"gasWanted":0,"gasUsed":0,"hash":{...}}


On the Sei node, when broadcasting a tx with incorrect sequence it returns a JSON RPC error response with an "Internal Error" code:

{"code":-32603,"message":"Internal error","data":"account sequence mismatch, expected 72, got 73: incorrect account sequence"}

```


## Testing performed to validate your change
- unit tests
- e2e test
