### PR TITLE
Deprecate LoadLatest flag

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -152,7 +152,7 @@ type BaseApp struct { //nolint: maligned
 
 	compactionInterval uint64
 
-	tmConfig *tmcfg.Config
+	TmConfig *tmcfg.Config
 }
 
 type appStore struct {
@@ -260,7 +260,7 @@ func NewBaseApp(
 }
 
 func (app *BaseApp) SetTendermintConfig(cfg *tmcfg.Config) {
-	app.tmConfig = cfg
+	app.TmConfig = cfg
 }
 
 // Name returns the name of the BaseApp.
@@ -1112,7 +1112,7 @@ func (app *BaseApp) ReloadDB() error {
 	if err := app.db.Close(); err != nil {
 		return err
 	}
-	db, err := sdk.NewLevelDB("application", app.tmConfig.DBDir())
+	db, err := sdk.NewLevelDB("application", app.TmConfig.DBDir())
 	if err != nil {
 		return err
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -80,8 +80,6 @@ type BaseConfig struct {
 	// CompactionInterval sets (in seconds) the interval between forced levelDB
 	// compaction. A value of 0 means no forced levelDB
 	CompactionInterval uint64 `mapstructure:"compaction-interval"`
-
-	LoadLatest bool `mapstructure:"load-latest"`
 }
 
 // APIConfig defines the API listener configuration.
@@ -225,7 +223,6 @@ func DefaultConfig() *Config {
 			IAVLCacheSize:       781250, // 50 MB
 			IAVLDisableFastNode: true,
 			CompactionInterval:  0,
-			LoadLatest:          true,
 		},
 		Telemetry: telemetry.Config{
 			Enabled:      false,
@@ -294,7 +291,6 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			IAVLCacheSize:       v.GetUint64("iavl-cache-size"),
 			IAVLDisableFastNode: v.GetBool("iavl-disable-fastnode"),
 			CompactionInterval:  v.GetUint64("compaction-interval"),
-			LoadLatest:          v.GetBool("load-latest"),
 		},
 		Telemetry: telemetry.Config{
 			ServiceName:             v.GetString("telemetry.service-name"),
@@ -348,12 +344,6 @@ func (c Config) ValidateBasic(tendermintConfig *tmcfg.Config) error {
 		return sdkerrors.ErrAppConfig.Wrapf(
 			"cannot enable state sync snapshots with '%s' pruning setting", storetypes.PruningOptionEverything,
 		)
-	}
-	if c.BaseConfig.LoadLatest && tendermintConfig.DBSync.Enable {
-		return sdkerrors.ErrAppConfig.Wrap("cannot load latest with DB sync enabled")
-	}
-	if !c.BaseConfig.LoadLatest && !tendermintConfig.DBSync.Enable {
-		return sdkerrors.ErrAppConfig.Wrap("shoulkd load latest with DB sync disabled")
 	}
 
 	return nil

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -65,9 +65,6 @@ min-retain-blocks = {{ .BaseConfig.MinRetainBlocks }}
 # InterBlockCache enables inter-block caching.
 inter-block-cache = {{ .BaseConfig.InterBlockCache }}
 
-# Whether to load the latest version of store immediately upon start
-load-latest = {{ .BaseConfig.LoadLatest }}
-
 # IndexEvents defines the set of events in the form {eventType}.{attributeKey},
 # which informs Tendermint what to index. If empty, all events will be indexed.
 #

--- a/server/start.go
+++ b/server/start.go
@@ -55,7 +55,6 @@ const (
 	FlagTracing            = "tracing"
 	FlagProfile            = "profile"
 	FlagInvCheckPeriod     = "inv-check-period"
-	FlagLoadLatest         = "load-latest"
 
 	FlagPruning            = "pruning"
 	FlagPruningKeepRecent  = "pruning-keep-recent"
@@ -241,7 +240,6 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint(FlagInvCheckPeriod, 0, "Assert registered invariants every N blocks")
 	cmd.Flags().Uint64(FlagMinRetainBlocks, 0, "Minimum block height offset during ABCI commit to prune Tendermint blocks")
 	cmd.Flags().Uint64(FlagCompactionInterval, 0, "Time interval in between forced levelDB compaction. 0 means no forced compaction.")
-	cmd.Flags().Bool(FlagLoadLatest, true, "Whether to load latest version from store immediately after app creation")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")


### PR DESCRIPTION
## Describe your changes and provide context
This flag is redundant since it should always be set to the opposite of DBSync.Enable (in tendermint config)

## Testing performed to validate your change
loadtest cluster

