### PR TITLE
replace snapshot manager multistore with new one after DBSync

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1118,5 +1118,8 @@ func (app *BaseApp) ReloadDB() error {
 	}
 	app.db = db
 	app.cms = store.NewCommitMultiStore(db)
+	if app.snapshotManager != nil {
+		app.snapshotManager.SetMultiStore(app.cms)
+	}
 	return nil
 }

--- a/snapshots/manager.go
+++ b/snapshots/manager.go
@@ -41,12 +41,12 @@ type restoreDone struct {
 // Although the ABCI interface (and this manager) passes chunks as byte slices, the internal
 // snapshot/restore APIs use IO streams (i.e. chan io.ReadCloser), for two reasons:
 //
-// 1) In the future, ABCI should support streaming. Consider e.g. InitChain during chain
-//    upgrades, which currently passes the entire chain state as an in-memory byte slice.
-//    https://github.com/tendermint/tendermint/issues/5184
+//  1. In the future, ABCI should support streaming. Consider e.g. InitChain during chain
+//     upgrades, which currently passes the entire chain state as an in-memory byte slice.
+//     https://github.com/tendermint/tendermint/issues/5184
 //
-// 2) io.ReadCloser streams automatically propagate IO errors, and can pass arbitrary
-//    errors via io.Pipe.CloseWithError().
+//  2. io.ReadCloser streams automatically propagate IO errors, and can pass arbitrary
+//     errors via io.Pipe.CloseWithError().
 type Manager struct {
 	store      *Store
 	multistore types.Snapshotter
@@ -76,6 +76,10 @@ func NewManagerWithExtensions(store *Store, multistore types.Snapshotter, extens
 		multistore: multistore,
 		extensions: extensions,
 	}
+}
+
+func (m *Manager) SetMultiStore(s types.Snapshotter) {
+	m.multistore = s
 }
 
 func (m *Manager) Close() error {


### PR DESCRIPTION
## Describe your changes and provide context
Snapshot manager is initialized with the old multistore which is closed when DBSync finishes. We need to replace the multistore with the new one after DBSync so that snapshot manager can continue to work.

`SetMultiStore` should be safe to call in `ReloadDB` since no snapshotting would be taking place during the call.

## Testing performed to validate your change
loadtest cluster

