### PR TITLE
Fix fee check for simulate mode

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -58,6 +58,7 @@ func (app *BaseApp) InitChain(ctx context.Context, req *abci.RequestInitChain) (
 		app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
 		app.StoreConsensusParams(app.prepareProposalState.ctx, req.ConsensusParams)
 		app.StoreConsensusParams(app.processProposalState.ctx, req.ConsensusParams)
+		app.StoreConsensusParams(app.checkState.ctx, req.ConsensusParams)
 	}
 
 	app.SetDeliverStateToCommit()

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1120,3 +1120,7 @@ func (app *BaseApp) ReloadDB() error {
 	}
 	return nil
 }
+
+func (app *BaseApp) GetCheckCtx() sdk.Context {
+	return app.checkState.ctx
+}

--- a/x/auth/ante/fee.go
+++ b/x/auth/ante/fee.go
@@ -13,7 +13,7 @@ import (
 
 // TxFeeChecker check if the provided fee is enough and returns the effective fee and tx priority,
 // the effective fee should be deducted later, and the priority should be returned in abci response.
-type TxFeeChecker func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error)
+type TxFeeChecker func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Coins, int64, error)
 
 // DeductFeeDecorator deducts fees from the first signer of the tx
 // If the first signer does not have the funds to pay for the fees, return with InsufficientFunds error
@@ -79,7 +79,7 @@ func (d DeductFeeDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sd
 }
 
 func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	fee, priority, err := dfd.txFeeChecker(ctx, tx)
+	fee, priority, err := dfd.txFeeChecker(ctx, tx, simulate)
 	if err != nil {
 		return ctx, err
 	}

--- a/x/auth/ante/validator_tx_fee.go
+++ b/x/auth/ante/validator_tx_fee.go
@@ -9,7 +9,7 @@ import (
 
 // checkTxFeeWithValidatorMinGasPrices implements the default fee logic, where the minimum price per
 // unit of gas is fixed and set by each validator, can the tx priority is computed from the gas price.
-func CheckTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+func CheckTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Coins, int64, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
 		return nil, 0, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
@@ -21,7 +21,7 @@ func CheckTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 	// Ensure that the provided fees meet a minimum threshold for the validator,
 	// if this is a CheckTx. This is only for local mempool purposes, and thus
 	// is only ran on check tx.
-	if ctx.IsCheckTx() {
+	if ctx.IsCheckTx() && !simulate {
 		minGasPrices := ctx.MinGasPrices()
 		if !minGasPrices.IsZero() {
 			requiredFees := make(sdk.Coins, len(minGasPrices))


### PR DESCRIPTION
## Describe your changes and provide context
We check if the provided fee meets validators' minimum limit in CheckTx to prevent spamming, but simulate also uses CheckTx's state, and since simulate is run with gas limit set to `auto`, the check here shouldn't apply.

## Testing performed to validate your change
tested with unit test in sei-chain
