### PR TITLE
Fix throughput metrics 

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -850,7 +850,7 @@ func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context
 func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, result *sdk.Result, anteEvents []abci.Event, priority int64, err error) {
 
 	defer telemetry.MeasureThroughputSinceWithLabels(
-		telemetry.TX_COUNT,
+		telemetry.TxCount,
 		[]metrics.Label{
 			telemetry.NewLabel("mode", modeKeyToString[mode]),
 		},
@@ -1035,7 +1035,7 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*sdk.Result, error) {
 
 	defer telemetry.MeasureThroughputSinceWithLabels(
-		telemetry.MESSAGE_COUNT,
+		telemetry.MessageCount,
 		[]metrics.Label{
 			telemetry.NewLabel("mode", modeKeyToString[mode]),
 		},

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/snapshots"
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -43,6 +44,13 @@ const (
 	runTxModeSimulate                  // Simulate a transaction
 	runTxModeDeliver                   // Deliver a transaction
 )
+
+var modeKeyToString = map[runTxMode]string{
+	runTxModeCheck:    "check",
+	runTxModeReCheck:  "recheck",
+	runTxModeSimulate: "simulate",
+	runTxModeDeliver:  "deliver",
+}
 
 const (
 	// archival related flags
@@ -840,7 +848,14 @@ func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context
 // returned if the tx does not run out of gas and if all the messages are valid
 // and execute successfully. An error is returned otherwise.
 func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, result *sdk.Result, anteEvents []abci.Event, priority int64, err error) {
-	defer ctx.ContextMemCache().IncrMetricCounter(1, sdk.TX_COUNT)
+
+	defer telemetry.MeasureThroughputSinceWithLabels(
+		telemetry.TX_COUNT,
+		[]metrics.Label{
+			telemetry.NewLabel("mode", modeKeyToString[mode]),
+		},
+		time.Now(),
+	)
 
 	// Reset events after each checkTx or simulateTx or recheckTx
 	// DeliverTx is garbage collected after FinalizeBlocker
@@ -920,7 +935,6 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	}
 
 	msgs := tx.GetMsgs()
-	ctx.ContextMemCache().IncrMetricCounter(uint32(len(msgs)), sdk.MESSAGE_COUNT)
 
 	if err := validateBasicTxMsgs(msgs); err != nil {
 		return sdk.GasInfo{}, nil, nil, 0, err
@@ -1019,6 +1033,15 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 // Handler does not exist for a given message route. Otherwise, a reference to a
 // Result is returned. The caller must not commit state if an error is returned.
 func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*sdk.Result, error) {
+
+	defer telemetry.MeasureThroughputSinceWithLabels(
+		telemetry.MESSAGE_COUNT,
+		[]metrics.Label{
+			telemetry.NewLabel("mode", modeKeyToString[mode]),
+		},
+		time.Now(),
+	)
+
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Println(err)
@@ -1055,7 +1078,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 			msgResult, err = handler(msgCtx, msg)
 			eventMsgName = sdk.MsgTypeURL(msg)
 			metrics.MeasureSinceWithLabels(
-				[]string{"cosmos", "run", "msg", "latency"},
+				[]string{"sei", "cosmos", "run", "msg", "latency"},
 				startTime,
 				[]metrics.Label{{Name: "type", Value: eventMsgName}},
 			)

--- a/telemetry/wrapper.go
+++ b/telemetry/wrapper.go
@@ -12,8 +12,8 @@ const (
 	MetricKeyMidBlocker   = "mid_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
-	MessageCount          = "message_count"
-	TxCount               = "transaction_count"
+	MessageCount          = "message"
+	TxCount               = "transaction"
 )
 
 // NewLabel creates a new instance of Label with name and value

--- a/telemetry/wrapper.go
+++ b/telemetry/wrapper.go
@@ -12,6 +12,9 @@ const (
 	MetricKeyMidBlocker   = "mid_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
+	MESSAGE_COUNT		  = "message_count"
+	TX_COUNT			  = "transaction_count"
+	ORDER_COUNT			  = "order_count"
 )
 
 // NewLabel creates a new instance of Label with name and value
@@ -81,11 +84,23 @@ func MeasureSinceWithLabels(keys []string, start time.Time, labels []metrics.Lab
 // validator_slashed
 func IncrValidatorSlashedCounter(validator string, slashingType string) {
 	metrics.IncrCounterWithLabels(
-		[]string{"validator", "slashed"},
+		[]string{"sei", "cosmos", "validator", "slashed"},
 		1,
 		[]metrics.Label{
 			NewLabel("type", slashingType),
 			NewLabel("validator", validator),
 		},
+	)
+}
+
+// Measures throughput
+// Metric Name:
+//
+//	sei_throughput_<metric_name>
+func MeasureThroughputSinceWithLabels(metricName string, labels []metrics.Label, start time.Time) {
+	metrics.MeasureSinceWithLabels(
+		[]string{"sei", "cosmos", "throughput", metricName},
+		start.UTC(),
+		labels,
 	)
 }

--- a/telemetry/wrapper.go
+++ b/telemetry/wrapper.go
@@ -12,9 +12,8 @@ const (
 	MetricKeyMidBlocker   = "mid_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
-	MESSAGE_COUNT		  = "message_count"
-	TX_COUNT			  = "transaction_count"
-	ORDER_COUNT			  = "order_count"
+	MessageCount          = "message_count"
+	TxCount               = "transaction_count"
 )
 
 // NewLabel creates a new instance of Label with name and value

--- a/types/context_cache.go
+++ b/types/context_cache.go
@@ -1,28 +1,15 @@
 package types
 
 import (
-	"strings"
 	"sync"
 
-	"github.com/armon/go-metrics"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
-
-const (
-	MESSAGE_COUNT      = "message_count"
-	MESSAGE_TYPE_COUNT = "message_type_count"
-	TX_COUNT           = "transaction_count"
-	ORDER_COUNT        = "order_count"
 )
 
 type ContextMemCache struct {
 	deferredBankOpsLock *sync.Mutex
 	deferredSends       *DeferredBankOperationMapping
 	deferredWithdrawals *DeferredBankOperationMapping
-
-	metricsLock             *sync.RWMutex
-	metricsCounterMapping   *map[string]uint32
-	metricsCounterWithLabel *map[string]map[string]uint32
 }
 
 func NewContextMemCache() *ContextMemCache {
@@ -30,9 +17,6 @@ func NewContextMemCache() *ContextMemCache {
 		deferredBankOpsLock:     &sync.Mutex{},
 		deferredSends:           NewDeferredBankOperationMap(),
 		deferredWithdrawals:     NewDeferredBankOperationMap(),
-		metricsLock:             &sync.RWMutex{},
-		metricsCounterMapping:   &map[string]uint32{},
-		metricsCounterWithLabel: &map[string]map[string]uint32{},
 	}
 }
 
@@ -42,39 +26,6 @@ func (c *ContextMemCache) GetDeferredSends() *DeferredBankOperationMapping {
 
 func (c *ContextMemCache) GetDeferredWithdrawals() *DeferredBankOperationMapping {
 	return c.deferredWithdrawals
-}
-
-func (c *ContextMemCache) IncrMetricCounter(count uint32, metricName string) {
-	c.metricsLock.Lock()
-	defer c.metricsLock.Unlock()
-
-	newCounter := (*c.metricsCounterMapping)[metricName] + count
-	(*c.metricsCounterMapping)[metricName] = newCounter
-}
-
-func (c *ContextMemCache) IncrMetricCounterWithLabel(count uint32, metricName string, label metrics.Label) {
-	c.metricsLock.Lock()
-	defer c.metricsLock.Unlock()
-
-	labelStr := strings.Join([]string{label.Name, label.Value}, ",")
-	if innerMap, ok := (*c.metricsCounterWithLabel)[metricName]; ok {
-		innerMap[labelStr] = innerMap[labelStr] + count
-	} else {
-		(*c.metricsCounterWithLabel)[metricName] = make(map[string]uint32)
-		(*c.metricsCounterWithLabel)[metricName][labelStr] = count
-	}
-}
-
-func (c *ContextMemCache) GetMetricCounters() *map[string]uint32 {
-	c.metricsLock.RLock()
-	defer c.metricsLock.RUnlock()
-	return c.metricsCounterMapping
-}
-
-func (c *ContextMemCache) GetMetricCountersWithLabel() *map[string]map[string]uint32 {
-	c.metricsLock.RLock()
-	defer c.metricsLock.RUnlock()
-	return c.metricsCounterWithLabel
 }
 
 func (c *ContextMemCache) UpsertDeferredSends(moduleAccount string, amount Coins) error {
@@ -139,8 +90,4 @@ func (c *ContextMemCache) Clear() {
 	defer c.deferredBankOpsLock.Unlock()
 	c.deferredSends = NewDeferredBankOperationMap()
 	c.deferredWithdrawals = NewDeferredBankOperationMap()
-
-	c.metricsLock.Lock()
-	defer c.metricsLock.Unlock()
-	c.metricsCounterMapping = &map[string]uint32{}
 }


### PR DESCRIPTION
## Describe your changes and provide context

This removes the metrics dependency on context memcache and just emits it as a counter (what it was doing essentially)

we have metrics for 
- wasmd execution latency & count breakdown per contract
- tx execution latency and count breakdown  breakdown per tx mode 
- msg execution latency and count  breakdown per tx mode
- specific msg handler latency and count breakdown per msg type

## Testing performed to validate your change
![image](https://github.com/sei-protocol/sei-cosmos/assets/18161326/93c64412-5748-4e0d-8d92-bbe5ae491a0d)

