### PR TITLE
Add checkTx parsedLogs

### DIFF
--- a/types/result.go
+++ b/types/result.go
@@ -115,6 +115,7 @@ func newTxResponseCheckTx(res *ctypes.ResultBroadcastTxCommit) *TxResponse {
 		Codespace: res.CheckTx.Codespace,
 		Code:      res.CheckTx.Code,
 		Data:      strings.ToUpper(hex.EncodeToString(res.CheckTx.Data)),
+		RawLog:    res.CheckTx.Log,
 		Logs:      parsedLogs,
 		GasWanted: res.CheckTx.GasWanted,
 	}
@@ -159,6 +160,7 @@ func NewResponseFormatBroadcastTx(res *ctypes.ResultBroadcastTx) *TxResponse {
 		Code:      res.Code,
 		Codespace: res.Codespace,
 		Data:      res.Data.String(),
+		RawLog:    res.Log,
 		Logs:      parsedLogs,
 		TxHash:    res.Hash.String(),
 	}

--- a/types/result.go
+++ b/types/result.go
@@ -107,13 +107,15 @@ func newTxResponseCheckTx(res *ctypes.ResultBroadcastTxCommit) *TxResponse {
 		txHash = res.Hash.String()
 	}
 
+	parsedLogs, _ := ParseABCILogs(res.CheckTx.Log)
+
 	return &TxResponse{
 		Height:    res.Height,
 		TxHash:    txHash,
 		Codespace: res.CheckTx.Codespace,
 		Code:      res.CheckTx.Code,
 		Data:      strings.ToUpper(hex.EncodeToString(res.CheckTx.Data)),
-		RawLog:    res.CheckTx.Log,
+		Logs:      parsedLogs,
 		GasWanted: res.CheckTx.GasWanted,
 	}
 }
@@ -151,11 +153,13 @@ func NewResponseFormatBroadcastTx(res *ctypes.ResultBroadcastTx) *TxResponse {
 		return nil
 	}
 
+	parsedLogs, _ := ParseABCILogs(res.Log)
+
 	return &TxResponse{
 		Code:      res.Code,
 		Codespace: res.Codespace,
 		Data:      res.Data.String(),
-		RawLog:    res.Log,
+		Logs:      parsedLogs,
 		TxHash:    res.Hash.String(),
 	}
 }

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -138,7 +138,9 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 	// test nil
 	s.Require().Equal((*sdk.TxResponse)(nil), sdk.NewResponseFormatBroadcastTxCommit(nil))
 
-	logs, err := sdk.ParseABCILogs(`[]`)
+	checkTxLogs, err := sdk.ParseABCILogs(`[{"log":"account sequence mismatch, expected 1, got 10: incorrect account sequence"}]`)
+	s.Require().NoError(err)
+	deliverTxLogs, err := sdk.ParseABCILogs("[]")
 	s.Require().NoError(err)
 
 	// test checkTx
@@ -150,7 +152,7 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 			Data:      nil,
 			GasWanted: 99,
 			Codespace: "codespace",
-			Log:       "rawlog",
+			Log:       `[{"log":"account sequence mismatch, expected 1, got 10: incorrect account sequence"}]`,
 		},
 	}
 	deliverTxResult := &ctypes.ResultBroadcastTxCommit{
@@ -184,7 +186,8 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 		Codespace: "codespace",
 		Code:      90,
 		Data:      "",
-		RawLog:    "rawlog",
+		RawLog:    `[{"log":"account sequence mismatch, expected 1, got 10: incorrect account sequence"}]`,
+		Logs:      checkTxLogs,
 		GasWanted: 99,
 	}
 	deliverWant := &sdk.TxResponse{
@@ -194,7 +197,7 @@ func (s *resultTestSuite) TestResponseFormatBroadcastTxCommit() {
 		Code:      90,
 		Data:      "",
 		RawLog:    `[]`,
-		Logs:      logs,
+		Logs:      deliverTxLogs,
 		Info:      "info",
 		GasWanted: 99,
 		GasUsed:   100,


### PR DESCRIPTION
## Describe your changes and provide context
This PR parses broadcastTx log so that it can be correctly shown in the response.log:

w/ this PR:
```
(base) ➜  sei-chain git:(master) ✗ seid tx bank send admin sei1txqs5kqjx5g33syy6mhtgq7z77wp2kf8r72qf6 100000sei -b block -y --chain-id sei-chain --fees=1000000usei --gas=500000 --sequence 10
code: 32
codespace: sdk
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs:
- events: []
  log: 'account sequence mismatch, expected 1, got 10: incorrect account sequence'
  msg_index: 0
raw_log: ""
timestamp: ""
tx: null
txhash: E71A5A9C34B5E09BE4116C77C0AA7FA63722FAA17A20FE229A8579E36BC5A318
```

w/o this PR:
```
...
logs: ""
raw_log: ""
...
```

## Testing performed to validate your change
- unit tests
- e2e test

