### PR TITLE
Certik audit fixes

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -143,13 +143,6 @@ func (app *BaseApp) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) (res
 	if app.beginBlocker != nil {
 		res = app.beginBlocker(ctx, req)
 		res.Events = sdk.MarkEventsToIndex(res.Events, app.indexEvents)
-
-		// call the hooks with the BeginBlock messages
-		for _, streamingListener := range app.abciListeners {
-			if err := streamingListener.ListenBeginBlock(app.deliverState.ctx, req, res); err != nil {
-				app.logger.Error("BeginBlock listening hook failed", "height", req.Header.Height, "err", err)
-			}
-		}
 	}
 
 	// call the streaming service hooks with the EndBlock messages

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -75,13 +75,7 @@ type (
 	// an older version of the software. In particular, if a module changed the substore key name
 	// (or removed a substore) between two versions of the software.
 	StoreLoader func(ms sdk.CommitMultiStore) error
-
-	RunTxPreHookKeyType  string
-	RunTxPostHookKeyType string
 )
-
-const RunTxPreHookKey = RunTxPreHookKeyType("key")
-const RunTxPostHookKey = RunTxPostHookKeyType("key")
 
 // BaseApp reflects the ABCI application implementation.
 type BaseApp struct { //nolint: maligned
@@ -872,17 +866,6 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 	defer span.End()
 	ctx = ctx.WithTraceSpanContext(spanCtx)
 	span.SetAttributes(attribute.String("txHash", fmt.Sprintf("%X", sha256.Sum256(txBytes))))
-
-	if goCtx := ctx.Context(); goCtx != nil {
-		if v := goCtx.Value(RunTxPreHookKey); v != nil {
-			callable := v.(func())
-			callable()
-		}
-		if v := goCtx.Value(RunTxPostHookKey); v != nil {
-			callable := v.(func())
-			defer callable()
-		}
-	}
 
 	// NOTE: GasWanted should be returned by the AnteHandler. GasUsed is
 	// determined by the GasMeter. We need access to the context to get the gas


### PR DESCRIPTION
## Describe your changes and provide context
1. remove duplicated ABCI listener calls
2. remove unused runTx hooks

## Testing performed to validate your change
no behavioral change
