### PR TITLE
Change dec coin amount of to iterative too

### DIFF
--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -476,30 +476,13 @@ func (coins DecCoins) Empty() bool {
 func (coins DecCoins) AmountOf(denom string) Dec {
 	mustValidateDenom(denom)
 
-	switch len(coins) {
-	case 0:
-		return ZeroDec()
-
-	case 1:
-		coin := coins[0]
+	for _, coin := range coins {
 		if coin.Denom == denom {
 			return coin.Amount
 		}
-		return ZeroDec()
-
-	default:
-		midIdx := len(coins) / 2 // 2:1, 3:1, 4:2
-		coin := coins[midIdx]
-
-		switch {
-		case denom < coin.Denom:
-			return coins[:midIdx].AmountOf(denom)
-		case denom == coin.Denom:
-			return coin.Amount
-		default:
-			return coins[midIdx+1:].AmountOf(denom)
-		}
 	}
+
+	return ZeroDec()
 }
 
 // IsEqual returns true if the two sets of DecCoins have the same value.

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -652,3 +652,44 @@ func (s *decCoinTestSuite) TestDecCoins_AddDecCoinWithIsValid() {
 		}
 	}
 }
+
+func (s *decCoinTestSuite) TestAmountOf() {
+	case0 := sdk.DecCoins{}
+	case1 := sdk.DecCoins{
+		sdk.NewDecCoin("gold", sdk.ZeroInt()),
+	}
+	case2 := sdk.DecCoins{
+		sdk.NewDecCoin("tree", sdk.NewIntWithDecimal(3, 2)),
+		sdk.NewDecCoin("mineral", sdk.NewIntWithDecimal(5, 2)),
+		sdk.NewDecCoin("gas", sdk.NewIntWithDecimal(1, 2)),
+	}
+	case3 := sdk.DecCoins{
+		sdk.NewDecCoin("tree", sdk.NewIntWithDecimal(1, 2)),
+		sdk.NewDecCoin("mineral", sdk.NewIntWithDecimal(1, 2)),
+		sdk.NewDecCoin("abc", sdk.NewIntWithDecimal(1, 4)),
+	}
+	case4 := sdk.DecCoins{
+		sdk.NewDecCoin("gas", sdk.NewIntWithDecimal(1, 2)),
+	}
+
+	cases := []struct {
+		coins           sdk.DecCoins
+		amountOfGAS     sdk.Dec
+		amountOfMINERAL sdk.Dec
+		amountOfTREE    sdk.Dec
+	}{
+		{case0, sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()},
+		{case1, sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()},
+		{case2, sdk.NewDecFromInt(sdk.NewIntWithDecimal(1, 2)), sdk.NewDecFromInt(sdk.NewIntWithDecimal(5, 2)), sdk.NewDecFromInt(sdk.NewIntWithDecimal(3, 2))},
+		{case3, sdk.NewDecFromInt(sdk.NewIntWithDecimal(0, 0)), sdk.NewDecFromInt(sdk.NewIntWithDecimal(1, 2)), sdk.NewDecFromInt(sdk.NewIntWithDecimal(1, 2))},
+		{case4, sdk.NewDecFromInt(sdk.NewIntWithDecimal(1, 2)), sdk.ZeroDec(), sdk.ZeroDec()},
+	}
+
+	for _, tc := range cases {
+		s.Require().Equal(tc.amountOfGAS, tc.coins.AmountOf("gas"), "coins: %s", tc.coins)
+		s.Require().Equal(tc.amountOfMINERAL, tc.coins.AmountOf("mineral"), "coins: %s", tc.coins)
+		s.Require().Equal(tc.amountOfTREE, tc.coins.AmountOf("tree"), "coins: %s", tc.coins)
+	}
+
+	s.Require().Panics(func() { cases[0].coins.AmountOf("10Invalid") })
+}

--- a/x/auth/ante/validator_tx_fee.go
+++ b/x/auth/ante/validator_tx_fee.go
@@ -24,7 +24,7 @@ func CheckTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx, simulate bo
 	// is only ran on check tx.
 	if ctx.IsCheckTx() && !simulate {
 		feeParams := paramsKeeper.GetFeesParams(ctx)
-		minGasPrices := GetMinimumGasPricesWanted(feeParams.GetGlobalMinimumGasPrices(), ctx.MinGasPrices())
+		minGasPrices := GetMinimumGasPricesWantedSorted(feeParams.GetGlobalMinimumGasPrices(), ctx.MinGasPrices())
 		if !minGasPrices.IsZero() {
 			requiredFees := make(sdk.Coins, len(minGasPrices))
 
@@ -51,8 +51,8 @@ func CheckTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx, simulate bo
 	return feeCoins, priority, nil
 }
 
-func GetMinimumGasPricesWanted(globalMinimumGasPrices, validatorMinimumGasPrices sdk.DecCoins) sdk.DecCoins {
-	return globalMinimumGasPrices.UnionMax(validatorMinimumGasPrices)
+func GetMinimumGasPricesWantedSorted(globalMinimumGasPrices, validatorMinimumGasPrices sdk.DecCoins) sdk.DecCoins {
+	return globalMinimumGasPrices.UnionMax(validatorMinimumGasPrices).Sort()
 }
 
 // getTxPriority returns a naive tx priority based on the amount of the smallest denomination of the gas price

--- a/x/auth/ante/validator_tx_fee_test.go
+++ b/x/auth/ante/validator_tx_fee_test.go
@@ -13,7 +13,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices := sdk.NewDecCoins()
 	validatorMinGasPrices := sdk.NewDecCoins()
 
-	minGasWanted := ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted := ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted := sdk.NewDecCoins()
 
@@ -23,7 +23,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices = sdk.NewDecCoins()
 	validatorMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)))
 
-	minGasWanted = ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted = ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)))
 
@@ -33,7 +33,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(2)))
 	validatorMinGasPrices = sdk.NewDecCoins()
 
-	minGasWanted = ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted = ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted = sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(2)))
 
@@ -43,7 +43,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(2)))
 	validatorMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("bar", sdk.NewInt(3)), sdk.NewDecCoin("baz", sdk.NewInt(4)))
 
-	minGasWanted = ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted = ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(3)), sdk.NewDecCoin("baz", sdk.NewInt(4)))
 
@@ -53,7 +53,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(2)))
 	validatorMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("baz", sdk.NewInt(3)), sdk.NewDecCoin("qux", sdk.NewInt(4)))
 
-	minGasWanted = ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted = ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(2)), sdk.NewDecCoin("baz", sdk.NewInt(3)), sdk.NewDecCoin("qux", sdk.NewInt(4)))
 
@@ -63,7 +63,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(2)))
 	validatorMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(3)), sdk.NewDecCoin("bar", sdk.NewInt(4)))
 
-	minGasWanted = ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted = ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(3)), sdk.NewDecCoin("bar", sdk.NewInt(4)))
 
@@ -73,7 +73,7 @@ func TestGetMinimumGasWanted(t *testing.T) {
 	globalMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(2)))
 	validatorMinGasPrices = sdk.NewDecCoins(sdk.NewDecCoin("baz", sdk.NewInt(3)), sdk.NewDecCoin("qux", sdk.NewInt(4)))
 
-	minGasWanted = ante.GetMinimumGasPricesWanted(globalMinGasPrices, validatorMinGasPrices)
+	minGasWanted = ante.GetMinimumGasPricesWantedSorted(globalMinGasPrices, validatorMinGasPrices)
 
 	expectedMinGasWanted = sdk.NewDecCoins(sdk.NewDecCoin("foo", sdk.NewInt(1)), sdk.NewDecCoin("bar", sdk.NewInt(2)), sdk.NewDecCoin("baz", sdk.NewInt(3)), sdk.NewDecCoin("qux", sdk.NewInt(4)))
 


### PR DESCRIPTION
## Describe your changes and provide context
This changes amount of for dec coins to be iterative too it dangerously assumes that the coins are in sorted order and returns 0 often if it's not.



## Testing performed to validate your change
Added a unit test for this, 

it would fail with the old logic

![image](https://github.com/sei-protocol/sei-cosmos/assets/18161326/d2d5d34a-5c86-494e-9619-a3e72080c753)

