### PR TITLE
Remove deferred withdrawals and add saturating sub with tests

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -390,6 +390,19 @@ func (coins Coins) SafeSub(coinsB Coins) (Coins, bool) {
 	return diff, diff.IsAnyNegative()
 }
 
+// PartitionSigned separates the coins between those with positive values and those with negative values,
+// and returns both positive and negative coins. This also discards any coins with zero values (not returned in either group).
+func (coins Coins) PartitionSigned() (positives Coins, negatives Coins) {
+	for _, coin := range coins {
+		if coin.Amount.IsPositive() {
+			positives = append(positives, coin)
+		} else if coin.Amount.IsNegative() {
+			negatives = append(negatives, coin)
+		}
+	}
+	return positives, negatives
+}
+
 // Max takes two valid Coins inputs and returns a valid Coins result
 // where for every denom D, AmountOf(D) of the result is the maximum
 // of AmountOf(D) of the inputs.  Note that the result might be not

--- a/types/context_cache.go
+++ b/types/context_cache.go
@@ -73,6 +73,8 @@ func (c *ContextMemCache) SafeSubDeferredSends(moduleAccount string, amount Coin
 }
 
 func (c *ContextMemCache) RangeOnDeferredSendsAndDelete(apply func(recipient string, amount Coins)) {
+	c.deferredBankOpsLock.Lock()
+	defer c.deferredBankOpsLock.Unlock()
 	c.deferredSends.RangeAndRemove(apply)
 }
 

--- a/types/context_cache.go
+++ b/types/context_cache.go
@@ -68,6 +68,8 @@ func (c *ContextMemCache) SafeSubDeferredSends(moduleAccount string, amount Coin
 	if !amount.IsValid() {
 		panic(sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amount.String()))
 	}
+	c.deferredBankOpsLock.Lock()
+	defer c.deferredBankOpsLock.Unlock()
 
 	return c.deferredSends.SafeSub(moduleAccount, amount)
 }

--- a/types/context_cache.go
+++ b/types/context_cache.go
@@ -36,7 +36,7 @@ func (c *ContextMemCache) UpsertDeferredSends(moduleAccount string, amount Coins
 }
 
 // This will perform a saturating sub against the deferred module balance atomically. This means that it will subtract any balances that it is able to, and then call the passed in `remainder handler` to ensure the remaining balance can be safely subtracted as well. If this remainderHandler returns an error, we will revert the saturating sub to ensure atomicity of the subtraction across the multiple balances
-func (c *ContextMemCache) SaturatingSubDeferredSends(moduleAccount string, amount Coins, remainderHandler func(amount Coins) error) error {
+func (c *ContextMemCache) AtomicSpilloverSubDeferredSends(moduleAccount string, amount Coins, remainderHandler func(amount Coins) error) error {
 	if !amount.IsValid() {
 		panic(sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amount.String()))
 	}

--- a/types/context_cache.go
+++ b/types/context_cache.go
@@ -9,23 +9,17 @@ import (
 type ContextMemCache struct {
 	deferredBankOpsLock *sync.Mutex
 	deferredSends       *DeferredBankOperationMapping
-	deferredWithdrawals *DeferredBankOperationMapping
 }
 
 func NewContextMemCache() *ContextMemCache {
 	return &ContextMemCache{
 		deferredBankOpsLock: &sync.Mutex{},
 		deferredSends:       NewDeferredBankOperationMap(),
-		deferredWithdrawals: NewDeferredBankOperationMap(),
 	}
 }
 
 func (c *ContextMemCache) GetDeferredSends() *DeferredBankOperationMapping {
 	return c.deferredSends
-}
-
-func (c *ContextMemCache) GetDeferredWithdrawals() *DeferredBankOperationMapping {
-	return c.deferredWithdrawals
 }
 
 func (c *ContextMemCache) UpsertDeferredSends(moduleAccount string, amount Coins) error {
@@ -37,13 +31,35 @@ func (c *ContextMemCache) UpsertDeferredSends(moduleAccount string, amount Coins
 	c.deferredBankOpsLock.Lock()
 	defer c.deferredBankOpsLock.Unlock()
 
-	// If there's already a pending withdrawal then subtract it from that amount first
-	// or else add it to the deferredSends mapping
-	ok := c.deferredWithdrawals.SafeSub(moduleAccount, amount)
-	if !ok {
-		c.deferredSends.UpsertMapping(moduleAccount, amount)
-	}
+	c.deferredSends.UpsertMapping(moduleAccount, amount)
 	return nil
+}
+
+// This will perform a saturating sub against the deferred module balance atomically. This means that it will subtract any balances that it is able to, and then call the passed in `remainder handler` to ensure the remaining balance can be safely subtracted as well. If this remainderHandler returns an error, we will revert the saturating sub to ensure atomicity of the subtraction across the multiple balances
+func (c *ContextMemCache) SaturatingSubDeferredSends(moduleAccount string, amount Coins, remainderHandler func(amount Coins) error) error {
+	if !amount.IsValid() {
+		panic(sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amount.String()))
+	}
+	originalBalance, ok := c.deferredSends.Get(moduleAccount)
+	if ok {
+		// found a balance, try to perform the logic
+		remainder := c.deferredSends.SaturatingSub(moduleAccount, amount)
+		if remainder.IsZero() {
+			// no remainder, return now
+			return nil
+		}
+		err := remainderHandler(remainder)
+		if err != nil {
+			// revert the map subtraction and the bubble up error
+			c.deferredSends.Set(moduleAccount, originalBalance)
+		}
+		return err
+	} else {
+		// run the remainder handler on the full amount
+		err := remainderHandler(amount)
+		// no need for revert because we dont even attempt a saturating sub, bubble up error if applicable
+		return err
+	}
 }
 
 func (c *ContextMemCache) SafeSubDeferredSends(moduleAccount string, amount Coins) bool {
@@ -55,55 +71,11 @@ func (c *ContextMemCache) SafeSubDeferredSends(moduleAccount string, amount Coin
 }
 
 func (c *ContextMemCache) RangeOnDeferredSendsAndDelete(apply func(recipient string, amount Coins)) {
-	c.deferredSends.RangeOnMapping(apply)
-}
-
-func (c *ContextMemCache) UpsertDeferredWithdrawals(moduleAccount string, amount Coins) error {
-	if !amount.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amount.String())
-	}
-
-	// Separate locks needed for all mappings - atmoic transaction needed
-	c.deferredBankOpsLock.Lock()
-	defer c.deferredBankOpsLock.Unlock()
-
-	// If there's already a pending deposit then subtract it from that amount first
-	// or else add it to the deferredWithdrawals mapping
-	ok := c.deferredSends.SafeSub(moduleAccount, amount)
-	if !ok {
-		c.deferredWithdrawals.UpsertMapping(moduleAccount, amount)
-	}
-	return nil
-}
-
-// This inserts or updates an entry for a module account for a deferred withdrawal.
-// This should be performed AFTER checking for a sufficient balance in the underlying bank balances for that module account.
-// Additionally, this does not attempt to do any safe subtraction from pending sends, so if that behavior is preferred, it will need to be checked separately.
-func (c *ContextMemCache) UpsertDeferredWithdrawalsNoSafeSub(moduleAccount string, amount Coins) error {
-	if !amount.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amount.String())
-	}
-
-	// Separate locks needed for all mappings - atmoic transaction needed
-	c.deferredBankOpsLock.Lock()
-	defer c.deferredBankOpsLock.Unlock()
-
-	c.deferredWithdrawals.UpsertMapping(moduleAccount, amount)
-	return nil
-}
-
-func (c *ContextMemCache) RangeOnDeferredWithdrawalsAndDelete(apply func(recipient string, amount Coins)) {
-	c.deferredWithdrawals.RangeOnMapping(apply)
-}
-
-func (c *ContextMemCache) ApplyOnAllDeferredOperationsAndDelete(apply func(recipient string, amount Coins)) {
-	c.RangeOnDeferredSendsAndDelete(apply)
-	c.RangeOnDeferredWithdrawalsAndDelete(apply)
+	c.deferredSends.RangeAndRemove(apply)
 }
 
 func (c *ContextMemCache) Clear() {
 	c.deferredBankOpsLock.Lock()
 	defer c.deferredBankOpsLock.Unlock()
 	c.deferredSends = NewDeferredBankOperationMap()
-	c.deferredWithdrawals = NewDeferredBankOperationMap()
 }

--- a/types/context_cache_test.go
+++ b/types/context_cache_test.go
@@ -18,7 +18,6 @@ func TestContextCacheTestSuite(t *testing.T) {
 }
 
 func (s *contextCacheTestSuite) SetupSuite() {
-	s.T().Parallel()
 	s.contextCache = *sdk.NewContextMemCache()
 }
 

--- a/types/context_cache_test.go
+++ b/types/context_cache_test.go
@@ -155,7 +155,7 @@ func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
 	))
 
 	// valid saturating sub - should succeed
-	err := s.contextCache.SaturatingSubDeferredSends(
+	err := s.contextCache.AtomicSpilloverSubDeferredSends(
 		"module1",
 		sdk.NewCoins(
 			sdk.NewInt64Coin("denom3", 25),
@@ -169,7 +169,7 @@ func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
 
 	// saturating sub with nonexisting denom and valid one - should fail
 	called := false
-	err = s.contextCache.SaturatingSubDeferredSends(
+	err = s.contextCache.AtomicSpilloverSubDeferredSends(
 		"module1",
 		sdk.NewCoins(
 			sdk.NewInt64Coin("denom1", 20),
@@ -188,7 +188,7 @@ func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
 
 	// different saturaing sub but this time the balance *is* present in underlying store
 	called = false
-	err = s.contextCache.SaturatingSubDeferredSends(
+	err = s.contextCache.AtomicSpilloverSubDeferredSends(
 		"module1",
 		sdk.NewCoins(
 			sdk.NewInt64Coin("denom1", 5),
@@ -206,7 +206,7 @@ func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
 
 	// test failed subtraction from underlying store
 	called = false
-	err = s.contextCache.SaturatingSubDeferredSends(
+	err = s.contextCache.AtomicSpilloverSubDeferredSends(
 		"module2",
 		sdk.NewCoins(
 			sdk.NewInt64Coin("denom3", 50),
@@ -224,7 +224,7 @@ func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
 
 	// saturating sub that uses all the balance of a denom and spills over into underlying store
 	called = false
-	err = s.contextCache.SaturatingSubDeferredSends(
+	err = s.contextCache.AtomicSpilloverSubDeferredSends(
 		"module3",
 		sdk.NewCoins(
 			sdk.NewInt64Coin("denom1", 75),
@@ -241,7 +241,7 @@ func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
 
 	// saturating sub for a module that doesnt exist in the map
 	called = false
-	err = s.contextCache.SaturatingSubDeferredSends(
+	err = s.contextCache.AtomicSpilloverSubDeferredSends(
 		"module4",
 		sdk.NewCoins(
 			sdk.NewInt64Coin("denom2", 30),

--- a/types/context_cache_test.go
+++ b/types/context_cache_test.go
@@ -18,6 +18,7 @@ func TestContextCacheTestSuite(t *testing.T) {
 }
 
 func (s *contextCacheTestSuite) SetupSuite() {
+	s.T().Parallel()
 	s.contextCache = *sdk.NewContextMemCache()
 }
 

--- a/types/context_cache_test.go
+++ b/types/context_cache_test.go
@@ -1,0 +1,279 @@
+package types_test
+
+import (
+	fmt "fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type contextCacheTestSuite struct {
+	suite.Suite
+	contextCache sdk.ContextMemCache
+}
+
+func TestContextCacheTestSuite(t *testing.T) {
+	suite.Run(t, new(contextCacheTestSuite))
+}
+
+func (s *contextCacheTestSuite) SetupSuite() {
+	s.T().Parallel()
+	s.contextCache = *sdk.NewContextMemCache()
+}
+
+func (s *contextCacheTestSuite) TestDeferredSendUpserts() {
+	s.contextCache.UpsertDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 100),
+		sdk.NewInt64Coin("denom2", 20),
+	))
+
+	s.contextCache.UpsertDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 50),
+		sdk.NewInt64Coin("denom2", 10),
+	))
+
+	s.contextCache.UpsertDeferredSends("module2", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 50),
+		sdk.NewInt64Coin("denom4", 40),
+	))
+
+	expectedDeferredBalances := map[string]sdk.Coins{
+		"module1": sdk.NewCoins(
+			sdk.NewInt64Coin("denom1", 100),
+			sdk.NewInt64Coin("denom2", 30),
+			sdk.NewInt64Coin("denom3", 50),
+		),
+		"module2": sdk.NewCoins(
+			sdk.NewInt64Coin("denom3", 50),
+			sdk.NewInt64Coin("denom4", 40),
+		),
+	}
+	entries := 0
+	s.contextCache.RangeOnDeferredSendsAndDelete(func(recipient string, amount sdk.Coins) {
+		s.Require().Equal(expectedDeferredBalances[recipient], amount, fmt.Sprint("unexpected deferred balances", recipient, amount))
+		entries++
+	})
+	s.Require().Equal(len(expectedDeferredBalances), entries)
+	entries = 0
+	// assert empty after range and delete
+	s.contextCache.RangeOnDeferredSendsAndDelete(func(recipient string, amount sdk.Coins) {
+		entries++
+	})
+	s.Require().Zero(entries)
+}
+
+func (s *contextCacheTestSuite) TestDeferredSendSafeSub() {
+	// set up some balances
+	s.contextCache.UpsertDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 100),
+		sdk.NewInt64Coin("denom2", 20),
+	))
+	s.contextCache.UpsertDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 50),
+		sdk.NewInt64Coin("denom2", 10),
+	))
+	s.contextCache.UpsertDeferredSends("module2", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 50),
+		sdk.NewInt64Coin("denom4", 40),
+	))
+	s.contextCache.UpsertDeferredSends("module3", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 10),
+	))
+
+	// valid safesub - should succeed
+	subtracted := s.contextCache.SafeSubDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 25),
+	))
+	s.Require().True(subtracted)
+
+	// safesub with nonexisting denom and valid one - should fail
+	subtracted = s.contextCache.SafeSubDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 20),
+		sdk.NewInt64Coin("denom4", 20),
+	))
+	s.Require().False(subtracted)
+
+	// safesub with other module multiple denoms - should succeed
+	subtracted = s.contextCache.SafeSubDeferredSends("module2", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 20),
+		sdk.NewInt64Coin("denom4", 20),
+	))
+	s.Require().True(subtracted)
+
+	// safesub with nonexisting denom and valid one - should fail
+	subtracted = s.contextCache.SafeSubDeferredSends("module4", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 20),
+		sdk.NewInt64Coin("denom4", 20),
+	))
+	s.Require().False(subtracted)
+
+	// safesub full balance for a module - should succeed
+	subtracted = s.contextCache.SafeSubDeferredSends("module3", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 10),
+	))
+	s.Require().True(subtracted)
+
+	expectedDeferredBalances := map[string]sdk.Coins{
+		"module1": sdk.NewCoins(
+			sdk.NewInt64Coin("denom1", 100),
+			sdk.NewInt64Coin("denom2", 30),
+			sdk.NewInt64Coin("denom3", 25),
+		),
+		"module2": sdk.NewCoins(
+			sdk.NewInt64Coin("denom3", 30),
+			sdk.NewInt64Coin("denom4", 20),
+		),
+		// is empty because was fully subbed
+		"module3": sdk.Coins(nil),
+	}
+
+	entries := 0
+	s.contextCache.RangeOnDeferredSendsAndDelete(func(recipient string, amount sdk.Coins) {
+		s.Require().Equal(expectedDeferredBalances[recipient], amount, fmt.Sprint("unexpected deferred balances", recipient, amount))
+		entries++
+	})
+	s.Require().Equal(len(expectedDeferredBalances), entries)
+}
+
+func (s *contextCacheTestSuite) TestDeferredSendSaturatingSub() {
+	// set up some balances
+	s.contextCache.UpsertDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 100),
+		sdk.NewInt64Coin("denom2", 20),
+	))
+	s.contextCache.UpsertDeferredSends("module1", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 50),
+		sdk.NewInt64Coin("denom2", 10),
+	))
+	s.contextCache.UpsertDeferredSends("module2", sdk.NewCoins(
+		sdk.NewInt64Coin("denom3", 50),
+		sdk.NewInt64Coin("denom4", 40),
+	))
+	s.contextCache.UpsertDeferredSends("module3", sdk.NewCoins(
+		sdk.NewInt64Coin("denom1", 10),
+	))
+
+	// valid saturating sub - should succeed
+	err := s.contextCache.SaturatingSubDeferredSends(
+		"module1",
+		sdk.NewCoins(
+			sdk.NewInt64Coin("denom3", 25),
+		),
+		func(amount sdk.Coins) error {
+			// we shouldnt even touch this
+			panic("Shouldn't be called")
+		},
+	)
+	s.Require().NoError(err)
+
+	// saturating sub with nonexisting denom and valid one - should fail
+	called := false
+	err = s.contextCache.SaturatingSubDeferredSends(
+		"module1",
+		sdk.NewCoins(
+			sdk.NewInt64Coin("denom1", 20),
+			sdk.NewInt64Coin("denom4", 20),
+		),
+		func(amount sdk.Coins) error {
+			// should be called with 20denom4
+			s.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin("denom4", 20)), amount)
+			called = true
+			// simulate error
+			return fmt.Errorf("insufficient balance")
+		},
+	)
+	s.Require().True(called)
+	s.Require().Error(err)
+
+	// different saturaing sub but this time the balance *is* present in underlying store
+	called = false
+	err = s.contextCache.SaturatingSubDeferredSends(
+		"module1",
+		sdk.NewCoins(
+			sdk.NewInt64Coin("denom1", 5),
+			sdk.NewInt64Coin("denom5", 20),
+		),
+		func(amount sdk.Coins) error {
+			s.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin("denom5", 20)), amount)
+			// simulate success querying underlying store
+			called = true
+			return nil
+		},
+	)
+	s.Require().True(called)
+	s.Require().NoError(err)
+
+	// test failed subtraction from underlying store
+	called = false
+	err = s.contextCache.SaturatingSubDeferredSends(
+		"module2",
+		sdk.NewCoins(
+			sdk.NewInt64Coin("denom3", 50),
+			sdk.NewInt64Coin("denom4", 55),
+		),
+		func(amount sdk.Coins) error {
+			s.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin("denom4", 15)), amount)
+			// simulate success querying underlying store
+			called = true
+			return fmt.Errorf("failed underlying subtract")
+		},
+	)
+	s.Require().True(called)
+	s.Require().Error(err)
+
+	// saturating sub that uses all the balance of a denom and spills over into underlying store
+	called = false
+	err = s.contextCache.SaturatingSubDeferredSends(
+		"module3",
+		sdk.NewCoins(
+			sdk.NewInt64Coin("denom1", 75),
+		),
+		func(amount sdk.Coins) error {
+			s.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin("denom1", 65)), amount)
+			// simulate success querying underlying store
+			called = true
+			return nil
+		},
+	)
+	s.Require().True(called)
+	s.Require().NoError(err)
+
+	// saturating sub for a module that doesnt exist in the map
+	called = false
+	err = s.contextCache.SaturatingSubDeferredSends(
+		"module4",
+		sdk.NewCoins(
+			sdk.NewInt64Coin("denom2", 30),
+		),
+		func(amount sdk.Coins) error {
+			s.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin("denom2", 30)), amount)
+			// simulate success querying underlying store
+			called = true
+			return nil
+		},
+	)
+	s.Require().True(called)
+	s.Require().NoError(err)
+
+	expectedDeferredBalances := map[string]sdk.Coins{
+		"module1": sdk.NewCoins(
+			sdk.NewInt64Coin("denom1", 95),
+			sdk.NewInt64Coin("denom2", 30),
+			sdk.NewInt64Coin("denom3", 25),
+		),
+		"module2": sdk.NewCoins(
+			sdk.NewInt64Coin("denom3", 50),
+			sdk.NewInt64Coin("denom4", 40),
+		),
+		// is empty because was fully subbed
+		"module3": sdk.Coins(nil),
+	}
+
+	entries := 0
+	s.contextCache.RangeOnDeferredSendsAndDelete(func(recipient string, amount sdk.Coins) {
+		s.Require().Equal(expectedDeferredBalances[recipient], amount, fmt.Sprint("unexpected deferred balances", recipient, amount))
+		entries++
+	})
+	s.Require().Equal(len(expectedDeferredBalances), entries)
+}

--- a/types/deferred_bank_operations.go
+++ b/types/deferred_bank_operations.go
@@ -17,6 +17,53 @@ func NewDeferredBankOperationMap() *DeferredBankOperationMapping {
 	}
 }
 
+// Get returns the current deferred balances for the passed in module account as well as a `found` bool.
+// This is threadsafe since it acquires a lock on the mutex.
+func (m *DeferredBankOperationMapping) Get(moduleAccount string) (Coins, bool) {
+	m.mappingLock.Lock()
+	defer m.mappingLock.Unlock()
+
+	deferredAmount, ok := m.deferredOperations[moduleAccount]
+	return deferredAmount, ok
+}
+
+// Get returns the current deferred balances for the passed in module account as well as a `found` bool.
+// This is threadsafe since it acquires a lock on the mutex.
+func (m *DeferredBankOperationMapping) Set(moduleAccount string, amount Coins) {
+	m.mappingLock.Lock()
+	defer m.mappingLock.Unlock()
+
+	m.deferredOperations[moduleAccount] = amount
+}
+
+// SaturatingSub will subtract the given amount from the module account as long as the resulting balance is positive or zero.
+// If there would be a remainder (eg. negative balance after subtraction), then it would subtract the full balance in the map
+//
+//	and then return the remainder that was unable to be subtracted.
+func (m *DeferredBankOperationMapping) SaturatingSub(moduleAccount string, amount Coins) Coins {
+	m.mappingLock.Lock()
+	defer m.mappingLock.Unlock()
+
+	if deferredAmount, ok := m.deferredOperations[moduleAccount]; ok {
+		newAmount, isNegative := deferredAmount.SafeSub(amount)
+		if !isNegative {
+			// this means that the subtraction FULLY succeeded, no remainders
+			m.deferredOperations[moduleAccount] = newAmount
+			// return empty remainder
+			return Coins{}
+		} else {
+			// else there were some negative, we need to partition the results, and return the negative balances as positive instead as the remainder
+			pos, neg := newAmount.PartitionSigned()
+			// assign positives to map (anything that wasnt touched or had sufficient balance to process the subtraction fully)
+			m.deferredOperations[moduleAccount] = pos
+			// convert the negatives to positives to represent the remainder
+			return neg.negative()
+		}
+	}
+	// no entry, so we return the full amount as the remainder
+	return amount
+}
+
 // If there's already a pending opposite operation then subtract it from that amount first
 // returns true if amount was subtracted
 func (m *DeferredBankOperationMapping) SafeSub(moduleAccount string, amount Coins) bool {
@@ -55,7 +102,7 @@ func (m *DeferredBankOperationMapping) GetSortedKeys() []string {
 	return keys
 }
 
-func (m *DeferredBankOperationMapping) RangeOnMapping(apply func(recipient string, amount Coins)) {
+func (m *DeferredBankOperationMapping) RangeAndRemove(apply func(recipient string, amount Coins)) {
 	m.mappingLock.Lock()
 	defer m.mappingLock.Unlock()
 

--- a/types/deferred_bank_operations.go
+++ b/types/deferred_bank_operations.go
@@ -38,8 +38,7 @@ func (m *DeferredBankOperationMapping) Set(moduleAccount string, amount Coins) {
 
 // SaturatingSub will subtract the given amount from the module account as long as the resulting balance is positive or zero.
 // If there would be a remainder (eg. negative balance after subtraction), then it would subtract the full balance in the map
-//
-//	and then return the remainder that was unable to be subtracted.
+// and then return the remainder that was unable to be subtracted.
 func (m *DeferredBankOperationMapping) SaturatingSub(moduleAccount string, amount Coins) Coins {
 	m.mappingLock.Lock()
 	defer m.mappingLock.Unlock()

--- a/x/auth/types/expected_keepers.go
+++ b/x/auth/types/expected_keepers.go
@@ -8,7 +8,4 @@ import (
 type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	DeferredSendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
-	DeferredSendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amount sdk.Coins) error
-	DeferredMintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
-	DeferredBurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 }

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -44,12 +44,9 @@ type Keeper interface {
 	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 
-	DeferredSendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amount sdk.Coins) error
 	DeferredSendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	WriteDeferredDepositsToModuleAccounts(ctx sdk.Context) []abci.Event
 	WriteDeferredOperations(ctx sdk.Context) []abci.Event
-	DeferredMintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
-	DeferredBurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 
 	DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr sdk.AccAddress, amt sdk.Coins) error
 	UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAddr sdk.AccAddress, amt sdk.Coins) error
@@ -344,45 +341,6 @@ func (k BaseKeeper) SendCoinsFromModuleToAccount(
 	return k.SendCoins(ctx, senderAddr, recipientAddr, amt)
 }
 
-// DeferredSendCoinsFromModuleToAccount transfers coins from a ModuleAccount to an AccAddress.
-// It will panic if the module account does not exist. An error is returned if
-// the recipient address is black-listed or if sending the tokens fails.
-// It's similar to SendCoinsFromModuleToAccount except the withdrawal happens as a batched operation
-func (k BaseKeeper) DeferredSendCoinsFromModuleToAccount(
-	ctx sdk.Context, moduleAccount string, recipientAddr sdk.AccAddress, amount sdk.Coins,
-) error {
-	moduleAddr := k.ak.GetModuleAddress(moduleAccount)
-	if moduleAddr == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleAccount))
-	}
-
-	if k.BlockedAddr(recipientAddr) {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", recipientAddr)
-	}
-
-	// Subtract from any pending sends fist
-	ok := ctx.ContextMemCache().SafeSubDeferredSends(moduleAccount, amount)
-	if !ok {
-		// Branch Context for validation and fail if the module doesn't have enough coins
-		// but don't write this to the underlying store
-		validationContext, _ := ctx.CacheContext()
-		err := k.subUnlockedCoins(validationContext, moduleAddr, amount)
-		if err != nil {
-			return err
-		}
-	}
-
-	err := k.addCoins(ctx, recipientAddr, amount)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		// we only want to add to deferred withdrawal if we previously identified that we can subtract from the unlocked coins
-		return ctx.ContextMemCache().UpsertDeferredWithdrawalsNoSafeSub(moduleAccount, amount)
-	}
-	return nil
-}
-
 // SendCoinsFromModuleToModule transfers coins from a ModuleAccount to another.
 // It will panic if either module account does not exist.
 func (k BaseKeeper) SendCoinsFromModuleToModule(
@@ -451,7 +409,6 @@ func (k BaseKeeper) DeferredSendCoinsFromAccountToModule(
 func (k BaseKeeper) WriteDeferredOperations(ctx sdk.Context) []abci.Event {
 	return append(
 		k.WriteDeferredDepositsToModuleAccounts(ctx),
-		k.WriteDeferredWithdrawalFromModuleAccounts(ctx)...,
 	)
 }
 
@@ -468,30 +425,6 @@ func (k BaseKeeper) WriteDeferredDepositsToModuleAccounts(ctx sdk.Context) []abc
 			err := k.addCoins(ctx, recipientAcc.GetAddress(), amount)
 			if err != nil {
 				ctx.Logger().Error(fmt.Sprintf("Failed to add coin=%s to module=%s address=%s, error is: %s", amount, recipient, recipientAcc.GetAddress(), err))
-			}
-		},
-	)
-	return ctx.EventManager().ABCIEvents()
-}
-
-// Process all lazy withdrawls stored previously
-func (k BaseKeeper) WriteDeferredWithdrawalFromModuleAccounts(ctx sdk.Context) []abci.Event {
-	ctx = ctx.WithEventManager(sdk.NewEventManager())
-	ctx.ContextMemCache().RangeOnDeferredWithdrawalsAndDelete(
-		func(recipient string, amount sdk.Coins) {
-			recipientAcc := k.ak.GetModuleAccount(ctx, recipient)
-			if recipientAcc == nil {
-				panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipient))
-			}
-
-			if amount.Empty() {
-				return
-			}
-
-			log.Printf("Removing coin=%s from module=%s address=%s", amount, recipient, recipientAcc.GetAddress())
-			err := k.subUnlockedCoins(ctx, recipientAcc.GetAddress(), amount)
-			if err != nil {
-				ctx.Logger().Error(fmt.Sprintf("Failed to remove coin=%s from module=%s address=%s, error is: %s", amount, recipient, recipientAcc.GetAddress(), err))
 			}
 		},
 	)
@@ -590,24 +523,6 @@ func (k BaseKeeper) MintCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 	return nil
 }
 
-// DeferredMintCoins creates new coins from thin air and adds it to the module account.
-// It will not update the AVL store immediate but instead caches the data in an mem var
-// it requires the user to flush the deposits all at once. Used for deterministic concurrency
-// writes at the end of a block.
-// It will panic if the module account does not exist or is unauthorized.
-func (k BaseKeeper) DeferredMintCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
-	addFn := func(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
-		return ctx.ContextMemCache().UpsertDeferredSends(moduleName, amounts)
-	}
-
-	err := k.createCoins(ctx, moduleName, amounts, addFn)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (k BaseKeeper) destroyCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins, subFn SubFn) error {
 	acc := k.ak.GetModuleAccount(ctx, moduleName)
 	if acc == nil {
@@ -652,42 +567,6 @@ func (k BaseKeeper) BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 		}
 		acc := k.ak.GetModuleAccount(ctx, moduleName)
 		return k.subUnlockedCoins(ctx, acc.GetAddress(), amounts)
-	}
-
-	err := k.destroyCoins(ctx, moduleName, amounts, subFn)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeferredBurnCoins burns coins deletes coins from the balance of the module account.
-// It will not update the AVL store immediate but instead caches the data in an mem var
-// it requires the user to flush the deposits all at once. Used for deterministic concurrency
-// writes at the end of a block.
-// It will panic if the module account does not exist or is unauthorized.
-func (k BaseKeeper) DeferredBurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
-	subFn := func(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
-
-		// Branch Context for validation and fail if the module doesn't have enough coins
-		// but don't write this to the underlying store
-		validationContext, _ := ctx.CacheContext()
-		moduleAcc := k.ak.GetModuleAccount(ctx, moduleName)
-
-		// Try subtract from the in mem var first, prevents the condition where
-		// the module may have a pending deposit that would be enough to pay for this send
-		ok := ctx.ContextMemCache().SafeSubDeferredSends(moduleName, amounts)
-		if ok {
-			return nil
-		}
-
-		err := k.subUnlockedCoins(validationContext, moduleAcc.GetAddress(), amounts)
-		if err != nil {
-			return err
-		}
-
-		return ctx.ContextMemCache().UpsertDeferredWithdrawalsNoSafeSub(moduleName, amounts)
 	}
 
 	err := k.destroyCoins(ctx, moduleName, amounts, subFn)

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -332,7 +332,7 @@ func (k BaseKeeper) SendCoinsFromModuleToAccount(
 	}
 	addCoinsAmount := amt
 	// if we dont call the remainder, the total amount was processed against deferrred sends, so we can "addCoins" the full amount
-	err := ctx.ContextMemCache().SaturatingSubDeferredSends(senderModule, amt, func(amount sdk.Coins) error {
+	err := ctx.ContextMemCache().AtomicSpilloverSubDeferredSends(senderModule, amt, func(amount sdk.Coins) error {
 		// modify the `addCoins` amount to represent the amount subtracted from deferred sends
 		addCoinsAmount = addCoinsAmount.Sub(amount)
 		// sendCoins the remainder
@@ -372,7 +372,7 @@ func (k BaseKeeper) SendCoinsFromModuleToModule(
 
 	addCoinsAmount := amt
 	// if we dont call the remainder, the total amount was processed against deferrred sends, so we can "addCoins" the full amount
-	err := ctx.ContextMemCache().SaturatingSubDeferredSends(senderModule, amt, func(amount sdk.Coins) error {
+	err := ctx.ContextMemCache().AtomicSpilloverSubDeferredSends(senderModule, amt, func(amount sdk.Coins) error {
 		// modify the `addCoins` amount to represent the amount subtracted from deferred sends
 		addCoinsAmount = addCoinsAmount.Sub(amount)
 		// sendCoins the remainder
@@ -571,7 +571,7 @@ func (k BaseKeeper) destroyCoins(ctx sdk.Context, moduleName string, amounts sdk
 func (k BaseKeeper) BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
 	subFn := func(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
 		// first subtract from deferred sends
-		return ctx.ContextMemCache().SaturatingSubDeferredSends(moduleName, amounts, func(remainder sdk.Coins) error {
+		return ctx.ContextMemCache().AtomicSpilloverSubDeferredSends(moduleName, amounts, func(remainder sdk.Coins) error {
 			acc := k.ak.GetModuleAccount(ctx, moduleName)
 			// then sub Unlocked coins on the remainder, if there is an error here, contextMemcache will rollback AND subFn will error
 			return k.subUnlockedCoins(ctx, acc.GetAddress(), remainder)

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -452,6 +452,202 @@ func (suite *IntegrationTestSuite) TestSendCoins() {
 	suite.Require().Equal(newBarCoin(25), coins[0], "expected only bar coins in the account balance, got: %v", coins)
 }
 
+func (suite *IntegrationTestSuite) TestSendCoinsModuleToAccountWithDeferredBalance() {
+	// add module accounts to supply keeper
+	ctx := suite.ctx
+	ctx = ctx.WithContextMemCache(sdk.NewContextMemCache())
+	authKeeper, keeper := suite.initKeepersWithmAccPerms(make(map[string]bool))
+	authKeeper.SetModuleAccount(ctx, multiPermAcc)
+	app := suite.app
+	app.BankKeeper = keeper
+
+	addr1 := sdk.AccAddress("addr1_______________")
+	acc1 := authKeeper.NewAccountWithAddress(ctx, addr1)
+	authKeeper.SetAccount(ctx, acc1)
+
+	deferredBalances := sdk.NewCoins(newFooCoin(10), newBarCoin(50))
+	bankBalances := sdk.NewCoins(newFooCoin(20), newBarCoin(30))
+	// setup deferred balances
+	ctx.ContextMemCache().UpsertDeferredSends(multiPerm, deferredBalances)
+	// set up bank balances
+	suite.Require().NoError(simapp.FundAccount(app.BankKeeper, ctx, multiPermAcc.GetAddress(), bankBalances))
+
+	// send foo with spillover, bar fully backed by deferred balances - no error
+	sendCoins := sdk.NewCoins(newFooCoin(20), newBarCoin(20))
+	// perform send from module to account
+	suite.Require().NoError(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, multiPerm, addr1, sendCoins))
+	expectedDeferredBalances := sdk.NewCoins(newBarCoin(30))
+	expectedBankBalances := sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok := ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals := app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	// assert receiver balances correct
+	userBals := app.BankKeeper.GetAllBalances(ctx, addr1)
+	suite.Require().Equal(sendCoins, userBals)
+
+	// perform same send from module to account - should fail this time - all vals should remain same
+	suite.Require().Error(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, multiPerm, addr1, sendCoins))
+	expectedDeferredBalances = sdk.NewCoins(newBarCoin(30))
+	expectedBankBalances = sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok = ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals = app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	// assert receiver balances correct
+	userBals = app.BankKeeper.GetAllBalances(ctx, addr1)
+	suite.Require().Equal(sendCoins, userBals)
+
+	// perform send 2 that only processes against deferred balances
+	sendCoins2 := sdk.NewCoins(newBarCoin(20))
+	suite.Require().NoError(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, multiPerm, addr1, sendCoins2))
+	expectedDeferredBalances = sdk.NewCoins(newBarCoin(10))
+	expectedBankBalances = sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok = ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals = app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	// assert receiver balances correct
+	userBals = app.BankKeeper.GetAllBalances(ctx, addr1)
+	suite.Require().Equal(sendCoins.Add(sendCoins2...), userBals)
+}
+
+func (suite *IntegrationTestSuite) TestSendCoinsModuleToModuleWithDeferredBalance() {
+	// add module accounts to supply keeper
+	ctx := suite.ctx
+	ctx = ctx.WithContextMemCache(sdk.NewContextMemCache())
+	authKeeper, keeper := suite.initKeepersWithmAccPerms(make(map[string]bool))
+	authKeeper.SetModuleAccount(ctx, multiPermAcc)
+	authKeeper.SetModuleAccount(ctx, randomPermAcc)
+	app := suite.app
+	app.BankKeeper = keeper
+
+	deferredBalances := sdk.NewCoins(newFooCoin(10), newBarCoin(50))
+	bankBalances := sdk.NewCoins(newFooCoin(20), newBarCoin(30))
+	// setup deferred balances
+	ctx.ContextMemCache().UpsertDeferredSends(multiPerm, deferredBalances)
+	// set up bank balances
+	suite.Require().NoError(simapp.FundAccount(app.BankKeeper, ctx, multiPermAcc.GetAddress(), bankBalances))
+
+	// send foo with spillover, bar fully backed by deferred balances - no error
+	sendCoins := sdk.NewCoins(newFooCoin(20), newBarCoin(20))
+	// perform send from module to module
+	suite.Require().NoError(app.BankKeeper.SendCoinsFromModuleToModule(ctx, multiPerm, randomPerm, sendCoins))
+	expectedDeferredBalances := sdk.NewCoins(newBarCoin(30))
+	expectedBankBalances := sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok := ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals := app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	// assert receiver balances correct
+	userBals := app.BankKeeper.GetAllBalances(ctx, randomPermAcc.GetAddress())
+	suite.Require().Equal(sendCoins, userBals)
+
+	// perform same send from module to module - should fail this time - all vals should remain same
+	suite.Require().Error(app.BankKeeper.SendCoinsFromModuleToModule(ctx, multiPerm, randomPerm, sendCoins))
+	expectedDeferredBalances = sdk.NewCoins(newBarCoin(30))
+	expectedBankBalances = sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok = ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals = app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	// assert receiver balances correct
+	userBals = app.BankKeeper.GetAllBalances(ctx, randomPermAcc.GetAddress())
+	suite.Require().Equal(sendCoins, userBals)
+
+	// perform send 2 that only processes against deferred balances
+	sendCoins2 := sdk.NewCoins(newBarCoin(20))
+	suite.Require().NoError(app.BankKeeper.SendCoinsFromModuleToModule(ctx, multiPerm, randomPerm, sendCoins2))
+	expectedDeferredBalances = sdk.NewCoins(newBarCoin(10))
+	expectedBankBalances = sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok = ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals = app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	// assert receiver balances correct
+	userBals = app.BankKeeper.GetAllBalances(ctx, randomPermAcc.GetAddress())
+	suite.Require().Equal(sendCoins.Add(sendCoins2...), userBals)
+}
+
+func (suite *IntegrationTestSuite) TestBurnCoinsWithDeferredBalance() {
+	// add module accounts to supply keeper
+	ctx := suite.ctx
+	ctx = ctx.WithContextMemCache(sdk.NewContextMemCache())
+	authKeeper, keeper := suite.initKeepersWithmAccPerms(make(map[string]bool))
+	authKeeper.SetModuleAccount(ctx, multiPermAcc)
+	app := suite.app
+	app.BankKeeper = keeper
+
+	deferredBalances := sdk.NewCoins(newFooCoin(10), newBarCoin(50))
+
+	// set up balances this way to ensure that supply is incremented appropriately
+	addr2 := sdk.AccAddress([]byte("addr2_______________"))
+	acc2 := app.AccountKeeper.NewAccountWithAddress(ctx, addr2)
+	app.AccountKeeper.SetAccount(ctx, acc2)
+	suite.Require().NoError(simapp.FundAccount(app.BankKeeper, ctx, addr2, deferredBalances))
+	suite.Require().NoError(app.BankKeeper.DeferredSendCoinsFromAccountToModule(ctx, addr2, multiPerm, deferredBalances))
+
+	bankBalances := sdk.NewCoins(newFooCoin(20), newBarCoin(30))
+	// setup deferred balances
+	// ctx.ContextMemCache().UpsertDeferredSends(multiPerm, deferredBalances)
+	// set up bank balances
+	suite.Require().NoError(simapp.FundAccount(app.BankKeeper, ctx, multiPermAcc.GetAddress(), bankBalances))
+
+	// burn foo with spillover, bar fully backed by deferred balances - no error
+	sendCoins := sdk.NewCoins(newFooCoin(20), newBarCoin(20))
+	// perform burn
+	suite.Require().NoError(app.BankKeeper.BurnCoins(ctx, multiPerm, sendCoins))
+	expectedDeferredBalances := sdk.NewCoins(newBarCoin(30))
+	expectedBankBalances := sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok := ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals := app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	suite.Require().Equal(newFooCoin(10), app.BankKeeper.GetSupply(ctx, "foo"))
+	suite.Require().Equal(newBarCoin(60), app.BankKeeper.GetSupply(ctx, "bar"))
+
+	// perform same burn - should fail this time - all vals should remain same
+	suite.Require().Error(app.BankKeeper.BurnCoins(ctx, multiPerm, sendCoins))
+	expectedDeferredBalances = sdk.NewCoins(newBarCoin(30))
+	expectedBankBalances = sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok = ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals = app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	suite.Require().Equal(newFooCoin(10), app.BankKeeper.GetSupply(ctx, "foo"))
+	suite.Require().Equal(newBarCoin(60), app.BankKeeper.GetSupply(ctx, "bar"))
+
+	// perform burn 2 that only processes against deferred balances
+	sendCoins2 := sdk.NewCoins(newBarCoin(20))
+	suite.Require().NoError(app.BankKeeper.BurnCoins(ctx, multiPerm, sendCoins2))
+	expectedDeferredBalances = sdk.NewCoins(newBarCoin(10))
+	expectedBankBalances = sdk.NewCoins(newFooCoin(10), newBarCoin(30))
+	// assert module balances correct
+	deferredBals, ok = ctx.ContextMemCache().GetDeferredSends().Get(multiPerm)
+	suite.Require().True(ok)
+	suite.Require().Equal(expectedDeferredBalances, deferredBals)
+	bals = app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress())
+	suite.Require().Equal(expectedBankBalances, bals)
+	suite.Require().Equal(newFooCoin(10), app.BankKeeper.GetSupply(ctx, "foo"))
+	suite.Require().Equal(newBarCoin(40), app.BankKeeper.GetSupply(ctx, "bar"))
+}
+
 func (suite *IntegrationTestSuite) TestValidateBalance() {
 	app, ctx := suite.app, suite.ctx
 	now := tmtime.Now()


### PR DESCRIPTION
## Describe your changes and provide context
This does several things:
1. Removes the deferred withdrawals and deferred mints/burns.
2. Adds a saturating sub as an alternative to safesub. We can use this and pass ing the subUnlockedCoins to atomically perform a saturating sub against the deferred balance first and then against the underlying balance using subUnlockedCoins.
3. Added a partition function for the coins to separate positive and negative values to separate remainders for the saturating sub
4. refactors the bank keepers to perform saturating subtraction instead of safesub

## Testing performed to validate your change
Unit tests... LOTS of unit tests
