### PR TITLE
Defer closing leveldb when commit is happening

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -305,6 +305,8 @@ func (app *BaseApp) SetDeliverStateToCommit() {
 // height.
 func (app *BaseApp) Commit(ctx context.Context) (res *abci.ResponseCommit, err error) {
 	defer telemetry.MeasureSince(time.Now(), "abci", "commit")
+	app.commitLock.Lock()
+	defer app.commitLock.Unlock()
 
 	if app.stateToCommit == nil {
 		panic("no state to commit")

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -269,6 +269,7 @@ func NewBaseApp(
 		TracingInfo: &tracing.Info{
 			Tracer: &tr,
 		},
+		commitLock: &sync.Mutex{},
 	}
 
 	app.TracingInfo.SetContext(context.Background())

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -158,6 +158,7 @@ type BaseApp struct { //nolint: maligned
 	ChainID string
 
 	votesInfoLock sync.RWMutex
+	commitLock    *sync.Mutex
 
 	compactionInterval uint64
 
@@ -1162,6 +1163,10 @@ func (app *BaseApp) startCompactionRoutine(db dbm.DB) {
 }
 
 func (app *BaseApp) Close() error {
+	// we do not want to close when a commit is ongoing since commit writes to stores
+	// and metadata in a non-atomic way
+	app.commitLock.Lock()
+	defer app.commitLock.Unlock()
 	if err := app.appStore.db.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Describe your changes and provide context
Closing leveldb while committing may lead to data corruption since a version might be partially written by the commit. This change makes it such that closing DB and commit are mutually exclusive.

## Testing performed to validate your change
tested in atlantic-2's db sync node, which restarts a lot

