### PR TITLE
[Certik Audit] Reuse signed blocks window

### DIFF
--- a/x/slashing/keeper/infractions.go
+++ b/x/slashing/keeper/infractions.go
@@ -89,7 +89,7 @@ func (k Keeper) HandleValidatorSignatureConcurrent(ctx sdk.Context, addr cryptot
 		)
 	}
 
-	minHeight := signInfo.StartHeight + k.SignedBlocksWindow(ctx)
+	minHeight := signInfo.StartHeight + window
 	maxMissed := window - minSignedPerWindow
 	shouldSlash = false
 	// if we are past the minimum height and the validator has missed too many blocks, punish them


### PR DESCRIPTION
## Describe your changes and provide context
This data is already queried, so use the in-memroy variable rather than re-query it
## Testing performed to validate your change

