### PR TITLE
Bank unit testing

### DIFF
--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -419,9 +419,7 @@ func (k BaseKeeper) DeferredSendCoinsFromAccountToModule(
 }
 
 func (k BaseKeeper) WriteDeferredOperations(ctx sdk.Context) []abci.Event {
-	return append(
-		k.WriteDeferredDepositsToModuleAccounts(ctx),
-	)
+	return k.WriteDeferredDepositsToModuleAccounts(ctx)
 }
 
 // WriteDeferredDepositsToModuleAccounts Iterates on all the lazy deposits and deposit them into the store


### PR DESCRIPTION
## Describe your changes and provide context
Improve the unit test coverage of bank keeper functional logic. (Omitted some coverage for things like querier which simply call tested functionality in keeper under the hood)

## Testing performed to validate your change

```
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:74:	GetPaginatedTotalSupply			84.6%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:105:	NewBaseKeeper				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:133:	WithMintCoinsRestriction		90.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:154:	DelegateCoins				81.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:202:	UndelegateCoins				78.6%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:230:	GetSupply				90.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:255:	HasSupply				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:263:	GetDenomMetaData			87.5%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:279:	GetAllDenomMetaData			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:292:	IterateAllDenomMetaData			88.9%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:310:	SetDenomMetaData			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:321:	SendCoinsFromModuleToAccount		100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:353:	SendCoinsFromModuleToModule		93.8%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:389:	SendCoinsFromAccountToModule		75.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:404:	DeferredSendCoinsFromAccountToModule	71.4%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:421:	WriteDeferredOperations			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:426:	WriteDeferredDepositsToModuleAccounts	90.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:447:	DelegateCoinsFromAccountToModule	66.7%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:466:	UndelegateCoinsFromModuleToAccount	66.7%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:482:	createCoins				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:520:	MintCoins				88.9%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:536:	destroyCoins				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:569:	BurnCoins				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:588:	setSupply				87.5%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:606:	trackDelegation				87.5%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:623:	trackUndelegation			87.5%
github.com/cosmos/cosmos-sdk/x/bank/keeper/keeper.go:642:	IterateTotalSupply			83.3%


github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:45:		NewBaseSendKeeper			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:60:		GetParams				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:66:		SetParams				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:73:		InputOutputCoins			87.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:133:		SendCoins				91.7%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:173:		subUnlockedCoins			87.5%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:207:		addCoins				90.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:232:		initBalances				88.9%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:251:		setBalance				87.5%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:272:		IsSendEnabledCoins			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:282:		IsSendEnabledCoin			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/send.go:288:		BlockedAddr				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:43:		NewBaseViewKeeper			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:52:		Logger					100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:57:		HasBalance				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:62:		GetAllBalances				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:73:		GetAccountsBalances			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:100:		GetBalance				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:117:		IterateAccountBalances			100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:136:		IterateAllBalances			76.9%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:165:		LockedCoins				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:180:		SpendableCoins				100.0%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:187:		spendableCoins				71.4%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:207:		ValidateBalance				91.7%
github.com/cosmos/cosmos-sdk/x/bank/keeper/view.go:230:		getAccountStore				100.0%
```