### PR TITLE
Fix ante validation

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -972,7 +972,12 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 			storeAccessOpEvents := msCache.GetEvents()
 			accessOps := ctx.TxMsgAccessOps()[acltypes.ANTE_MSG_INDEX]
 
-			missingAccessOps := ctx.MsgValidator().ValidateAccessOperations(accessOps, storeAccessOpEvents)
+			accessOpsDepGen, _ := app.anteDepGenerator([]acltypes.AccessOperation{}, tx, ctx.TxIndex())
+
+			fmt.Println("stored access ops: ", accessOps)
+			fmt.Println("generated access ops: ", accessOpsDepGen)
+
+			missingAccessOps := ctx.MsgValidator().ValidateAccessOperations(accessOpsDepGen, storeAccessOpEvents)
 			if len(missingAccessOps) != 0 {
 				for op := range missingAccessOps {
 					ctx.Logger().Info((fmt.Sprintf("Antehandler Missing Access Operation:%s ", op.String())))

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -972,12 +972,7 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 			storeAccessOpEvents := msCache.GetEvents()
 			accessOps := ctx.TxMsgAccessOps()[acltypes.ANTE_MSG_INDEX]
 
-			accessOpsDepGen, _ := app.anteDepGenerator([]acltypes.AccessOperation{}, tx, ctx.TxIndex())
-
-			fmt.Println("stored access ops: ", accessOps)
-			fmt.Println("generated access ops: ", accessOpsDepGen)
-
-			missingAccessOps := ctx.MsgValidator().ValidateAccessOperations(accessOpsDepGen, storeAccessOpEvents)
+			missingAccessOps := ctx.MsgValidator().ValidateAccessOperations(accessOps, storeAccessOpEvents)
 			if len(missingAccessOps) != 0 {
 				for op := range missingAccessOps {
 					ctx.Logger().Info((fmt.Sprintf("Antehandler Missing Access Operation:%s ", op.String())))

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -508,7 +508,7 @@ func (k Keeper) BuildDependencyDag(ctx sdk.Context, txDecoder sdk.TxDecoder, ant
 			return nil, err
 		}
 		anteDepSet := make(map[acltypes.AccessOperation]struct{})
-
+		anteAccessOpsList := []acltypes.AccessOperation{}
 		for _, accessOp := range anteDeps {
 			// if found in set, we've already included this access Op in out ante dependencies, so skip it
 			if _, found := anteDepSet[accessOp]; found {
@@ -520,7 +520,10 @@ func (k Keeper) BuildDependencyDag(ctx sdk.Context, txDecoder sdk.TxDecoder, ant
 				return nil, err
 			}
 			dependencyDag.AddNodeBuildDependency(acltypes.ANTE_MSG_INDEX, txIndex, accessOp)
+			anteAccessOpsList = append(anteAccessOpsList, accessOp)
 		}
+		// add Access ops for msg for anteMsg
+		dependencyDag.AddAccessOpsForMsg(acltypes.ANTE_MSG_INDEX, txIndex, anteAccessOpsList)
 
 		msgs := tx.GetMsgs()
 		for messageIndex, msg := range msgs {


### PR DESCRIPTION
## Describe your changes and provide context
This properly adds the ante deps message access ops (with index -1) to the map used for comparator validation. Prior to this, we were regenerating the antedeps, but this is a more correct fix.

## Testing performed to validate your change
localsei verification
