### PR TITLE
Revert "Always reset state between proposals (#285)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,18 +37,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-
-## Pending
-
-### Bugfixes
-* (baseapp) [#285](https://github.com/sei-protocol/sei-cosmos/pull/285) Reset state before calling PrepareProposal and ProcessProposal. Copy of [#15487](https://github.com/cosmos/cosmos-sdk/pull/15487)
-
 ## v0.45.9 - 2022-10-14
 
 ATTENTION:
 
-This is a security release for the
-[Dragonberry security advisory](https://forum.cosmos.network/t/ibc-security-advisory-dragonberry/7702).
+This is a security release for the 
+[Dragonberry security advisory](https://forum.cosmos.network/t/ibc-security-advisory-dragonberry/7702). 
 
 All users should upgrade immediately.
 
@@ -72,7 +66,7 @@ replace (
 * [#13323](https://github.com/cosmos/cosmos-sdk/pull/13323) Ensure `withdraw_rewards` rewards are emitted from all actions that result in rewards being withdrawn.
 * [#13321](https://github.com/cosmos/cosmos-sdk/pull/13321) Add flag to disable fast node migration and usage.
 * (store) [#13326](https://github.com/cosmos/cosmos-sdk/pull/13326) Implementation of ADR-038 file StreamingService, backport #8664.
-* (store) [#13540](https://github.com/cosmos/cosmos-sdk/pull/13540) Default fastnode migration to false to prevent suprises. Operators must enable it, unless they have it enabled already.
+* (store) [#13540](https://github.com/cosmos/cosmos-sdk/pull/13540) Default fastnode migration to false to prevent suprises. Operators must enable it, unless they have it enabled already. 
 
 ### API Breaking Changes
 


### PR DESCRIPTION
This reverts commit db47ec3fab7187aa12d75e3564bb0136a8145ed5.

## Describe your changes and provide context
With optimistic processing this is not applicable on our side 

## Testing performed to validate your change
Launched a cluster with 3.0.3, with only this change applied and see that it app hashes
![image](https://github.com/sei-protocol/sei-cosmos/assets/18161326/5d6b0606-aba5-4556-b2c9-6417572eee26)
