### PR TITLE
Add deferred balance to total supply calculation

### DIFF
--- a/x/bank/keeper/invariants.go
+++ b/x/bank/keeper/invariants.go
@@ -62,6 +62,11 @@ func TotalSupply(k Keeper) sdk.Invariant {
 			expectedTotal = expectedTotal.Add(balance)
 			return false
 		})
+		// also iterate over deferred balances
+		k.IterateDeferredBalances(ctx, func(addr sdk.AccAddress, coin sdk.Coin) bool {
+			expectedTotal = expectedTotal.Add(coin)
+			return false
+		})
 
 		broken := !expectedTotal.IsEqual(supply)
 

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -46,6 +46,7 @@ type Keeper interface {
 
 	DeferredSendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	WriteDeferredBalances(ctx sdk.Context) []abci.Event
+	IterateDeferredBalances(ctx sdk.Context, cb func(addr sdk.AccAddress, coin sdk.Coin) bool)
 
 	DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr sdk.AccAddress, amt sdk.Coins) error
 	UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAddr sdk.AccAddress, amt sdk.Coins) error
@@ -426,7 +427,7 @@ func (k BaseKeeper) DeferredSendCoinsFromAccountToModule(
 	return nil
 }
 
-// WriteDeferredDepositsToModuleAccounts Iterates on all the lazy deposits and deposit them into the store
+// WriteDeferredDepositsToModuleAccounts Iterates on all the deferred deposits and deposit them into the store
 func (k BaseKeeper) WriteDeferredBalances(ctx sdk.Context) []abci.Event {
 	if k.deferredCache == nil {
 		panic("bank keeper created without deferred cache")
@@ -475,6 +476,14 @@ func (k BaseKeeper) WriteDeferredBalances(ctx sdk.Context) []abci.Event {
 	// clear deferred cache
 	k.deferredCache.Clear(ctx)
 	return ctx.EventManager().ABCIEvents()
+}
+
+func (k BaseKeeper) IterateDeferredBalances(ctx sdk.Context, cb func(addr sdk.AccAddress, coin sdk.Coin) bool) {
+	if k.deferredCache == nil {
+		panic("bank keeper created without deferred cache")
+	}
+	// pass cb to deferred cache iterator
+	k.deferredCache.IterateDeferredBalances(ctx, cb)
 }
 
 // DelegateCoinsFromAccountToModule delegates coins and transfers them from a

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -622,6 +622,14 @@ func (suite *IntegrationTestSuite) TestWriteDeferredOperations() {
 	// verify that bank balances are only the original bank balances
 	suite.Require().Equal(bankBalances, app.BankKeeper.GetAllBalances(ctx, multiPermAcc.GetAddress()))
 
+	// test iterate over balances
+	totalDeferredBal := sdk.NewCoins()
+	app.BankKeeper.IterateDeferredBalances(ctx, func(addr sdk.AccAddress, coin sdk.Coin) bool {
+		totalDeferredBal = totalDeferredBal.Add(coin)
+		return false
+	})
+	suite.Require().Equal(deferredBalances, totalDeferredBal)
+
 	// write deferred balances
 	app.BankKeeper.WriteDeferredBalances(ctx)
 


### PR DESCRIPTION
## Describe your changes and provide context
Updated the invariant total supply calculation to include deferred balance, since otherwise it would ALWAYS fail because of the fees that are deferred for the broken invariant tx itself.


## Testing performed to validate your change
verified invariant error no longer exists on localsei
updated unit tests for deferred iterator in bankkeeper

