### PR TITLE
Disable crisis msg verify invariant

### DIFF
--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -2,65 +2,68 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	// sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 )
 
 var _ types.MsgServer = Keeper{}
 
 func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvariant) (*types.MsgVerifyInvariantResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
-	constantFee := sdk.NewCoins(k.GetConstantFee(ctx))
+	return nil, fmt.Errorf("verify invariant is currently unsupported")
+	// TODO: uncomment to reimplement verify invariant behavior in the future
+	// ctx := sdk.UnwrapSDKContext(goCtx)
+	// constantFee := sdk.NewCoins(k.GetConstantFee(ctx))
 
-	sender, err := sdk.AccAddressFromBech32(msg.Sender)
-	if err != nil {
-		return nil, err
-	}
-	if err := k.SendCoinsFromAccountToFeeCollector(ctx, sender, constantFee); err != nil {
-		return nil, err
-	}
+	// sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// if err := k.SendCoinsFromAccountToFeeCollector(ctx, sender, constantFee); err != nil {
+	// 	return nil, err
+	// }
 
-	// use a cached context to avoid gas costs during invariants
-	cacheCtx, _ := ctx.CacheContext()
+	// // use a cached context to avoid gas costs during invariants
+	// cacheCtx, _ := ctx.CacheContext()
 
-	found := false
-	msgFullRoute := msg.FullInvariantRoute()
+	// found := false
+	// msgFullRoute := msg.FullInvariantRoute()
 
-	var res string
-	var stop bool
-	for _, invarRoute := range k.Routes() {
-		if invarRoute.FullRoute() == msgFullRoute {
-			res, stop = invarRoute.Invar(cacheCtx)
-			found = true
+	// var res string
+	// var stop bool
+	// for _, invarRoute := range k.Routes() {
+	// 	if invarRoute.FullRoute() == msgFullRoute {
+	// 		res, stop = invarRoute.Invar(cacheCtx)
+	// 		found = true
 
-			break
-		}
-	}
+	// 		break
+	// 	}
+	// }
 
-	if !found {
-		return nil, types.ErrUnknownInvariant
-	}
+	// if !found {
+	// 	return nil, types.ErrUnknownInvariant
+	// }
 
-	if stop {
-		// Currently, because the chain halts here, this transaction will never be included in the
-		// blockchain thus the constant fee will have never been deducted. Thus no refund is required.
+	// if stop {
+	// 	// Currently, because the chain halts here, this transaction will never be included in the
+	// 	// blockchain thus the constant fee will have never been deducted. Thus no refund is required.
 
-		// TODO replace with circuit breaker
-		panic(res)
-	}
+	// 	// TODO replace with circuit breaker
+	// 	panic(res)
+	// }
 
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeInvariant,
-			sdk.NewAttribute(types.AttributeKeyRoute, msg.InvariantRoute),
-		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCrisis),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-	})
+	// ctx.EventManager().EmitEvents(sdk.Events{
+	// 	sdk.NewEvent(
+	// 		types.EventTypeInvariant,
+	// 		sdk.NewAttribute(types.AttributeKeyRoute, msg.InvariantRoute),
+	// 	),
+	// 	sdk.NewEvent(
+	// 		sdk.EventTypeMessage,
+	// 		sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCrisis),
+	// 		sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+	// 	),
+	// })
 
-	return &types.MsgVerifyInvariantResponse{}, nil
+	// return &types.MsgVerifyInvariantResponse{}, nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
This disables the handler behavior for verify invariant. It will be fairly straightforward to undo in the future if/when we would like to re-enable

## Testing performed to validate your change
localsei testing
