### PR TITLE
Update Misleading Code Naming

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -829,7 +829,7 @@ func handleQueryApp(app *BaseApp, path []string, req abci.RequestQuery) abci.Res
 	return sdkerrors.QueryResultWithDebug(
 		sdkerrors.Wrap(
 			sdkerrors.ErrUnknownRequest,
-			"expected second parameter to be either 'simulate' or 'version', neither was present",
+			"expected second parameter to be either 'simulate', 'version' or 'snapshot', neither was present",
 		), app.trace)
 }
 

--- a/baseapp/msg_service_router.go
+++ b/baseapp/msg_service_router.go
@@ -46,9 +46,9 @@ func (msr *MsgServiceRouter) HandlerByTypeURL(typeURL string) MsgServiceHandler 
 // service description, handler is an object which implements that gRPC service.
 //
 // This function PANICs:
-// - if it is called before the service `Msg`s have been registered using
-//   RegisterInterfaces,
-// - or if a service is being registered twice.
+//   - if it is called before the service `Msg`s have been registered using
+//     RegisterInterfaces,
+//   - or if a service is being registered twice.
 func (msr *MsgServiceRouter) RegisterService(sd *grpc.ServiceDesc, handler interface{}) {
 	// Adds a top-level query handler based on the gRPC service name.
 	for _, method := range sd.Methods {
@@ -113,7 +113,7 @@ func (msr *MsgServiceRouter) RegisterService(sd *grpc.ServiceDesc, handler inter
 				return handler(goCtx, req)
 			}
 			if err := req.ValidateBasic(); err != nil {
-				if mm, ok := req.(getter1); ok {
+				if mm, ok := req.(CoinInterface); ok {
 					if !mm.GetAmount().Amount.IsZero() {
 						return nil, err
 					}
@@ -148,6 +148,6 @@ func noopInterceptor(_ context.Context, _ interface{}, _ *grpc.UnaryServerInfo, 
 	return nil, nil
 }
 
-type getter1 interface {
+type CoinInterface interface {
 	GetAmount() sdk.Coin
 }

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -412,20 +412,17 @@ func DefaultSigVerificationGasConsumer(
 	pubkey := sig.PubKey
 	switch pubkey := pubkey.(type) {
 	case *ed25519.PubKey:
-		meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
+		meter.ConsumeGas(params.GetSigVerifyCostED25519(), "ante verify: ed25519")
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "ED25519 public keys are unsupported")
 	case *sr25519.PubKey:
-		meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: sr25519")
+		meter.ConsumeGas(params.GetSr25519VerifyCost(), "ante verify: sr25519")
 		return nil
-
 	case *secp256k1.PubKey:
-		meter.ConsumeGas(params.SigVerifyCostSecp256k1, "ante verify: secp256k1")
+		meter.ConsumeGas(params.GetSigVerifyCostSecp256k1(), "ante verify: secp256k1")
 		return nil
-
 	case *secp256r1.PubKey:
 		meter.ConsumeGas(params.SigVerifyCostSecp256r1(), "ante verify: secp256r1")
 		return nil
-
 	case multisig.PubKey:
 		multisignature, ok := sig.Data.(*signing.MultiSignatureData)
 		if !ok {

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -71,8 +71,10 @@ func DefaultParams() Params {
 
 // SigVerifyCostSecp256r1 returns gas fee of secp256r1 signature verification.
 // Set by benchmarking current implementation:
-//     BenchmarkSig/secp256k1     4334   277167 ns/op   4128 B/op   79 allocs/op
-//     BenchmarkSig/secp256r1    10000   108769 ns/op   1672 B/op   33 allocs/op
+//
+//	BenchmarkSig/secp256k1     4334   277167 ns/op   4128 B/op   79 allocs/op
+//	BenchmarkSig/secp256r1    10000   108769 ns/op   1672 B/op   33 allocs/op
+//
 // Based on the results above secp256k1 is 2.7x is slwer. However we propose to discount it
 // because we are we don't compare the cgo implementation of secp256k1, which is faster.
 func (p Params) SigVerifyCostSecp256r1() uint64 {
@@ -169,4 +171,9 @@ func (p Params) Validate() error {
 	}
 
 	return nil
+}
+
+func (p *Params) GetSr25519VerifyCost() uint64 {
+	// TODO:: define param for sr25519 once its confirmed that it will be supported
+	return p.SigVerifyCostED25519
 }


### PR DESCRIPTION
## Describe your changes and provide context

```
The pointed locations provide a misleading naming for code elements. In particular:

The Sei blockchain supports transactions signed according to the SR25519 scheme. However, the code at the pointed location accounts, for the verification cost, the constant parameter meant for signatures based on the ED25519 scheme. Since costs between the two schemes could actually be different, such constant may be misleading when configuring the parameter as it is meant for a different algorithm. Moreover it can create confusion if ED25519 needs to be supported in the future.

The handleQueryApp function handles queries to the /app endpoint and expects the second element of the path to be one among "simulate", "version" or "snapshot". However the message included in the error in the case the path does not hit one of the allowed keys only cites "simulate" and "version" as expected values, omitting the "snapshot" one, which is also supported.

The getter1 interface is used as a handy tool to call the GetAmount method on the sdk.Msg interface by casting its type. However the getter1 name is not meaningful in respect to its usage.
```
## Testing performed to validate your change

Unit tests