### PR TITLE
apply audit fixes for cache and aclmapping

### DIFF
--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -106,6 +106,8 @@ func (ckv *CommitKVStoreCache) CacheWrap(storeKey types.StoreKey) types.CacheWra
 // If the value doesn't exist in the write-through cache, the query is delegated
 // to the underlying CommitKVStore.
 func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
+	ckv.mtx.Lock()
+	defer ckv.mtx.Unlock()
 
 	types.AssertValidKey(key)
 
@@ -115,9 +117,6 @@ func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
 		// cache hit
 		return value
 	}
-	// in case of cache miss, we need to lock mutex
-	ckv.mtx.Lock()
-	defer ckv.mtx.Unlock()
 
 	// cache miss; write to cache
 	value = ckv.CommitKVStore.Get(key)

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -106,8 +106,6 @@ func (ckv *CommitKVStoreCache) CacheWrap(storeKey types.StoreKey) types.CacheWra
 // If the value doesn't exist in the write-through cache, the query is delegated
 // to the underlying CommitKVStore.
 func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
-	ckv.mtx.Lock()
-	defer ckv.mtx.Unlock()
 
 	types.AssertValidKey(key)
 
@@ -117,6 +115,9 @@ func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
 		// cache hit
 		return value
 	}
+	// in case of cache miss, we need to lock mutex
+	ckv.mtx.Lock()
+	defer ckv.mtx.Unlock()
 
 	// cache miss; write to cache
 	value = ckv.CommitKVStore.Get(key)

--- a/types/accesscontrol/comparator.go
+++ b/types/accesscontrol/comparator.go
@@ -97,12 +97,6 @@ func (c *Comparator) DependencyMatch(accessOp AccessOperation, prefix []byte) bo
 		return false
 	}
 
-	// At this point the resource identifier matches, but the access type is unknown, therefore
-	// it will match both read and writes
-	if accessOp.AccessType == AccessType_UNKNOWN {
-		return true
-	}
-
 	return true
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
This addresses certik audit comments about redundant logic in comparator as well as some inefficient locking in KVstore logic.

## Testing performed to validate your change
Need to test on loadtest cluster
