### PR TITLE
Add a new snapshot directory config

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -214,6 +214,7 @@ type snapshotData struct {
 	snapshotManager    *snapshots.Manager
 	snapshotInterval   uint64 // block interval between state sync snapshots
 	snapshotKeepRecent uint32 // recent state sync snapshots to keep
+	snapshotDirectory  string //  state sync snapshots directory
 }
 
 // NewBaseApp returns a reference to an initialized BaseApp. It accepts a

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -92,6 +92,11 @@ func SetSnapshotKeepRecent(keepRecent uint32) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetSnapshotKeepRecent(keepRecent) }
 }
 
+// SetSnapshotDirectory sets the snapshot directory.
+func SetSnapshotDirectory(dir string) func(*BaseApp) {
+	return func(app *BaseApp) { app.SetSnapshotDirectory(dir) }
+}
+
 // SetSnapshotStore sets the snapshot store.
 func SetSnapshotStore(snapshotStore *snapshots.Store) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetSnapshotStore(snapshotStore) }
@@ -296,6 +301,14 @@ func (app *BaseApp) SetSnapshotKeepRecent(snapshotKeepRecent uint32) {
 		panic("SetSnapshotKeepRecent() on sealed BaseApp")
 	}
 	app.snapshotKeepRecent = snapshotKeepRecent
+}
+
+// SetSnapshotDirectory sets the snapshot directory.
+func (app *BaseApp) SetSnapshotDirectory(dir string) {
+	if app.sealed {
+		panic("SetSnapshotDirectory() on sealed BaseApp")
+	}
+	app.snapshotDirectory = dir
 }
 
 // SetInterfaceRegistry sets the InterfaceRegistry.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -174,6 +174,10 @@ type StateSyncConfig struct {
 	// SnapshotKeepRecent sets the number of recent state sync snapshots to keep.
 	// 0 keeps all snapshots.
 	SnapshotKeepRecent uint32 `mapstructure:"snapshot-keep-recent"`
+
+	// SnapshotDirectory sets the parent directory for where state sync snapshots are persisted.
+	// Default is emtpy which will then store under the app home directory.
+	SnapshotDirectory string `mapstructure:"snapshot-directory"`
 }
 
 // Config defines the server's top level configuration
@@ -264,6 +268,7 @@ func DefaultConfig() *Config {
 		StateSync: StateSyncConfig{
 			SnapshotInterval:   0,
 			SnapshotKeepRecent: 2,
+			SnapshotDirectory:  "",
 		},
 	}
 }
@@ -345,6 +350,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 		StateSync: StateSyncConfig{
 			SnapshotInterval:   v.GetUint64("state-sync.snapshot-interval"),
 			SnapshotKeepRecent: v.GetUint32("state-sync.snapshot-keep-recent"),
+			SnapshotDirectory:  v.GetString("state-sync.snapshot-directory"),
 		},
 	}, nil
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -18,3 +18,8 @@ func TestSetMinimumFees(t *testing.T) {
 	cfg.SetMinGasPrices(sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)})
 	require.Equal(t, "5.000000000000000000foo", cfg.MinGasPrices)
 }
+
+func TestSetSnapshotDirectory(t *testing.T) {
+	cfg := DefaultConfig()
+	require.Equal(t, "", cfg.StateSync.SnapshotDirectory)
+}

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -235,7 +235,8 @@ snapshot-keep-recent = {{ .StateSync.SnapshotKeepRecent }}
 
 # snapshot-directory sets the directory for where state sync snapshots are persisted.
 # default is emtpy which will then store under the app home directory same as before.
-snapshot-directory = {{ .StateSync.SnapshotDirectory }}
+snapshot-directory = "{{ .StateSync.SnapshotDirectory }}"
+
 `
 
 var configTemplate *template.Template

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -232,6 +232,10 @@ snapshot-interval = {{ .StateSync.SnapshotInterval }}
 
 # snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
 snapshot-keep-recent = {{ .StateSync.SnapshotKeepRecent }}
+
+# snapshot-directory sets the directory for where state sync snapshots are persisted.
+# default is emtpy which will then store under the app home directory same as before.
+snapshot-directory = {{ .StateSync.SnapshotDirectory }}
 `
 
 var configTemplate *template.Template

--- a/server/start.go
+++ b/server/start.go
@@ -74,7 +74,7 @@ const (
 	// state sync-related flags
 	FlagStateSyncSnapshotInterval   = "state-sync.snapshot-interval"
 	FlagStateSyncSnapshotKeepRecent = "state-sync.snapshot-keep-recent"
-	FlagStateSyncSnapshotDir        = "state-sync.snapshot-dir"
+	FlagStateSyncSnapshotDir        = "state-sync.snapshot-directory"
 
 	// gRPC-related flags
 	flagGRPCOnly       = "grpc-only"

--- a/server/start.go
+++ b/server/start.go
@@ -74,6 +74,7 @@ const (
 	// state sync-related flags
 	FlagStateSyncSnapshotInterval   = "state-sync.snapshot-interval"
 	FlagStateSyncSnapshotKeepRecent = "state-sync.snapshot-keep-recent"
+	FlagStateSyncSnapshotDir        = "state-sync.snapshot-dir"
 
 	// gRPC-related flags
 	flagGRPCOnly       = "grpc-only"

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -270,12 +270,16 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, t
 		panic(err)
 	}
 
-	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
-	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)
+	snapshotDirectory := cast.ToString(appOpts.Get(server.FlagStateSyncSnapshotDir))
+	if snapshotDirectory == "" {
+		snapshotDirectory = filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
+	}
+
+	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDirectory)
 	if err != nil {
 		panic(err)
 	}
-	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
+	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDirectory)
 	if err != nil {
 		panic(err)
 	}
@@ -298,6 +302,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, t
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetSnapshotDirectory(snapshotDirectory),
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
 		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
 		baseapp.SetCompactionInterval(cast.ToUint64(appOpts.Get(server.FlagCompactionInterval))),


### PR DESCRIPTION
## Describe your changes and provide context
This change add a new config `snapshot-directory` in app.toml to override default directory for storing state sync snapshot.

## Testing performed to validate your change
Tests are covered in https://github.com/sei-protocol/sei-chain/pull/944