### PR TITLE
[occ] MVKV store implementation and tests

### DIFF
--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -92,7 +92,6 @@ func (store *VersionIndexedStore) Get(key []byte) []byte {
 	if mvsValue != nil {
 		if mvsValue.IsEstimate() {
 			store.abortChannel <- scheduler.NewEstimateAbort(mvsValue.Index())
-			// TODO: is it safe to return nil here?
 			return nil
 		} else {
 			// This handles both detecting readset conflicts and updating readset if applicable
@@ -174,7 +173,6 @@ func (store *VersionIndexedStore) Delete(key []byte) {
 	store.setValue(key, nil, true, true)
 }
 
-// TODO: with this current implementation, if we check HAS and the underlying parent store has the value, the readset is still populated with key and value, so even if the value changes, although HAS would have the same result, we would still fail validation. Is this an issue?
 // Has implements types.KVStore.
 func (store *VersionIndexedStore) Has(key []byte) bool {
 	// necessary locking happens within store.Get

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -12,19 +12,6 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-// TODO: when integrating, this store needs to be wrapped by a gaskv so that we can appropriately track ALL of the calls that get directed to the various KV layers. We can store this gas usage calculation in the overall tx execution level, and then use the gas calculation for the transactions that succeed validation
-
-// should manage a parent store AND a multiversion store AND a cache kv that's used for generating read / write sets
-// reads should waterfall from cache kv to multiversion store to parent store
-// writes should only be applied to the cache kv, and later we'll update the multiversion store after tx execution
-
-// TODO: is this helpful? its not really gonna be widely used as a pattern, but maybe good to create a standard for future modifications / implementations for mvkv
-type MVKV interface {
-	// validate
-	// write to multiversion store
-
-}
-
 // Version Indexed Store wraps the multiversion store in a way that implements the KVStore interface, but also stores the index of the transaction, and so store actions are applied to the multiversion store using that index
 type VersionIndexedStore struct {
 	mtx sync.Mutex

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -1,0 +1,169 @@
+package multiversion
+
+import (
+	"io"
+	"sync"
+
+	"github.com/cosmos/cosmos-sdk/internal/conv"
+	"github.com/cosmos/cosmos-sdk/store/types"
+	scheduler "github.com/cosmos/cosmos-sdk/types/occ"
+	dbm "github.com/tendermint/tm-db"
+)
+
+// TODO: when integrating, this store needs to be wrapped by a gaskv so that we can appropriately track ALL of the calls that get directed to the various KV layers. We can store this gas usage calculation in the overall tx execution level, and then use the gas calculation for the transactions that succeed validation
+
+// should manage a parent store AND a multiversion store AND a cache kv that's used for generating read / write sets
+// reads should waterfall from cache kv to multiversion store to parent store
+// writes should only be applied to the cache kv, and later we'll update the multiversion store after tx execution
+
+// Version Indexed Store wraps the multiversion store in a way that implements the KVStore interface, but also stores the index of the transaction, and so store actions are applied to the multiversion store using that index
+type VersionIndexedStore struct {
+	mtx sync.Mutex
+	// used for tracking reads and writes for eventual validation + persistence into multi-version store
+	readset  map[string][]byte // contains the key -> value mapping for all keys read from the store (not mvkv, underlying store)
+	writeset map[string][]byte // contains the key -> value mapping for all keys written to the store
+
+	// TODO: do we need this? - I think so? / maybe we just treat `nil` value in the writeset as a delete
+	deleted *sync.Map
+	// dirty keys that haven't been sorted yet for iteration
+	dirtySet map[string]struct{}
+	// used for iterators - populated at the time of iterator instantiation
+	sortedCache *dbm.MemDB // always ascending sorted
+	// parent stores (both multiversion and underlying parent store)
+	multiVersionStore MultiVersionStore
+	parent            types.KVStore
+	// transaction metadata for versioned operations
+	transactionIndex int
+	incarnation      int
+	// have abort channel here for aborting transactions
+	abortChannel chan scheduler.Abort
+}
+
+var _ types.KVStore = (*VersionIndexedStore)(nil)
+
+func NewVersionIndexedStore(parent types.KVStore, multiVersionStore MultiVersionStore, transactionIndex, incarnation int, abortChannel chan scheduler.Abort) *VersionIndexedStore {
+	return &VersionIndexedStore{
+		readset:           make(map[string][]byte),
+		writeset:          make(map[string][]byte),
+		deleted:           &sync.Map{},
+		dirtySet:          make(map[string]struct{}),
+		sortedCache:       dbm.NewMemDB(),
+		parent:            parent,
+		multiVersionStore: multiVersionStore,
+		transactionIndex:  transactionIndex,
+		incarnation:       incarnation,
+		abortChannel:      abortChannel,
+	}
+}
+
+// GetReadset returns the readset
+func (store *VersionIndexedStore) GetReadset() map[string][]byte {
+	return store.readset
+}
+
+// GetWriteset returns the writeset
+func (store *VersionIndexedStore) GetWriteset() map[string][]byte {
+	return store.writeset
+}
+
+// Get implements types.KVStore.
+func (store *VersionIndexedStore) Get(key []byte) []byte {
+	// first try to get from writeset cache, if cache miss, then try to get from multiversion store, if that misses, then get from parent store
+	// if the key is in the cache, return it
+
+	// don't have RW mutex because we have to update readset
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
+
+	types.AssertValidKey(key)
+	strKey := conv.UnsafeBytesToStr(key)
+	// first check the MVKV writeset, and return that value if present
+	cacheValue, ok := store.writeset[strKey]
+	if ok {
+		// return the value from the cache, no need to update any readset stuff
+		return cacheValue
+	}
+	// read the readset to see if the value exists - and return if applicable
+	if readsetVal, ok := store.readset[strKey]; ok {
+		return readsetVal
+	}
+
+	// if we didn't find it, then we want to check the multivalue store + add to readset if applicable
+	mvsValue := store.multiVersionStore.GetLatestBeforeIndex(store.transactionIndex, key)
+	if mvsValue != nil {
+		// found something,
+		if mvsValue.IsEstimate() {
+			store.abortChannel <- scheduler.NewEstimateAbort(mvsValue.Index())
+			// TODO: is it safe to return nil here?
+			return nil
+		} else {
+			// This handles both detecting readset conflicts and updating readset if applicable
+			return store.parseValueAndUpdateReadset(strKey, mvsValue)
+		}
+	}
+	// if we didn't find it in the multiversion store, then we want to check the parent store + add to readset
+	parentValue := store.parent.Get(key)
+	store.readset[strKey] = parentValue
+	return parentValue
+}
+
+// This functions handles reads with deleted items and values and verifies that the data is consistent to what we currently have in the readset (IF we have a readset value for that key)
+func (store *VersionIndexedStore) parseValueAndUpdateReadset(strKey string, mvsValue MultiVersionValueItem) []byte {
+	value := mvsValue.Value()
+	if mvsValue.IsDeleted() {
+		value = nil
+	}
+	store.readset[strKey] = value
+	return value
+}
+
+// Delete implements types.KVStore.
+func (v *VersionIndexedStore) Delete(key []byte) {
+	// v.multiVersionStore.Delete(v.transactionIndex, key)
+	panic("unimplemented")
+}
+
+// Has implements types.KVStore.
+func (v *VersionIndexedStore) Has(key []byte) bool {
+	panic("unimplemented")
+}
+
+// Set implements types.KVStore.
+func (*VersionIndexedStore) Set(key []byte, value []byte) {
+	panic("unimplemented")
+}
+
+// Iterator implements types.KVStore.
+func (v *VersionIndexedStore) Iterator(start []byte, end []byte) dbm.Iterator {
+	panic("unimplemented")
+}
+
+// ReverseIterator implements types.KVStore.
+func (v *VersionIndexedStore) ReverseIterator(start []byte, end []byte) dbm.Iterator {
+	panic("unimplemented")
+}
+
+// GetStoreType implements types.KVStore.
+func (v *VersionIndexedStore) GetStoreType() types.StoreType {
+	panic("unimplemented")
+}
+
+// CacheWrap implements types.KVStore.
+func (*VersionIndexedStore) CacheWrap(storeKey types.StoreKey) types.CacheWrap {
+	panic("CacheWrap not supported for version indexed store")
+}
+
+// CacheWrapWithListeners implements types.KVStore.
+func (*VersionIndexedStore) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
+	panic("CacheWrapWithListeners not supported for version indexed store")
+}
+
+// CacheWrapWithTrace implements types.KVStore.
+func (*VersionIndexedStore) CacheWrapWithTrace(storeKey types.StoreKey, w io.Writer, tc types.TraceContext) types.CacheWrap {
+	panic("CacheWrapWithTrace not supported for version indexed store")
+}
+
+// GetWorkingHash implements types.KVStore.
+func (v *VersionIndexedStore) GetWorkingHash() ([]byte, error) {
+	panic("should never attempt to get working hash from version indexed store")
+}

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -168,7 +168,7 @@ func (v *VersionIndexedStore) ReverseIterator(start []byte, end []byte) dbm.Iter
 
 // GetStoreType implements types.KVStore.
 func (v *VersionIndexedStore) GetStoreType() types.StoreType {
-	panic("unimplemented")
+	return v.parent.GetStoreType()
 }
 
 // CacheWrap implements types.KVStore.

--- a/store/multiversion/mvkv_test.go
+++ b/store/multiversion/mvkv_test.go
@@ -1,0 +1,75 @@
+package multiversion_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store/cachekv"
+	"github.com/cosmos/cosmos-sdk/store/dbadapter"
+	"github.com/cosmos/cosmos-sdk/store/multiversion"
+	"github.com/cosmos/cosmos-sdk/store/types"
+	scheduler "github.com/cosmos/cosmos-sdk/types/occ"
+	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
+)
+
+type MockParentStore struct{}
+
+func TestVersionIndexedStoreGet(t *testing.T) {
+	mem := dbadapter.Store{DB: dbm.NewMemDB()}
+	parentKVStore := cachekv.NewStore(mem, types.NewKVStoreKey("mock"), 1000)
+	mvs := multiversion.NewMultiVersionStore()
+	// initialize a new VersionIndexedStore
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 1, 2, make(chan scheduler.Abort))
+
+	// mock a value in the parent store
+	parentKVStore.Set([]byte("key1"), []byte("value1"))
+
+	// read key that doesn't exist
+	val := vis.Get([]byte("key2"))
+	require.Nil(t, val)
+
+	// read key that falls down to parent store
+	val2 := vis.Get([]byte("key1"))
+	require.Equal(t, []byte("value1"), val2)
+	// verify value now in readset
+	require.Equal(t, []byte("value1"), vis.GetReadset()["key1"])
+
+	// read the same key that should now be served from the readset (can be verified by setting a different value for the key in the parent store)
+	parentKVStore.Set([]byte("key1"), []byte("value2")) // realistically shouldn't happen, modifying to verify readset access
+	val3 := vis.Get([]byte("key1"))
+	require.Equal(t, []byte("value1"), val3)
+
+	// test deleted value written to MVS but not parent store
+	mvs.Delete(0, 2, []byte("delKey"))
+	parentKVStore.Set([]byte("delKey"), []byte("value4"))
+	valDel := vis.Get([]byte("delKey"))
+	require.Nil(t, valDel)
+
+	// set different key in MVS - for various indices
+	mvs.Set(0, 2, []byte("key3"), []byte("value3"))
+	mvs.Set(2, 1, []byte("key3"), []byte("value4"))
+	mvs.SetEstimate(5, 0, []byte("key3"))
+
+	// read the key that falls down to MVS
+	val4 := vis.Get([]byte("key3"))
+	// should equal value3 because value4 is later than the key in question
+	require.Equal(t, []byte("value3"), val4)
+
+	// try a read that falls through to MVS with a later tx index
+	vis2 := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 3, 2, make(chan scheduler.Abort))
+	val5 := vis2.Get([]byte("key3"))
+	// should equal value3 because value4 is later than the key in question
+	require.Equal(t, []byte("value4"), val5)
+
+	// test estimate values writing to abortChannel
+	abortChannel := make(chan scheduler.Abort)
+	vis3 := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 6, 2, abortChannel)
+	go func() {
+		vis3.Get([]byte("key3"))
+	}()
+	abort := <-abortChannel // read the abort from the channel
+	require.Equal(t, 5, abort.DependentTxIdx)
+	require.Equal(t, scheduler.ErrReadEstimate, abort.Err)
+
+	// TODO: also test values that are served from writeset - needs to be AFTER `set` is implemented
+}

--- a/store/multiversion/mvkv_test.go
+++ b/store/multiversion/mvkv_test.go
@@ -108,3 +108,20 @@ func TestVersionIndexedStoreSetters(t *testing.T) {
 	require.Equal(t, []byte("value3"), vis.Get([]byte("key2")))
 	require.Zero(t, len(vis.GetReadset()))
 }
+
+func TestVersionIndexedStoreBoilerplateFunctions(t *testing.T) {
+	mem := dbadapter.Store{DB: dbm.NewMemDB()}
+	parentKVStore := cachekv.NewStore(mem, types.NewKVStoreKey("mock"), 1000)
+	mvs := multiversion.NewMultiVersionStore()
+	// initialize a new VersionIndexedStore
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 1, 2, make(chan scheduler.Abort))
+
+	// asserts panics where appropriate
+	require.Panics(t, func() { vis.CacheWrap(types.NewKVStoreKey("mock")) })
+	require.Panics(t, func() { vis.CacheWrapWithListeners(types.NewKVStoreKey("mock"), nil) })
+	require.Panics(t, func() { vis.CacheWrapWithTrace(types.NewKVStoreKey("mock"), nil, nil) })
+	require.Panics(t, func() { vis.GetWorkingHash() })
+
+	// assert properly returns store type
+	require.Equal(t, types.StoreTypeDB, vis.GetStoreType())
+}

--- a/types/occ/scheduler.go
+++ b/types/occ/scheduler.go
@@ -1,0 +1,20 @@
+package scheduler
+
+import "errors"
+
+var (
+	ErrReadEstimate = errors.New("multiversion store value contains estimate, cannot read, aborting")
+)
+
+// define the return struct for abort due to conflict
+type Abort struct {
+	DependentTxIdx int
+	Err            error
+}
+
+func NewEstimateAbort(dependentTxIdx int) Abort {
+	return Abort{
+		DependentTxIdx: dependentTxIdx,
+		Err:            ErrReadEstimate,
+	}
+}


### PR DESCRIPTION
## Describe your changes and provide context
This implements an mvkv store that will manage access from a transaction execution to the underlying multiversion store and underlying parent store if the multiversion store doesn't have that key. It will first serve any reads from its own writeset and readset, but if it does have to fall through to multiversion store or parent store, it will add those values to the readset.

## Testing performed to validate your change
Unit tests
