### PR TITLE
[occ] Add concurrency worker configuration

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -60,7 +60,8 @@ const (
 	FlagArchivalArweaveIndexDBFullPath = "archival-arweave-index-db-full-path"
 	FlagArchivalArweaveNodeURL         = "archival-arweave-node-url"
 
-	FlagChainID = "chain-id"
+	FlagChainID            = "chain-id"
+	FlagConcurrencyWorkers = "concurrency-workers"
 )
 
 var (
@@ -294,6 +295,17 @@ func NewBaseApp(
 	app.startCompactionRoutine(db)
 	if app.orphanConfig != nil {
 		app.cms.(*rootmulti.Store).SetOrphanConfig(app.orphanConfig)
+	}
+
+	// initialize concurrency-workers to the flag's value
+	// this avoids forcing every implementation to pass an option
+	if app.ConcurrencyWorkers == 0 {
+		app.ConcurrencyWorkers = cast.ToInt(appOpts.Get(FlagConcurrencyWorkers))
+	}
+	// this can only occur if concurrency-workers is explicitly set to 0
+	// a valid default value applies if not set at all
+	if app.ConcurrencyWorkers == 0 || app.ConcurrencyWorkers < -1 {
+		panic("--concurrency-workers must be greater than 0 or -1 for unlimited")
 	}
 
 	return app

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -171,7 +171,7 @@ type BaseApp struct { //nolint: maligned
 
 	TracingInfo *tracing.Info
 
-	ConcurrencyWorkers int
+	concurrencyWorkers int
 }
 
 type appStore struct {
@@ -300,12 +300,12 @@ func NewBaseApp(
 
 	// if no option overrode already, initialize to the flags value
 	// this avoids forcing every implementation to pass an option, but allows it
-	if app.ConcurrencyWorkers == 0 {
-		app.ConcurrencyWorkers = cast.ToInt(appOpts.Get(FlagConcurrencyWorkers))
+	if app.concurrencyWorkers == 0 {
+		app.concurrencyWorkers = cast.ToInt(appOpts.Get(FlagConcurrencyWorkers))
 	}
 	// safely default this to the default value if 0
-	if app.ConcurrencyWorkers == 0 {
-		app.ConcurrencyWorkers = config.DefaultConcurrencyWorkers
+	if app.concurrencyWorkers == 0 {
+		app.concurrencyWorkers = config.DefaultConcurrencyWorkers
 	}
 
 	return app
@@ -319,6 +319,11 @@ func (app *BaseApp) Name() string {
 // AppVersion returns the application's protocol version.
 func (app *BaseApp) AppVersion() uint64 {
 	return app.appVersion
+}
+
+// ConcurrencyWorkers returns the number of concurrent workers for the BaseApp.
+func (app *BaseApp) ConcurrencyWorkers() int {
+	return app.concurrencyWorkers
 }
 
 // Version returns the application's version string.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/server/config"
 	"reflect"
 	"strings"
 	"sync"
@@ -16,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/cosmos/cosmos-sdk/utils/tracing"
 	"github.com/gogo/protobuf/proto"
 	sdbm "github.com/sei-protocol/sei-tm-db/backends"
@@ -298,13 +298,12 @@ func NewBaseApp(
 		app.cms.(*rootmulti.Store).SetOrphanConfig(app.orphanConfig)
 	}
 
-	// initialize concurrency-workers to the flag's value
-	// this avoids forcing every implementation to pass an option
+	// if no option overrode already, initialize to the flags value
+	// this avoids forcing every implementation to pass an option, but allows it
 	if app.ConcurrencyWorkers == 0 {
 		app.ConcurrencyWorkers = cast.ToInt(appOpts.Get(FlagConcurrencyWorkers))
 	}
-	// this can only occur if concurrency-workers is explicitly set to 0
-	// a valid default value applies if not set at all
+	// safely default this to the default value if 0
 	if app.ConcurrencyWorkers == 0 {
 		app.ConcurrencyWorkers = config.DefaultConcurrencyWorkers
 	}

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -60,7 +60,8 @@ const (
 	FlagArchivalArweaveIndexDBFullPath = "archival-arweave-index-db-full-path"
 	FlagArchivalArweaveNodeURL         = "archival-arweave-node-url"
 
-	FlagChainID = "chain-id"
+	FlagChainID            = "chain-id"
+	FlagConcurrencyWorkers = "concurrency-workers"
 )
 
 var (
@@ -168,6 +169,8 @@ type BaseApp struct { //nolint: maligned
 	TmConfig *tmcfg.Config
 
 	TracingInfo *tracing.Info
+
+	ConcurrencyWorkers int
 }
 
 type appStore struct {
@@ -293,6 +296,7 @@ func NewBaseApp(
 	if app.orphanConfig != nil {
 		app.cms.(*rootmulti.Store).SetOrphanConfig(app.orphanConfig)
 	}
+	app.ConcurrencyWorkers = cast.ToInt(appOpts.Get(FlagConcurrencyWorkers))
 
 	return app
 }

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/server/config"
 	"reflect"
 	"strings"
 	"sync"
@@ -304,8 +305,8 @@ func NewBaseApp(
 	}
 	// this can only occur if concurrency-workers is explicitly set to 0
 	// a valid default value applies if not set at all
-	if app.ConcurrencyWorkers == 0 || app.ConcurrencyWorkers < -1 {
-		panic("--concurrency-workers must be greater than 0 or -1 for unlimited")
+	if app.ConcurrencyWorkers == 0 {
+		app.ConcurrencyWorkers = config.DefaultConcurrencyWorkers
 	}
 
 	return app

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -60,8 +60,7 @@ const (
 	FlagArchivalArweaveIndexDBFullPath = "archival-arweave-index-db-full-path"
 	FlagArchivalArweaveNodeURL         = "archival-arweave-node-url"
 
-	FlagChainID            = "chain-id"
-	FlagConcurrencyWorkers = "concurrency-workers"
+	FlagChainID = "chain-id"
 )
 
 var (
@@ -296,7 +295,6 @@ func NewBaseApp(
 	if app.orphanConfig != nil {
 		app.cms.(*rootmulti.Store).SetOrphanConfig(app.orphanConfig)
 	}
-	app.ConcurrencyWorkers = cast.ToInt(appOpts.Get(FlagConcurrencyWorkers))
 
 	return app
 }

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -87,6 +87,10 @@ func SetSnapshotInterval(interval uint64) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetSnapshotInterval(interval) }
 }
 
+func SetConcurrencyWorkers(workers int) func(*BaseApp) {
+	return func(app *BaseApp) { app.SetConcurrencyWorkers(workers) }
+}
+
 // SetSnapshotKeepRecent sets the recent snapshots to keep.
 func SetSnapshotKeepRecent(keepRecent uint32) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetSnapshotKeepRecent(keepRecent) }
@@ -293,6 +297,13 @@ func (app *BaseApp) SetSnapshotInterval(snapshotInterval uint64) {
 		panic("SetSnapshotInterval() on sealed BaseApp")
 	}
 	app.snapshotInterval = snapshotInterval
+}
+
+func (app *BaseApp) SetConcurrencyWorkers(workers int) {
+	if app.sealed {
+		panic("SetConcurrencyWorkers() on sealed BaseApp")
+	}
+	app.ConcurrencyWorkers = workers
 }
 
 // SetSnapshotKeepRecent sets the number of recent snapshots to keep.

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -303,7 +303,7 @@ func (app *BaseApp) SetConcurrencyWorkers(workers int) {
 	if app.sealed {
 		panic("SetConcurrencyWorkers() on sealed BaseApp")
 	}
-	app.ConcurrencyWorkers = workers
+	app.concurrencyWorkers = workers
 }
 
 // SetSnapshotKeepRecent sets the number of recent snapshots to keep.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -88,6 +88,10 @@ type BaseConfig struct {
 	SeparateOrphanVersionsToKeep int64  `mapstructure:"separate-orphan-versions-to-keep"`
 	NumOrphanPerFile             int    `mapstructure:"num-orphan-per-file"`
 	OrphanDirectory              string `mapstructure:"orphan-dir"`
+
+	// ConcurrencyWorkers defines the number of workers to use for concurrent
+	// transaction execution. A value of -1 means unlimited workers.  Default value is 10.
+	ConcurrencyWorkers int `mapstructure:"concurrency-workers"`
 }
 
 // APIConfig defines the API listener configuration.
@@ -236,6 +240,7 @@ func DefaultConfig() *Config {
 			IAVLDisableFastNode: true,
 			CompactionInterval:  0,
 			NoVersioning:        false,
+			ConcurrencyWorkers:  10,
 		},
 		Telemetry: telemetry.Config{
 			Enabled:      false,
@@ -310,6 +315,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			SeparateOrphanVersionsToKeep: v.GetInt64("separate-orphan-versions-to-keep"),
 			NumOrphanPerFile:             v.GetInt("num-orphan-per-file"),
 			OrphanDirectory:              v.GetString("orphan-dir"),
+			ConcurrencyWorkers:           v.GetInt("concurrency-workers"),
 		},
 		Telemetry: telemetry.Config{
 			ServiceName:             v.GetString("telemetry.service-name"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -374,9 +374,6 @@ func (c Config) ValidateBasic(tendermintConfig *tmcfg.Config) error {
 			"cannot enable state sync snapshots with '%s' pruning setting", storetypes.PruningOptionEverything,
 		)
 	}
-	if c.ConcurrencyWorkers == 0 || c.ConcurrencyWorkers < -2 {
-		return sdkerrors.ErrAppConfig.Wrapf("concurrency-workers must be a positive integer or -1 (unlimited)")
-	}
 
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -21,6 +21,9 @@ const (
 
 	// DefaultGRPCWebAddress defines the default address to bind the gRPC-web server to.
 	DefaultGRPCWebAddress = "0.0.0.0:9091"
+
+	// DefaultConcurrencyWorkers defines the default workers to use for concurrent transactions
+	DefaultConcurrencyWorkers = 10
 )
 
 // BaseConfig defines the server's basic configuration
@@ -240,7 +243,7 @@ func DefaultConfig() *Config {
 			IAVLDisableFastNode: true,
 			CompactionInterval:  0,
 			NoVersioning:        false,
-			ConcurrencyWorkers:  10,
+			ConcurrencyWorkers:  DefaultConcurrencyWorkers,
 		},
 		Telemetry: telemetry.Config{
 			Enabled:      false,
@@ -370,6 +373,9 @@ func (c Config) ValidateBasic(tendermintConfig *tmcfg.Config) error {
 		return sdkerrors.ErrAppConfig.Wrapf(
 			"cannot enable state sync snapshots with '%s' pruning setting", storetypes.PruningOptionEverything,
 		)
+	}
+	if c.ConcurrencyWorkers == 0 || c.ConcurrencyWorkers < -2 {
+		return sdkerrors.ErrAppConfig.Wrapf("concurrency-workers must be a positive integer or -1 (unlimited)")
 	}
 
 	return nil

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -28,9 +28,3 @@ func TestSetConcurrencyWorkers(t *testing.T) {
 	cfg := DefaultConfig()
 	require.Equal(t, 10, cfg.ConcurrencyWorkers)
 }
-
-func TestValidateBasic(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.ConcurrencyWorkers = -2
-	require.Error(t, cfg.ValidateBasic(nil))
-}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -23,3 +23,14 @@ func TestSetSnapshotDirectory(t *testing.T) {
 	cfg := DefaultConfig()
 	require.Equal(t, "", cfg.StateSync.SnapshotDirectory)
 }
+
+func TestSetConcurrencyWorkers(t *testing.T) {
+	cfg := DefaultConfig()
+	require.Equal(t, 10, cfg.ConcurrencyWorkers)
+}
+
+func TestValidateBasic(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ConcurrencyWorkers = -2
+	require.Error(t, cfg.ValidateBasic(nil))
+}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -26,5 +26,5 @@ func TestSetSnapshotDirectory(t *testing.T) {
 
 func TestSetConcurrencyWorkers(t *testing.T) {
 	cfg := DefaultConfig()
-	require.Equal(t, 10, cfg.ConcurrencyWorkers)
+	require.Equal(t, DefaultConcurrencyWorkers, cfg.ConcurrencyWorkers)
 }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -101,7 +101,7 @@ num-orphan-per-file = {{ .BaseConfig.NumOrphanPerFile }}
 # if separate-orphan-storage is true, where to store orphan data
 orphan-dir = "{{ .BaseConfig.OrphanDirectory }}"
 
-# ConcurrencyWorkers defines how many workers to run for concurrent transaction execution
+# concurrency-workers defines how many workers to run for concurrent transaction execution
 concurrency-workers = {{ .BaseConfig.ConcurrencyWorkers }}
 
 ###############################################################################

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -102,7 +102,7 @@ num-orphan-per-file = {{ .BaseConfig.NumOrphanPerFile }}
 orphan-dir = "{{ .BaseConfig.OrphanDirectory }}"
 
 # concurrency-workers defines how many workers to run for concurrent transaction execution
-concurrency-workers = {{ .BaseConfig.ConcurrencyWorkers }}
+# concurrency-workers = {{ .BaseConfig.ConcurrencyWorkers }}
 
 ###############################################################################
 ###                         Telemetry Configuration                         ###

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -102,7 +102,7 @@ num-orphan-per-file = {{ .BaseConfig.NumOrphanPerFile }}
 orphan-dir = "{{ .BaseConfig.OrphanDirectory }}"
 
 # ConcurrencyWorkers defines how many workers to run for concurrent transaction execution
-concurrency-workers = "{{ .BaseConfig.ConcurrencyWorkers }}"
+concurrency-workers = {{ .BaseConfig.ConcurrencyWorkers }}
 
 ###############################################################################
 ###                         Telemetry Configuration                         ###

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -101,6 +101,9 @@ num-orphan-per-file = {{ .BaseConfig.NumOrphanPerFile }}
 # if separate-orphan-storage is true, where to store orphan data
 orphan-dir = "{{ .BaseConfig.OrphanDirectory }}"
 
+# ConcurrencyWorkers defines how many workers to run for concurrent transaction execution
+concurrency-workers = "{{ .BaseConfig.ConcurrencyWorkers }}"
+
 ###############################################################################
 ###                         Telemetry Configuration                         ###
 ###############################################################################

--- a/server/start.go
+++ b/server/start.go
@@ -70,6 +70,7 @@ const (
 	FlagSeparateOrphanVersionsToKeep = "separate-orphan-versions-to-keep"
 	FlagNumOrphanPerFile             = "num-orphan-per-file"
 	FlagOrphanDirectory              = "orphan-dir"
+	FlagConcurrencyWorkers           = "concurrency-workers"
 
 	// state sync-related flags
 	FlagStateSyncSnapshotInterval   = "state-sync.snapshot-interval"
@@ -252,6 +253,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Int64(FlagSeparateOrphanVersionsToKeep, 2, "Number of versions to keep if storing orphans separately")
 	cmd.Flags().Int(FlagNumOrphanPerFile, 100000, "Number of orphans to store on each file if storing orphans separately")
 	cmd.Flags().String(FlagOrphanDirectory, path.Join(defaultNodeHome, "orphans"), "Directory to store orphan files if storing orphans separately")
+	cmd.Flags().Int(FlagConcurrencyWorkers, 0, "Number of workers to use for concurrent transaction execution")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")

--- a/server/start.go
+++ b/server/start.go
@@ -253,7 +253,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Int64(FlagSeparateOrphanVersionsToKeep, 2, "Number of versions to keep if storing orphans separately")
 	cmd.Flags().Int(FlagNumOrphanPerFile, 100000, "Number of orphans to store on each file if storing orphans separately")
 	cmd.Flags().String(FlagOrphanDirectory, path.Join(defaultNodeHome, "orphans"), "Directory to store orphan files if storing orphans separately")
-	cmd.Flags().Int(FlagConcurrencyWorkers, 0, "Number of workers to process concurrent transactions")
+	cmd.Flags().Int(FlagConcurrencyWorkers, 10, "Number of workers to process concurrent transactions")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")

--- a/server/start.go
+++ b/server/start.go
@@ -253,7 +253,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Int64(FlagSeparateOrphanVersionsToKeep, 2, "Number of versions to keep if storing orphans separately")
 	cmd.Flags().Int(FlagNumOrphanPerFile, 100000, "Number of orphans to store on each file if storing orphans separately")
 	cmd.Flags().String(FlagOrphanDirectory, path.Join(defaultNodeHome, "orphans"), "Directory to store orphan files if storing orphans separately")
-	cmd.Flags().Int(FlagConcurrencyWorkers, 10, "Number of workers to process concurrent transactions")
+	cmd.Flags().Int(FlagConcurrencyWorkers, config.DefaultConcurrencyWorkers, "Number of workers to process concurrent transactions")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")

--- a/server/start.go
+++ b/server/start.go
@@ -253,7 +253,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Int64(FlagSeparateOrphanVersionsToKeep, 2, "Number of versions to keep if storing orphans separately")
 	cmd.Flags().Int(FlagNumOrphanPerFile, 100000, "Number of orphans to store on each file if storing orphans separately")
 	cmd.Flags().String(FlagOrphanDirectory, path.Join(defaultNodeHome, "orphans"), "Directory to store orphan files if storing orphans separately")
-	cmd.Flags().Int(FlagConcurrencyWorkers, 0, "Number of workers to use for concurrent transaction execution")
+	cmd.Flags().Int(FlagConcurrencyWorkers, 0, "Number of workers to process concurrent transactions")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -312,6 +312,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, t
 			NumOrphansPerFile:           cast.ToInt(appOpts.Get(server.FlagNumOrphanPerFile)),
 			OrphanDirectory:             cast.ToString(appOpts.Get(server.FlagOrphanDirectory)),
 		}),
+		baseapp.SetConcurrencyWorkers(cast.ToInt(appOpts.Get(server.FlagConcurrencyWorkers))),
 	)
 }
 

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -312,7 +312,6 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, t
 			NumOrphansPerFile:           cast.ToInt(appOpts.Get(server.FlagNumOrphanPerFile)),
 			OrphanDirectory:             cast.ToString(appOpts.Get(server.FlagOrphanDirectory)),
 		}),
-		baseapp.SetConcurrencyWorkers(cast.ToInt(appOpts.Get(server.FlagConcurrencyWorkers))),
 	)
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
- `ConcurrencyWorkers` represents the number of workers to use for concurrent transactions
- since concurrrency-workers is a baseapp-level setting, implementations (like sei-chain) shouldn't have to pass it (but can)
- it defaults to 10 if not set (via cli default value)
- it defaults to 10 in app.toml only if that file is being created (and doesn't exist)
- if explicitly set to zero on command line, it will override with the default (for safety)
- cli takes precedence over the config file
- no one has to do anything to get it to be 10 (no config changes no sei-chain changes required (aside from new cosmos version))

## Testing performed to validate your change
- Unit Tests for setting the value
- Manually testing scenarios with sei-chain
