### PR TITLE
[occ] Occ multiversion store

### DIFF
--- a/store/multiversion/data_structures_test.go
+++ b/store/multiversion/data_structures_test.go
@@ -198,3 +198,31 @@ func TestMultiversionItemEstimate(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, one, value.Value())
 }
+
+func TestMultiversionItemRemove(t *testing.T) {
+	mvItem := mv.NewMultiVersionItem()
+
+	mvItem.Set(1, 0, []byte("one"))
+	mvItem.Set(2, 0, []byte("two"))
+
+	mvItem.Remove(2)
+	value, found := mvItem.GetLatest()
+	require.True(t, found)
+	require.Equal(t, []byte("one"), value.Value())
+}
+
+func TestMultiversionItemGetLatestNonEstimate(t *testing.T) {
+	mvItem := mv.NewMultiVersionItem()
+
+	mvItem.SetEstimate(3, 0)
+
+	value, found := mvItem.GetLatestNonEstimate()
+	require.False(t, found)
+	require.Nil(t, value)
+
+	mvItem.Set(1, 0, []byte("one"))
+	value, found = mvItem.GetLatestNonEstimate()
+	require.True(t, found)
+	require.Equal(t, []byte("one"), value.Value())
+
+}

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -14,11 +14,17 @@ type MultiVersionStore interface {
 	SetEstimate(index int, incarnation int, key []byte)
 	Delete(index int, incarnation int, key []byte)
 	Has(index int, key []byte) bool
+	Iterator(index int, start, end []byte) types.Iterator
+	ReverseIterator(index int, start, end []byte) types.Iterator
 	WriteLatestToStore(parentStore types.KVStore)
-	SetWriteset(index int, incarnation int, writeset map[string][]byte)
+	SetWriteset(index int, incarnation int, writeset WriteSet)
 	InvalidateWriteset(index int, incarnation int)
-	SetEstimatedWriteset(index int, incarnation int, writeset map[string][]byte)
+	SetEstimatedWriteset(index int, incarnation int, writeset WriteSet)
 }
+
+type WriteSet map[string][]byte
+
+var _ MultiVersionStore = (*Store)(nil)
 
 type Store struct {
 	mtx sync.RWMutex
@@ -26,13 +32,13 @@ type Store struct {
 	multiVersionMap map[string]MultiVersionValue
 	// TODO: do we need to support iterators as well similar to how cachekv does it - yes
 
-	txWritesets map[int]map[string][]byte // map of tx index -> writeset
+	txWritesetKeys map[int][]string // map of tx index -> writeset keys
 }
 
 func NewMultiVersionStore() *Store {
 	return &Store{
 		multiVersionMap: make(map[string]MultiVersionValue),
-		txWritesets:     make(map[int]map[string][]byte),
+		txWritesetKeys:  make(map[int][]string),
 	}
 }
 
@@ -104,13 +110,42 @@ func (s *Store) Set(index int, incarnation int, key []byte, value []byte) {
 	s.multiVersionMap[keyString].Set(index, incarnation, value)
 }
 
+func (s *Store) removeOldWriteset(index int, newWriteSet WriteSet) {
+	writeset := make(map[string][]byte)
+	if newWriteSet != nil {
+		// if non-nil writeset passed in, we can use that to optimize removals
+		writeset = newWriteSet
+	}
+	// if there is already a writeset existing, we should remove that fully
+	if keys, ok := s.txWritesetKeys[index]; ok {
+		// we need to delete all of the keys in the writeset from the multiversion store
+		for _, key := range keys {
+			// small optimization to check if the new writeset is going to write this key, if so, we can leave it behind
+			if _, ok := writeset[key]; ok {
+				// we don't need to remove this key because it will be overwritten anyways - saves the operation of removing + rebalancing underlying btree
+				continue
+			}
+			// remove from the appropriate item if present in multiVersionMap
+			if val, ok := s.multiVersionMap[key]; ok {
+				val.Remove(index)
+			}
+		}
+	}
+	// unset the writesetKeys for this index
+	s.txWritesetKeys[index] = nil
+}
+
 // SetWriteset sets a writeset for a transaction index, and also writes all of the multiversion items in the writeset to the multiversion store.
-func (s *Store) SetWriteset(index int, incarnation int, writeset map[string][]byte) {
+func (s *Store) SetWriteset(index int, incarnation int, writeset WriteSet) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	s.txWritesets[index] = writeset
+	// remove old writeset if it exists
+	s.removeOldWriteset(index, writeset)
+
+	writeSetKeys := make([]string, 0, len(writeset))
 	for key, value := range writeset {
+		writeSetKeys = append(writeSetKeys, key)
 		s.tryInitMultiVersionItem(key)
 		if value == nil {
 			// delete if nil value
@@ -119,6 +154,8 @@ func (s *Store) SetWriteset(index int, incarnation int, writeset map[string][]by
 			s.multiVersionMap[key].Set(index, incarnation, value)
 		}
 	}
+	sort.Strings(writeSetKeys)
+	s.txWritesetKeys[index] = writeSetKeys
 }
 
 // InvalidateWriteset iterates over the keys for the given index and incarnation writeset and replaces with ESTIMATEs
@@ -126,25 +163,33 @@ func (s *Store) InvalidateWriteset(index int, incarnation int) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	if _, ok := s.txWritesets[index]; ok {
-		for key := range s.txWritesets[index] {
+	if keys, ok := s.txWritesetKeys[index]; ok {
+		for _, key := range keys {
 			// invalidate all of the writeset items - is this suboptimal? - we could potentially do concurrently if slow because locking is on an item specific level
 			s.tryInitMultiVersionItem(key) // this SHOULD no-op because we're invalidating existing keys
 			s.multiVersionMap[key].SetEstimate(index, incarnation)
 		}
-		s.txWritesets[index] = nil
 	}
+	// we leave the writeset in place because we'll need it for key removal later if/when we replace with a new writeset
 }
 
 // SetEstimatedWriteset is used to directly write estimates instead of writing a writeset and later invalidating
-func (s *Store) SetEstimatedWriteset(index int, incarnation int, writeset map[string][]byte) {
+func (s *Store) SetEstimatedWriteset(index int, incarnation int, writeset WriteSet) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
+	// remove old writeset if it exists
+	s.removeOldWriteset(index, writeset)
+
+	writeSetKeys := make([]string, 0, len(writeset))
+	// still need to save the writeset so we can remove the elements later:
 	for key := range writeset {
+		writeSetKeys = append(writeSetKeys, key)
 		s.tryInitMultiVersionItem(key)
 		s.multiVersionMap[key].SetEstimate(index, incarnation)
 	}
+	sort.Strings(writeSetKeys)
+	s.txWritesetKeys[index] = writeSetKeys
 }
 
 // SetEstimate implements MultiVersionStore.
@@ -167,7 +212,42 @@ func (s *Store) Delete(index int, incarnation int, key []byte) {
 	s.multiVersionMap[keyString].Delete(index, incarnation)
 }
 
-var _ MultiVersionStore = (*Store)(nil)
+// Iterator implements MultiVersionStore.
+func (store *Store) Iterator(index int, start, end []byte) types.Iterator {
+	// return store.iterator(index, start, end, true)
+	panic("unimplemented")
+}
+
+// ReverseIterator implements MultiVersionStore.
+func (store *Store) ReverseIterator(index int, start, end []byte) types.Iterator {
+	// return store.iterator(index, start, end, false)
+	panic("unimplemented")
+}
+
+// func (store *Store) iterator(index int, start, end []byte, ascending bool) types.Iterator {
+// 	store.mtx.Lock()
+// 	defer store.mtx.Unlock()
+
+// 	var parent, cache types.Iterator
+
+// 	if ascending {
+// 		parent = store.parent.Iterator(start, end)
+// 	} else {
+// 		parent = store.parent.ReverseIterator(start, end)
+// 	}
+// 	defer func() {
+// 		if err := recover(); err != nil {
+// 			// close out parent iterator, then reraise panic
+// 			if parent != nil {
+// 				parent.Close()
+// 			}
+// 			panic(err)
+// 		}
+// 	}()
+// 	store.dirtyItems(start, end)
+// 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
+// 	return NewCacheMergeIterator(parent, cache, ascending, store.eventManager, store.storeKey)
+// }
 
 func (s *Store) WriteLatestToStore(parentStore types.KVStore) {
 	s.mtx.Lock()
@@ -181,7 +261,11 @@ func (s *Store) WriteLatestToStore(parentStore types.KVStore) {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		mvValue, _ := s.multiVersionMap[key].GetLatest()
+		mvValue, found := s.multiVersionMap[key].GetLatestNonEstimate()
+		if !found {
+			// this means that at some point, there was an estimate, but we have since removed it so there isn't anything writeable at the key, so we can skip
+			continue
+		}
 		// we shouldn't have any ESTIMATE values when performing the write, because all transactions should be complete by this point
 		if mvValue.IsEstimate() {
 			panic("should not have any estimate values when writing to parent store")

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -18,7 +18,7 @@ type MultiVersionStore interface {
 	SetWriteset(index int, incarnation int, writeset WriteSet)
 	InvalidateWriteset(index int, incarnation int)
 	SetEstimatedWriteset(index int, incarnation int, writeset WriteSet)
-	GetWritesetKeys() map[int][]string
+	GetAllWritesetKeys() map[int][]string
 }
 
 type WriteSet map[string][]byte
@@ -192,7 +192,7 @@ func (s *Store) SetEstimatedWriteset(index int, incarnation int, writeset WriteS
 }
 
 // GetWritesetKeys implements MultiVersionStore.
-func (s *Store) GetWritesetKeys() map[int][]string {
+func (s *Store) GetAllWritesetKeys() map[int][]string {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	return s.txWritesetKeys

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -18,7 +18,6 @@ type MultiVersionStore interface {
 	SetWriteset(index int, incarnation int, writeset map[string][]byte)
 	InvalidateWriteset(index int, incarnation int)
 	SetEstimatedWriteset(index int, incarnation int, writeset map[string][]byte)
-	// TODO: do we want to add helper functions for validations with readsets / applying writesets ?
 }
 
 type Store struct {
@@ -113,7 +112,7 @@ func (s *Store) SetWriteset(index int, incarnation int, writeset map[string][]by
 	s.txWritesets[index] = writeset
 	for key, value := range writeset {
 		s.tryInitMultiVersionItem(key)
-		if value == nil { // TODO: safe assumption?
+		if value == nil {
 			// delete if nil value
 			s.multiVersionMap[key].Delete(index, incarnation)
 		} else {
@@ -171,7 +170,6 @@ func (s *Store) Delete(index int, incarnation int, key []byte) {
 var _ MultiVersionStore = (*Store)(nil)
 
 func (s *Store) WriteLatestToStore(parentStore types.KVStore) {
-	// TODO: this shouldn't affect gas because the gas meter wrap happens further within transaction handling - but lets confirm
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -131,7 +131,7 @@ func (s *Store) removeOldWriteset(index int, newWriteSet WriteSet) {
 		}
 	}
 	// unset the writesetKeys for this index
-	s.txWritesetKeys[index] = nil
+	delete(s.txWritesetKeys, index)
 }
 
 // SetWriteset sets a writeset for a transaction index, and also writes all of the multiversion items in the writeset to the multiversion store.

--- a/store/multiversion/store_test.go
+++ b/store/multiversion/store_test.go
@@ -3,8 +3,10 @@ package multiversion_test
 import (
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/store/dbadapter"
 	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 )
 
 func TestMultiVersionStore(t *testing.T) {
@@ -51,4 +53,73 @@ func TestMultiVersionStoreKeyDNE(t *testing.T) {
 	require.Nil(t, store.GetLatest([]byte("key1")))
 	require.Nil(t, store.GetLatestBeforeIndex(0, []byte("key1")))
 	require.False(t, store.Has(0, []byte("key1")))
+}
+
+func TestMultiVersionStoreWriteToParent(t *testing.T) {
+	// initialize cachekv store
+	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
+	mvs := multiversion.NewMultiVersionStore()
+
+	parentKVStore.Set([]byte("key2"), []byte("value0"))
+	parentKVStore.Set([]byte("key4"), []byte("value4"))
+
+	mvs.Set(1, 1, []byte("key1"), []byte("value1"))
+	mvs.Set(2, 1, []byte("key1"), []byte("value2"))
+	mvs.Set(3, 1, []byte("key2"), []byte("value3"))
+	mvs.Delete(1, 1, []byte("key3"))
+	mvs.Delete(1, 1, []byte("key4"))
+
+	mvs.WriteLatestToStore(parentKVStore)
+
+	// assert state in parent store
+	require.Equal(t, []byte("value2"), parentKVStore.Get([]byte("key1")))
+	require.Equal(t, []byte("value3"), parentKVStore.Get([]byte("key2")))
+	require.False(t, parentKVStore.Has([]byte("key3")))
+	require.False(t, parentKVStore.Has([]byte("key4")))
+
+	// verify panic if mvs contains ESTIMATE
+	mvs.SetEstimate(1, 2, []byte("key5"))
+
+	require.Panics(t, func() {
+		mvs.WriteLatestToStore(parentKVStore)
+	})
+}
+
+func TestMultiVersionStoreWritesetSetAndInvalidate(t *testing.T) {
+	mvs := multiversion.NewMultiVersionStore()
+
+	writeset := make(map[string][]byte)
+	writeset["key1"] = []byte("value1")
+	writeset["key2"] = []byte("value2")
+	writeset["key3"] = nil
+
+	mvs.SetWriteset(1, 2, writeset)
+	require.Equal(t, []byte("value1"), mvs.GetLatest([]byte("key1")).Value())
+	require.Equal(t, []byte("value2"), mvs.GetLatest([]byte("key2")).Value())
+	require.True(t, mvs.GetLatest([]byte("key3")).IsDeleted())
+
+	writeset2 := make(map[string][]byte)
+	writeset2["key1"] = []byte("value3")
+
+	mvs.SetWriteset(2, 1, writeset2)
+	require.Equal(t, []byte("value3"), mvs.GetLatest([]byte("key1")).Value())
+
+	// invalidate writeset1
+	mvs.InvalidateWriteset(1, 2)
+
+	// verify estimates
+	require.True(t, mvs.GetLatestBeforeIndex(2, []byte("key1")).IsEstimate())
+	require.True(t, mvs.GetLatestBeforeIndex(2, []byte("key2")).IsEstimate())
+	require.True(t, mvs.GetLatestBeforeIndex(2, []byte("key3")).IsEstimate())
+
+	// third writeset
+	writeset3 := make(map[string][]byte)
+	writeset3["key4"] = []byte("foo")
+	writeset3["key5"] = nil
+
+	// write the writeset directly as estimate
+	mvs.SetEstimatedWriteset(3, 1, writeset3)
+
+	require.True(t, mvs.GetLatest([]byte("key4")).IsEstimate())
+	require.True(t, mvs.GetLatest([]byte("key5")).IsEstimate())
 }

--- a/store/multiversion/store_test.go
+++ b/store/multiversion/store_test.go
@@ -131,8 +131,8 @@ func TestMultiVersionStoreWritesetSetAndInvalidate(t *testing.T) {
 	// verify that GetLatest for key3 returns nil - because of removal from writeset
 	require.Nil(t, mvs.GetLatest([]byte("key3")))
 
-	// verify output for GetWritesetKeys
-	writesetKeys := mvs.GetWritesetKeys()
+	// verify output for GetAllWritesetKeys
+	writesetKeys := mvs.GetAllWritesetKeys()
 	// we have 3 writesets
 	require.Equal(t, 3, len(writesetKeys))
 	require.Equal(t, []string{"key1"}, writesetKeys[1])

--- a/store/multiversion/store_test.go
+++ b/store/multiversion/store_test.go
@@ -128,6 +128,15 @@ func TestMultiVersionStoreWritesetSetAndInvalidate(t *testing.T) {
 	mvs.SetWriteset(1, 2, writeset1_b)
 	require.Equal(t, []byte("value4"), mvs.GetLatestBeforeIndex(2, []byte("key1")).Value())
 	require.Nil(t, mvs.GetLatestBeforeIndex(2, []byte("key2")))
-	require.Nil(t, mvs.GetLatestBeforeIndex(2, []byte("key3")))
+	// verify that GetLatest for key3 returns nil - because of removal from writeset
+	require.Nil(t, mvs.GetLatest([]byte("key3")))
+
+	// verify output for GetWritesetKeys
+	writesetKeys := mvs.GetWritesetKeys()
+	// we have 3 writesets
+	require.Equal(t, 3, len(writesetKeys))
+	require.Equal(t, []string{"key1"}, writesetKeys[1])
+	require.Equal(t, []string{"key1"}, writesetKeys[2])
+	require.Equal(t, []string{"key4", "key5"}, writesetKeys[3])
 
 }


### PR DESCRIPTION
## Describe your changes and provide context
This adds in functionality to write the latest multiversion values to another store (to be used for writing to parent after transaction execution), and also adds in helpers for writeset management such as setting, invalidating, and setting estimated writesets.

## Testing performed to validate your change
Unit testing for added functionality
