### PR TITLE
[occ] Add batch tx delivery interface

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -234,9 +234,23 @@ func (app *BaseApp) CheckTx(ctx context.Context, req *abci.RequestCheckTx) (*abc
 	}, nil
 }
 
+// DeliverTxBatch executes multiple txs
+// TODO: support occ logic with scheduling
+func (app *BaseApp) DeliverTxBatch(ctx sdk.Context, req sdk.DeliverTxBatchRequest) (res sdk.DeliverTxBatchResponse) {
+	// TODO: replace with actual scheduler logic
+	// This is stubbed so that it does something sensible
+	responses := make([]*sdk.DeliverTxResult, 0, len(req.TxEntries))
+	for _, tx := range req.TxEntries {
+		responses = append(responses, &sdk.DeliverTxResult{
+			Response: app.DeliverTx(ctx, tx.Request),
+		})
+	}
+	return sdk.DeliverTxBatchResponse{Results: responses}
+}
+
 // DeliverTx implements the ABCI interface and executes a tx in DeliverTx mode.
 // State only gets persisted if all messages are valid and get executed successfully.
-// Otherwise, the ResponseDeliverTx will contain releveant error information.
+// Otherwise, the ResponseDeliverTx will contain relevant error information.
 // Regardless of tx execution outcome, the ResponseDeliverTx will contain relevant
 // gas execution context.
 // TODO: (occ) this is the function called from sei-chain to perform execution of a transaction.

--- a/types/tx_batch.go
+++ b/types/tx_batch.go
@@ -1,0 +1,27 @@
+package types
+
+import abci "github.com/tendermint/tendermint/abci/types"
+
+// DeliverTxEntry represents an individual transaction's request within a batch.
+// This can be extended to include tx-level tracing or metadata
+type DeliverTxEntry struct {
+	Request abci.RequestDeliverTx
+}
+
+// DeliverTxBatchRequest represents a request object for a batch of transactions.
+// This can be extended to include request-level tracing or metadata
+type DeliverTxBatchRequest struct {
+	TxEntries []*DeliverTxEntry
+}
+
+// DeliverTxResult represents an individual transaction's response within a batch.
+// This can be extended to include tx-level tracing or metadata
+type DeliverTxResult struct {
+	Response abci.ResponseDeliverTx
+}
+
+// DeliverTxBatchResponse represents a response object for a batch of transactions.
+// This can be extended to include response-level tracing or metadata
+type DeliverTxBatchResponse struct {
+	Results []*DeliverTxResult
+}


### PR DESCRIPTION
## Describe your changes and provide context
- `sei-cosmos` will receive a list of transactions, so that sei-chain does not need to hold the logic for OCC
- This will make the logic easier to test, as sei-cosmos will be fairly self-contained
- Types can be extended within a tx and within request/response

Example interaction:
<img src="https://github.com/sei-protocol/sei-cosmos/assets/6051744/58c9a263-7bc6-4ede-83ab-5e34794510b1" width=50% height=50%>

## Testing performed to validate your change
- This is a skeleton for a batch interface
