### PR TITLE
[occ] Iterateset tracking and validation implementation

### DIFF
--- a/store/multiversion/memiterator.go
+++ b/store/multiversion/memiterator.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/types"
 	occtypes "github.com/cosmos/cosmos-sdk/types/occ"
-	scheduler "github.com/cosmos/cosmos-sdk/types/occ"
 )
 
 // Iterates over iterKVCache items.
@@ -86,7 +85,7 @@ func (store *Store) newMVSValidationIterator(
 	items *dbm.MemDB,
 	ascending bool,
 	writeset WriteSet,
-) (iterator *memIterator, abortChannel chan scheduler.Abort) {
+) (iterator *memIterator, abortChannel chan occtypes.Abort) {
 	var iter types.Iterator
 	var err error
 
@@ -103,7 +102,7 @@ func (store *Store) newMVSValidationIterator(
 		panic(err)
 	}
 
-	abortChannel = make(chan scheduler.Abort, 1)
+	abortChannel = make(chan occtypes.Abort, 1)
 
 	return &memIterator{
 		Iterator:       iter,

--- a/store/multiversion/memiterator.go
+++ b/store/multiversion/memiterator.go
@@ -72,10 +72,10 @@ func (mi *memIterator) Value() []byte {
 	// need to update readset
 	// if we have a deleted value, return nil
 	if val.IsDeleted() {
-		mi.ReadsetHandler.UpdateReadSet(key, nil)
+		defer mi.ReadsetHandler.UpdateReadSet(key, nil)
 		return nil
 	}
-	mi.ReadsetHandler.UpdateReadSet(key, val.Value())
+	defer mi.ReadsetHandler.UpdateReadSet(key, val.Value())
 	return val.Value()
 }
 

--- a/store/multiversion/memiterator.go
+++ b/store/multiversion/memiterator.go
@@ -85,7 +85,8 @@ func (store *Store) newMVSValidationIterator(
 	items *dbm.MemDB,
 	ascending bool,
 	writeset WriteSet,
-) (iterator *memIterator, abortChannel chan occtypes.Abort) {
+	abortChannel chan occtypes.Abort,
+) *memIterator {
 	var iter types.Iterator
 	var err error
 
@@ -102,8 +103,6 @@ func (store *Store) newMVSValidationIterator(
 		panic(err)
 	}
 
-	abortChannel = make(chan occtypes.Abort, 1)
-
 	return &memIterator{
 		Iterator:       iter,
 		mvStore:        store,
@@ -111,5 +110,5 @@ func (store *Store) newMVSValidationIterator(
 		abortChannel:   abortChannel,
 		ReadsetHandler: NoOpHandler{},
 		writeset:       writeset,
-	}, abortChannel
+	}
 }

--- a/store/multiversion/mergeiterator.go
+++ b/store/multiversion/mergeiterator.go
@@ -16,6 +16,7 @@ type mvsMergeIterator struct {
 	parent    types.Iterator
 	cache     types.Iterator
 	ascending bool
+	ReadsetHandler
 }
 
 var _ types.Iterator = (*mvsMergeIterator)(nil)
@@ -23,11 +24,13 @@ var _ types.Iterator = (*mvsMergeIterator)(nil)
 func NewMVSMergeIterator(
 	parent, cache types.Iterator,
 	ascending bool,
+	readsetHandler ReadsetHandler,
 ) *mvsMergeIterator {
 	iter := &mvsMergeIterator{
-		parent:    parent,
-		cache:     cache,
-		ascending: ascending,
+		parent:         parent,
+		cache:          cache,
+		ascending:      ascending,
+		ReadsetHandler: readsetHandler,
 	}
 
 	return iter

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -12,12 +12,70 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
+// exposes a handler for adding items to readset, useful for iterators
+type ReadsetHandler interface {
+	UpdateReadSet(key []byte, value []byte)
+}
+
+type NoOpHandler struct{}
+
+func (NoOpHandler) UpdateReadSet(key []byte, value []byte) {}
+
+// exposes a handler for adding items to iterateset, to be called upon iterator close
+type IterateSetHandler interface {
+	UpdateIterateSet(*iterationTracker)
+}
+
+type iterationTracker struct {
+	startKey     []byte   // start of the iteration range
+	endKey       []byte   // end of the iteration range
+	earlyStopKey []byte   // key that caused early stop
+	iteratedKeys [][]byte // list of keys that were iterated TODO: this is necessary over just a count because we ned to know if key A was removed and B added which would still have the same count, maybe not, because we add iterated keys to readset, maybe its fine?
+	ascending    bool
+
+	writeset WriteSet
+
+	// TODO: is it possible that terimation is affected by keys later in iteration that weren't reached? eg. number of keys affecting iteration?
+	// TODO: i believe to get number of keys the iteration would need to be done fully so its not a concern?
+
+	// TODO: maybe we need to store keys served from writeset for the transaction? that way if theres OTHER keys within the writeset and the iteration range, and were written to the writeset later, we can discriminate between the groups?
+	// keysServedFromWriteset map[string]struct{}
+
+	// actually its simpler to just store a copy of the writeset at the time of iterator creation
+}
+
+func NewIterationTracker(startKey, endKey []byte, ascending bool, writeset WriteSet) *iterationTracker {
+	copyWriteset := make(WriteSet, len(writeset))
+
+	for key, value := range writeset {
+		copyWriteset[key] = value
+	}
+
+	return &iterationTracker{
+		startKey:     startKey,
+		endKey:       endKey,
+		iteratedKeys: [][]byte{},
+		ascending:    ascending,
+		writeset:     copyWriteset,
+	}
+}
+
+func (item *iterationTracker) AddKey(key []byte) {
+	item.iteratedKeys = append(item.iteratedKeys, key)
+}
+
+func (item *iterationTracker) SetEarlyStopKey(key []byte) {
+	item.earlyStopKey = key
+}
+
 // Version Indexed Store wraps the multiversion store in a way that implements the KVStore interface, but also stores the index of the transaction, and so store actions are applied to the multiversion store using that index
 type VersionIndexedStore struct {
 	mtx sync.Mutex
 	// used for tracking reads and writes for eventual validation + persistence into multi-version store
-	readset  map[string][]byte // contains the key -> value mapping for all keys read from the store (not mvkv, underlying store)
-	writeset map[string][]byte // contains the key -> value mapping for all keys written to the store
+	// TODO: does this need sync.Map?
+	readset    map[string][]byte // contains the key -> value mapping for all keys read from the store (not mvkv, underlying store)
+	writeset   map[string][]byte // contains the key -> value mapping for all keys written to the store
+	iterateset []*iterationTracker
 	// TODO: need to add iterateset here as well
 
 	// dirty keys that haven't been sorted yet for iteration
@@ -36,11 +94,14 @@ type VersionIndexedStore struct {
 }
 
 var _ types.KVStore = (*VersionIndexedStore)(nil)
+var _ ReadsetHandler = (*VersionIndexedStore)(nil)
+var _ IterateSetHandler = (*VersionIndexedStore)(nil)
 
 func NewVersionIndexedStore(parent types.KVStore, multiVersionStore MultiVersionStore, transactionIndex, incarnation int, abortChannel chan scheduler.Abort) *VersionIndexedStore {
 	return &VersionIndexedStore{
 		readset:           make(map[string][]byte),
 		writeset:          make(map[string][]byte),
+		iterateset:        []*iterationTracker{},
 		dirtySet:          make(map[string]struct{}),
 		sortedStore:       dbm.NewMemDB(),
 		parent:            parent,
@@ -97,7 +158,7 @@ func (store *VersionIndexedStore) Get(key []byte) []byte {
 	}
 	// if we didn't find it in the multiversion store, then we want to check the parent store + add to readset
 	parentValue := store.parent.Get(key)
-	store.updateReadSet(key, parentValue)
+	store.UpdateReadSet(key, parentValue)
 	return parentValue
 }
 
@@ -107,7 +168,7 @@ func (store *VersionIndexedStore) parseValueAndUpdateReadset(strKey string, mvsV
 	if mvsValue.IsDeleted() {
 		value = nil
 	}
-	store.updateReadSet([]byte(strKey), value)
+	store.UpdateReadSet([]byte(strKey), value)
 	return value
 }
 
@@ -201,40 +262,22 @@ func (v *VersionIndexedStore) ReverseIterator(start []byte, end []byte) dbm.Iter
 func (store *VersionIndexedStore) iterator(start []byte, end []byte, ascending bool) dbm.Iterator {
 	store.mtx.Lock()
 	defer store.mtx.Unlock()
+
+	// get the sorted keys from MVS
+	// TODO: ideally we take advantage of mvs keys already being sorted
+	// TODO: ideally merge btree and mvs keys into a single sorted btree
+	memDB := store.multiVersionStore.CollectIteratorItems(store.transactionIndex)
+
 	// TODO: ideally we persist writeset keys into a sorted btree for later use
 	// make a set of total keys across mvkv and mvs to iterate
-	keysToIterate := make(map[string]struct{})
 	for key := range store.writeset {
-		keysToIterate[key] = struct{}{}
-	}
-
-	// TODO: ideally we take advantage of mvs keys already being sorted
-	// get the multiversion store sorted keys
-	writesetMap := store.multiVersionStore.GetAllWritesetKeys()
-	for i := 0; i < store.transactionIndex; i++ {
-		// add all the writesets keys up until current index
-		for _, key := range writesetMap[i] {
-			keysToIterate[key] = struct{}{}
-		}
-	}
-	// TODO: ideally merge btree and mvs keys into a single sorted btree
-
-	// TODO: this is horribly inefficient, fix this
-	sortedKeys := make([]string, len(keysToIterate))
-	for key := range keysToIterate {
-		sortedKeys = append(sortedKeys, key)
-	}
-	sort.Strings(sortedKeys)
-
-	memDB := dbm.NewMemDB()
-	for _, key := range sortedKeys {
 		memDB.Set([]byte(key), []byte{})
 	}
 
 	var parent, memIterator types.Iterator
 
 	// make a memIterator
-	memIterator = store.newMemIterator(start, end, memDB, ascending)
+	memIterator = store.newMemIterator(start, end, memDB, ascending, store)
 
 	if ascending {
 		parent = store.parent.Iterator(start, end)
@@ -242,8 +285,13 @@ func (store *VersionIndexedStore) iterator(start []byte, end []byte, ascending b
 		parent = store.parent.ReverseIterator(start, end)
 	}
 
+	mergeIterator := NewMVSMergeIterator(parent, memIterator, ascending, store)
+
+	iterationTracker := NewIterationTracker(start, end, ascending, store.writeset)
+	trackedIterator := NewTrackedIterator(mergeIterator, iterationTracker, store)
+
 	// mergeIterator
-	return NewMVSMergeIterator(parent, memIterator, ascending)
+	return trackedIterator
 
 }
 
@@ -297,10 +345,15 @@ func (store *VersionIndexedStore) WriteEstimatesToMultiVersionStore() {
 	store.multiVersionStore.SetEstimatedWriteset(store.transactionIndex, store.incarnation, store.writeset)
 }
 
-func (store *VersionIndexedStore) updateReadSet(key []byte, value []byte) {
+func (store *VersionIndexedStore) UpdateReadSet(key []byte, value []byte) {
 	// add to readset
 	keyStr := string(key)
 	store.readset[keyStr] = value
 	// add to dirty set
 	store.dirtySet[keyStr] = struct{}{}
+}
+
+func (store *VersionIndexedStore) UpdateIterateSet(iterationTracker *iterationTracker) {
+	// append to iterateset
+	store.iterateset = append(store.iterateset, iterationTracker)
 }

--- a/store/multiversion/mvkv_test.go
+++ b/store/multiversion/mvkv_test.go
@@ -321,6 +321,12 @@ func TestIterator(t *testing.T) {
 
 	// iterate over the keys - exclusive on key5
 	iter := vis.Iterator([]byte("000"), []byte("key5"))
+
+	// verify domain is superset
+	start, end := iter.Domain()
+	require.Equal(t, []byte("000"), start)
+	require.Equal(t, []byte("key5"), end)
+
 	vals := []string{}
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {

--- a/store/multiversion/mvkv_test.go
+++ b/store/multiversion/mvkv_test.go
@@ -354,6 +354,17 @@ func TestIterator(t *testing.T) {
 	require.Equal(t, []string{"value1", "value2", "value3", "valueNew"}, vals3)
 	iter3.Close()
 
+	vis.Set([]byte("key6"), []byte("value6"))
+	// iterate over the keys, writeset being the last of the iteration range
+	iter4 := vis.Iterator([]byte("000"), []byte("key7"))
+	vals4 := []string{}
+	defer iter4.Close()
+	for ; iter4.Valid(); iter4.Next() {
+		vals4 = append(vals4, string(iter4.Value()))
+	}
+	require.Equal(t, []string{"value1", "value2", "value3", "valueNew", "value5", "value6"}, vals4)
+	iter4.Close()
+
 	// add an estimate to MVS
 	mvs.SetEstimatedWriteset(1, 1, map[string][]byte{
 		"key2": []byte("value1_b"),

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -241,7 +241,10 @@ func (s *Store) CollectIteratorItems(index int) *db.MemDB {
 	// get all writeset keys prior to index
 	keys := s.GetAllWritesetKeys()
 	for i := 0; i < index; i++ {
-		indexedWriteset := keys[i]
+		indexedWriteset, ok := keys[i]
+		if !ok {
+			continue
+		}
 		// TODO: do we want to exclude keys out of the range or just let the iterator handle it?
 		for _, key := range indexedWriteset {
 			// TODO: inefficient because (logn) for each key + rebalancing? maybe theres a better way to add to a tree to reduce rebalancing overhead

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
+	db "github.com/tendermint/tm-db"
 )
 
 type MultiVersionStore interface {
@@ -19,13 +20,17 @@ type MultiVersionStore interface {
 	InvalidateWriteset(index int, incarnation int)
 	SetEstimatedWriteset(index int, incarnation int, writeset WriteSet)
 	GetAllWritesetKeys() map[int][]string
+	CollectIteratorItems(index int) *db.MemDB
 	SetReadset(index int, readset ReadSet)
 	GetReadset(index int) ReadSet
-	ValidateTransactionState(index int) []int
+	SetIterateset(index int, iterateset Iterateset)
+	GetIterateset(index int) Iterateset
+	ValidateTransactionState(index int) (bool, []int)
 }
 
 type WriteSet map[string][]byte
 type ReadSet map[string][]byte
+type Iterateset []iterationTracker
 
 var _ MultiVersionStore = (*Store)(nil)
 
@@ -37,6 +42,7 @@ type Store struct {
 
 	txWritesetKeys map[int][]string // map of tx index -> writeset keys
 	txReadSets     map[int]ReadSet
+	txIterateSets  map[int]Iterateset
 
 	parentStore types.KVStore
 }
@@ -46,6 +52,7 @@ func NewMultiVersionStore(parentStore types.KVStore) *Store {
 		multiVersionMap: make(map[string]MultiVersionValue),
 		txWritesetKeys:  make(map[int][]string),
 		txReadSets:      make(map[int]ReadSet),
+		txIterateSets:   make(map[int]Iterateset),
 		parentStore:     parentStore,
 	}
 }
@@ -212,9 +219,108 @@ func (s *Store) GetReadset(index int) ReadSet {
 	return s.txReadSets[index]
 }
 
-func (s *Store) ValidateTransactionState(index int) []int {
+func (s *Store) SetIterateset(index int, iterateset Iterateset) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.txIterateSets[index] = iterateset
+}
+
+func (s *Store) GetIterateset(index int) Iterateset {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	return s.txIterateSets[index]
+}
+
+// CollectIteratorItems implements MultiVersionStore. It will return a memDB containing all of the keys present in the multiversion store within the iteration range prior to (exclusive of) the index.
+func (s *Store) CollectIteratorItems(index int) *db.MemDB {
+	sortedItems := db.NewMemDB()
+
+	// get all writeset keys prior to index
+	keys := s.GetAllWritesetKeys()
+	for i := 0; i < index; i++ {
+		indexedWriteset := keys[i]
+		// TODO: do we want to exclude keys out of the range or just let the iterator handle it?
+		for _, key := range indexedWriteset {
+			// TODO: inefficient because (logn) for each key + rebalancing? maybe theres a better way to add to a tree to reduce rebalancing overhead
+			sortedItems.Set([]byte(key), []byte{})
+		}
+	}
+	return sortedItems
+}
+
+func (s *Store) validateIterator(index int, iterationTracker iterationTracker) bool {
+	// TODO: what if we added a key LATER within the transaction AFTER iteration. in that case, it won't be in expected Keys, but would be in the iteration range, causing issue?
+	// collect items from multiversion store
+	sortedItems := s.CollectIteratorItems(index)
+	// add the iterationtracker writeset keys to the sorted items
+	for key, _ := range iterationTracker.writeset {
+		sortedItems.Set([]byte(key), []byte{})
+	}
+
+	var parentIter types.Iterator
+
+	iter, abortChannel := s.newMVSValidationIterator(index, iterationTracker.startKey, iterationTracker.endKey, sortedItems, iterationTracker.ascending, iterationTracker.writeset)
+	if iterationTracker.ascending {
+		parentIter = s.parentStore.Iterator(iterationTracker.startKey, iterationTracker.endKey)
+	} else {
+		parentIter = s.parentStore.ReverseIterator(iterationTracker.startKey, iterationTracker.endKey)
+	}
+	// create a new MVSMergeiterator
+	mergeIterator := NewMVSMergeIterator(parentIter, iter, iterationTracker.ascending, NoOpHandler{})
+	defer mergeIterator.Close()
+	keys := iterationTracker.iteratedKeys
+
+	validChan := make(chan bool, 1)
+
+	// listen for abort while iterating
+	go func(expectedKeys [][]byte, returnChan chan bool) {
+		for ; mergeIterator.Valid(); mergeIterator.Next() {
+			if len(expectedKeys) == 0 {
+				// if we have no more expected keys, then the iterator is invalid
+				returnChan <- false
+				return
+			}
+			key := mergeIterator.Key()
+			if !bytes.Equal(key, expectedKeys[0]) {
+				// if key isn't equal, that means that the iterator is invalid
+				returnChan <- false
+				return
+			}
+			expectedKeys = expectedKeys[1:]
+
+			// if our iterator key was the early stop, then we can break
+			if bytes.Equal(key, iterationTracker.earlyStopKey) {
+				returnChan <- true
+				return
+			}
+		}
+		returnChan <- !(len(expectedKeys) > 0)
+	}(keys, validChan)
+
+	select {
+	case <-abortChannel:
+		// if we get an abort, then we know that the iterator is invalid
+		return false
+	case valid := <-validChan:
+		return valid
+	}
+}
+
+// TODO: do we want to return bool + []int where bool indicates whether it was valid and then []int indicates only ones for which we need to wait due to estimates? - yes i think so?
+func (s *Store) ValidateTransactionState(index int) (bool, []int) {
 	defer telemetry.MeasureSince(time.Now(), "store", "mvs", "validate")
 	conflictSet := map[int]struct{}{}
+	valid := true
+
+	// TODO: validate iterateset
+	// TODO: can we parallelize for all iterators?
+	iterateset := s.GetIterateset(index)
+	for _, iterationTracker := range iterateset {
+		iteratorValid := s.validateIterator(index, iterationTracker)
+		valid = valid && iteratorValid
+	}
 
 	// validate readset
 	readset := s.GetReadset(index)
@@ -235,14 +341,14 @@ func (s *Store) ValidateTransactionState(index int) []int {
 			} else if latestValue.IsDeleted() {
 				if value != nil {
 					// conflict
-					conflictSet[latestValue.Index()] = struct{}{}
+					// TODO: would we want to return early?
+					valid = false
 				}
 			} else if !bytes.Equal(latestValue.Value(), value) {
-				conflictSet[latestValue.Index()] = struct{}{}
+				valid = false
 			}
 		}
 	}
-	// TODO: validate iterateset
 
 	// convert conflictset into sorted indices
 	conflictIndices := make([]int, 0, len(conflictSet))
@@ -251,7 +357,7 @@ func (s *Store) ValidateTransactionState(index int) []int {
 	}
 
 	sort.Ints(conflictIndices)
-	return conflictIndices
+	return valid, conflictIndices
 }
 
 func (s *Store) WriteLatestToStore() {

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -358,6 +358,7 @@ func (s *Store) ValidateTransactionState(index int) (bool, []int) {
 	}
 
 	sort.Ints(conflictIndices)
+	// TODO: maybe we have an indicator for the case where all of the validations are valid EXCEPT for some estimates encountered, in which case we may not want to re-execute, simply revalidate once the ESTIMATES are cleared
 	return valid, conflictIndices
 }
 

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -335,9 +335,8 @@ func (s *Store) ValidateTransactionState(index int) (bool, []int) {
 				panic("there shouldn't be readset conflicts with parent kv store, since it shouldn't change")
 			}
 		} else {
-			// if estimate, mark as conflict index
+			// if estimate, mark as conflict index - but don't invalidate
 			if latestValue.IsEstimate() {
-				valid = false
 				conflictSet[latestValue.Index()] = struct{}{}
 			} else if latestValue.IsDeleted() {
 				if value != nil {

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -357,7 +357,6 @@ func (s *Store) ValidateTransactionState(index int) (bool, []int) {
 	}
 
 	sort.Ints(conflictIndices)
-	// TODO: maybe we have an indicator for the case where all of the validations are valid EXCEPT for some estimates encountered, in which case we may not want to re-execute, simply revalidate once the ESTIMATES are cleared
 	return valid, conflictIndices
 }
 

--- a/store/multiversion/trackediterator.go
+++ b/store/multiversion/trackediterator.go
@@ -1,0 +1,41 @@
+package multiversion
+
+import "github.com/cosmos/cosmos-sdk/store/types"
+
+// tracked iterator is a wrapper around an existing iterator to track the iterator progress and monitor which keys are iterated.
+type trackedIterator struct {
+	types.Iterator
+
+	iterateset *iterationTracker
+	IterateSetHandler
+}
+
+// TODO: test
+
+func NewTrackedIterator(iter types.Iterator, iterationTracker *iterationTracker, iterateSetHandler IterateSetHandler) *trackedIterator {
+	return &trackedIterator{
+		Iterator:          iter,
+		iterateset:        iterationTracker,
+		IterateSetHandler: iterateSetHandler,
+	}
+}
+
+// Close calls first updates the iterateset from the iterator, and then calls iterator.Close()
+func (ti *trackedIterator) Close() error {
+	// TODO: if there are more keys to the iterator, then we consider it early stopped?
+	if ti.Iterator.Valid() {
+		// TODO: test whether reaching end of iteration range means valid is true or false
+		ti.iterateset.SetEarlyStopKey(ti.Iterator.Key())
+	}
+	// Update iterate set
+	ti.IterateSetHandler.UpdateIterateSet(ti.iterateset)
+	return ti.Iterator.Close()
+}
+
+// Key calls the iterator.Key() and adds the key to the iterateset, then returns the key from the iterator
+func (ti *trackedIterator) Key() []byte {
+	key := ti.Iterator.Key()
+	// add key to the tracker
+	ti.iterateset.AddKey(key)
+	return key
+}

--- a/store/multiversion/trackediterator.go
+++ b/store/multiversion/trackediterator.go
@@ -6,13 +6,13 @@ import "github.com/cosmos/cosmos-sdk/store/types"
 type trackedIterator struct {
 	types.Iterator
 
-	iterateset *iterationTracker
+	iterateset iterationTracker
 	IterateSetHandler
 }
 
 // TODO: test
 
-func NewTrackedIterator(iter types.Iterator, iterationTracker *iterationTracker, iterateSetHandler IterateSetHandler) *trackedIterator {
+func NewTrackedIterator(iter types.Iterator, iterationTracker iterationTracker, iterateSetHandler IterateSetHandler) *trackedIterator {
 	return &trackedIterator{
 		Iterator:          iter,
 		iterateset:        iterationTracker,
@@ -38,4 +38,20 @@ func (ti *trackedIterator) Key() []byte {
 	// add key to the tracker
 	ti.iterateset.AddKey(key)
 	return key
+}
+
+// Value calls the iterator.Key() and adds the key to the iterateset, then returns the value from the iterator
+func (ti *trackedIterator) Value() []byte {
+	key := ti.Iterator.Key()
+	// add key to the tracker
+	ti.iterateset.AddKey(key)
+	return ti.Iterator.Value()
+}
+
+func (ti *trackedIterator) Next() {
+	// add current key to the tracker
+	key := ti.Iterator.Key()
+	ti.iterateset.AddKey(key)
+	// call next
+	ti.Iterator.Next()
 }


### PR DESCRIPTION
## Describe your changes and provide context
This implements a tracked iterator that is used to keep track of keys that have been iterated, and to also save metadata about the iteration for LATER validation. The iterator will be replayed and if there are any new keys / any keys missing within the iteration range, it will fail validation. the actual values served by the iterator are covered by readset validation. 

Additionally, the early stop behavior allows the iterateset to ONLY be sensitive to changes to the keys available WITHIN the iteration range. In the event that we perform iteration, and THEN write a key within the range of iteration, this will not fail iteration because we take a snapshot of the mvkv writeset at the moment of iteration, so when we replay the iterator, we populate that iterator with the writeset at that time, so we appropriately replicate the iterator behavior.

In the case that we encounter an ESTIMATE, we have to terminate the iterator validation and mark it as failed because it is impossible to know whether that ESTIMATE represents a value change or a delete, since the latter, will affect the keys available for iteration.

This change also implements handlers that iterators receive for updating readset and iterateset in the `mvkv`

## Testing performed to validate your change
Unit tests for various iteration scenarios
