### PR TITLE
[occ] Allow parent app to pass per-tx contexts

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -243,16 +243,12 @@ func (app *BaseApp) DeliverTxBatch(ctx sdk.Context, req sdk.DeliverTxBatchReques
 	}
 
 	scheduler := tasks.NewScheduler(app.concurrencyWorkers, app.DeliverTx)
-	txRes, err := scheduler.ProcessAll(ctx, reqList)
+	resp, err := scheduler.ProcessAll(ctx, req)
 	if err != nil {
 		//TODO: handle error
 	}
 
-	responses := make([]*sdk.DeliverTxResult, 0, len(req.TxEntries))
-	for _, tx := range txRes {
-		responses = append(responses, &sdk.DeliverTxResult{Response: tx})
-	}
-	return sdk.DeliverTxBatchResponse{Results: responses}
+	return resp
 }
 
 // DeliverTx implements the ABCI interface and executes a tx in DeliverTx mode.

--- a/baseapp/deliver_tx_batch_test.go
+++ b/baseapp/deliver_tx_batch_test.go
@@ -123,6 +123,7 @@ func TestDeliverTxBatch(t *testing.T) {
 			require.NoError(t, err)
 			requests = append(requests, &sdk.DeliverTxEntry{
 				Request: abci.RequestDeliverTx{Tx: txBytes},
+				Context: app.deliverState.ctx.WithTxIndex(i),
 			})
 		}
 

--- a/baseapp/deliver_tx_batch_test.go
+++ b/baseapp/deliver_tx_batch_test.go
@@ -131,7 +131,6 @@ func TestDeliverTxBatch(t *testing.T) {
 
 		for idx, deliverTxRes := range responses.Results {
 			res := deliverTxRes.Response
-			fmt.Printf("%d: %d\n", idx, res.GasUsed)
 			require.Equal(t, abci.CodeTypeOK, res.Code)
 			requireAttribute(t, res.Events, "tx-id", fmt.Sprintf("%d", idx))
 			requireAttribute(t, res.Events, "tx-val", fmt.Sprintf("%d", blockN+1))

--- a/baseapp/deliver_tx_batch_test.go
+++ b/baseapp/deliver_tx_batch_test.go
@@ -132,7 +132,6 @@ func TestDeliverTxBatch(t *testing.T) {
 
 		for idx, deliverTxRes := range responses.Results {
 			res := deliverTxRes.Response
-			fmt.Printf("%d: %d\n", idx, res.GasUsed)
 			require.Equal(t, abci.CodeTypeOK, res.Code)
 			requireAttribute(t, res.Events, "tx-id", fmt.Sprintf("%d", idx))
 			requireAttribute(t, res.Events, "tx-val", fmt.Sprintf("%d", blockN+1))

--- a/baseapp/deliver_tx_batch_test.go
+++ b/baseapp/deliver_tx_batch_test.go
@@ -132,6 +132,7 @@ func TestDeliverTxBatch(t *testing.T) {
 
 		for idx, deliverTxRes := range responses.Results {
 			res := deliverTxRes.Response
+			fmt.Printf("%d: %d\n", idx, res.GasUsed)
 			require.Equal(t, abci.CodeTypeOK, res.Code)
 			requireAttribute(t, res.Events, "tx-id", fmt.Sprintf("%d", idx))
 			requireAttribute(t, res.Events, "tx-val", fmt.Sprintf("%d", blockN+1))

--- a/baseapp/deliver_tx_batch_test.go
+++ b/baseapp/deliver_tx_batch_test.go
@@ -3,7 +3,6 @@ package baseapp
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,15 +11,27 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-func toInt(b []byte) int {
-	r, _ := strconv.Atoi(string(b))
-	return r
-}
+func anteHandler(capKey sdk.StoreKey, storeKey []byte) sdk.AnteHandler {
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		store := ctx.KVStore(capKey)
+		txTest := tx.(txTest)
 
-func toByteArr(i int) []byte {
-	return []byte(fmt.Sprintf("%d", i))
+		if txTest.FailOnAnte {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "ante handler failure")
+		}
+
+		val := getIntFromStore(store, storeKey)
+		setIntOnStore(store, storeKey, val+1)
+
+		ctx.EventManager().EmitEvents(
+			counterEvent("ante-val", val+1),
+		)
+
+		return ctx, nil
+	}
 }
 
 func handlerKVStore(capKey sdk.StoreKey) sdk.Handler {
@@ -40,12 +51,12 @@ func handlerKVStore(capKey sdk.StoreKey) sdk.Handler {
 		store := ctx.KVStore(capKey)
 
 		// increment per-tx key (no conflict)
-		val := toInt(store.Get(txKey))
-		store.Set(txKey, toByteArr(val+1))
+		val := getIntFromStore(store, txKey)
+		setIntOnStore(store, txKey, val+1)
 
 		// increment shared key
-		sharedVal := toInt(store.Get(sharedKey))
-		store.Set(sharedKey, toByteArr(sharedVal+1))
+		sharedVal := getIntFromStore(store, sharedKey)
+		setIntOnStore(store, sharedKey, sharedVal+1)
 
 		// Emit an event with the incremented value and the unique ID
 		ctx.EventManager().EmitEvent(
@@ -75,8 +86,11 @@ func requireAttribute(t *testing.T, evts []abci.Event, name string, val string) 
 
 func TestDeliverTxBatch(t *testing.T) {
 	// test increments in the ante
-	//anteKey := []byte("ante-key")
-	anteOpt := func(bapp *BaseApp) {}
+	anteKey := []byte("ante-key")
+
+	anteOpt := func(bapp *BaseApp) {
+		bapp.SetAnteHandler(anteHandler(capKey1, anteKey))
+	}
 
 	// test increments in the handler
 	routerOpt := func(bapp *BaseApp) {
@@ -117,6 +131,7 @@ func TestDeliverTxBatch(t *testing.T) {
 
 		for idx, deliverTxRes := range responses.Results {
 			res := deliverTxRes.Response
+			fmt.Printf("%d: %d\n", idx, res.GasUsed)
 			require.Equal(t, abci.CodeTypeOK, res.Code)
 			requireAttribute(t, res.Events, "tx-id", fmt.Sprintf("%d", idx))
 			requireAttribute(t, res.Events, "tx-val", fmt.Sprintf("%d", blockN+1))

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -1523,7 +1523,6 @@ func TestDeliverTx(t *testing.T) {
 			res := app.DeliverTx(app.deliverState.ctx, abci.RequestDeliverTx{Tx: txBytes})
 			require.True(t, res.IsOK(), fmt.Sprintf("%v", res))
 			events := res.GetEvents()
-			fmt.Printf("%d: %d\n", i, res.GasUsed)
 			require.Len(t, events, 3, "should contain ante handler, message type and counter events respectively")
 			require.Equal(t, sdk.MarkEventsToIndex(counterEvent("ante_handler", counter).ToABCIEvents(), map[string]struct{}{})[0], events[0], "ante handler event")
 			require.Equal(t, sdk.MarkEventsToIndex(counterEvent(sdk.EventTypeMessage, counter).ToABCIEvents(), map[string]struct{}{})[0], events[2], "msg handler update counter event")

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -1523,6 +1523,7 @@ func TestDeliverTx(t *testing.T) {
 			res := app.DeliverTx(app.deliverState.ctx, abci.RequestDeliverTx{Tx: txBytes})
 			require.True(t, res.IsOK(), fmt.Sprintf("%v", res))
 			events := res.GetEvents()
+			fmt.Printf("%d: %d\n", i, res.GasUsed)
 			require.Len(t, events, 3, "should contain ante handler, message type and counter events respectively")
 			require.Equal(t, sdk.MarkEventsToIndex(counterEvent("ante_handler", counter).ToABCIEvents(), map[string]struct{}{})[0], events[0], "ante handler event")
 			require.Equal(t, sdk.MarkEventsToIndex(counterEvent(sdk.EventTypeMessage, counter).ToABCIEvents(), map[string]struct{}{})[0], events[2], "msg handler update counter event")

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -32,6 +32,7 @@ const (
 )
 
 type deliverTxTask struct {
+	BaseCtx sdk.Context
 	Ctx     sdk.Context
 	AbortCh chan occ.Abort
 
@@ -106,7 +107,7 @@ func toTasks(reqs []*sdk.DeliverTxEntry) []*deliverTxTask {
 			Request: r.Request,
 			Index:   idx,
 			Status:  statusPending,
-			Ctx:     r.Context,
+			BaseCtx: r.Context,
 		})
 	}
 	return res
@@ -276,7 +277,7 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 		defer close(ch)
 		for _, task := range tasks {
 			// initialize the context
-			ctx := task.Ctx.WithTxIndex(task.Index)
+			ctx := task.BaseCtx.WithTxIndex(task.Index)
 			abortCh := make(chan occ.Abort, len(s.multiVersionStores))
 
 			// if there are no stores, don't try to wrap, because there's nothing to wrap
@@ -296,7 +297,7 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 					return vs[k]
 				})
 
-				ctx = task.Ctx.WithMultiStore(ms)
+				ctx = ctx.WithMultiStore(ms)
 			}
 
 			task.AbortCh = abortCh

--- a/types/tx_batch.go
+++ b/types/tx_batch.go
@@ -6,6 +6,7 @@ import abci "github.com/tendermint/tendermint/abci/types"
 // This can be extended to include tx-level tracing or metadata
 type DeliverTxEntry struct {
 	Request abci.RequestDeliverTx
+	Context Context
 }
 
 // DeliverTxBatchRequest represents a request object for a batch of transactions.


### PR DESCRIPTION
## Describe your changes and provide context
- sei-chain needs to pass per-tx notification channels on contexts 
- this allows for per-tx contexts to be passed
 
## Testing performed to validate your change
- updated all unit tests
