### PR TITLE
Add occ flag check to context

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -34,6 +34,7 @@ type Context struct {
 	voteInfo      []abci.VoteInfo
 	gasMeter      GasMeter
 	blockGasMeter GasMeter
+	occEnabled    bool
 	checkTx       bool
 	recheckTx     bool // if recheckTx == true, then checkTx must also be true
 	minGasPrice   DecCoins
@@ -105,8 +106,7 @@ func (c Context) IsReCheckTx() bool {
 }
 
 func (c Context) IsOCCEnabled() bool {
-	//TODO: implement flag for OCC
-	return true
+	return c.occEnabled
 }
 
 func (c Context) MinGasPrices() DecCoins {
@@ -283,6 +283,12 @@ func (c Context) WithBlockGasMeter(meter GasMeter) Context {
 // WithIsCheckTx enables or disables CheckTx value for verifying transactions and returns an updated Context
 func (c Context) WithIsCheckTx(isCheckTx bool) Context {
 	c.checkTx = isCheckTx
+	return c
+}
+
+// WithIsOCCEnabled enables or disables whether OCC is used as the concurrency algorithm
+func (c Context) WithIsOCCEnabled(isOCCEnabled bool) Context {
+	c.occEnabled = isOCCEnabled
 	return c
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -104,6 +104,11 @@ func (c Context) IsReCheckTx() bool {
 	return c.recheckTx
 }
 
+func (c Context) IsOCCEnabled() bool {
+	//TODO: implement flag for OCC
+	return true
+}
+
 func (c Context) MinGasPrices() DecCoins {
 	return c.minGasPrice
 }

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -87,6 +87,7 @@ func (s *contextTestSuite) TestContextWithCustom() {
 	height := int64(1)
 	chainid := "chainid"
 	ischeck := true
+	isOCC := true
 	txbytes := []byte("txbytes")
 	logger := mocks.NewMockLogger(ctrl)
 	voteinfos := []abci.VoteInfo{{}}
@@ -106,10 +107,13 @@ func (s *contextTestSuite) TestContextWithCustom() {
 		WithGasMeter(meter).
 		WithMinGasPrices(minGasPrices).
 		WithBlockGasMeter(blockGasMeter).
-		WithHeaderHash(headerHash)
+		WithHeaderHash(headerHash).
+		WithIsOCCEnabled(isOCC)
+
 	s.Require().Equal(height, ctx.BlockHeight())
 	s.Require().Equal(chainid, ctx.ChainID())
 	s.Require().Equal(ischeck, ctx.IsCheckTx())
+	s.Require().Equal(isOCC, ctx.IsOCCEnabled())
 	s.Require().Equal(txbytes, ctx.TxBytes())
 	s.Require().Equal(logger, ctx.Logger())
 	s.Require().Equal(voteinfos, ctx.VoteInfos())


### PR DESCRIPTION
## Describe your changes and provide context
- Allows sei-chain to ask isOCCEnabled() so that it can choose to use the OCC logic 
- Sei-chain can set this to true according to desired logic

## Testing performed to validate your change
- unit test that sets flag and verifies value
