### PR TITLE
[occ] Generated Estimated Writeset

### DIFF
--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -55,7 +55,17 @@ type Store struct {
 	logger log.Logger
 }
 
-func NewMultiVersionStore(parentStore types.KVStore, logger log.Logger) *Store {
+func NewMultiVersionStore(parentStore types.KVStore) *Store {
+	return &Store{
+		multiVersionMap: make(map[string]MultiVersionValue),
+		txWritesetKeys:  make(map[int][]string),
+		txReadSets:      make(map[int]ReadSet),
+		txIterateSets:   make(map[int]Iterateset),
+		parentStore:     parentStore,
+	}
+}
+
+func NewMultiVersionStoreWithLogger(parentStore types.KVStore, logger log.Logger) *Store {
 	return &Store{
 		multiVersionMap: make(map[string]MultiVersionValue),
 		txWritesetKeys:  make(map[int][]string),

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -2,6 +2,7 @@ package multiversion
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -415,10 +416,12 @@ func (s *Store) WriteLatestToStore() {
 			// be sure if the underlying store might do a save with the byteslice or
 			// not. Once we get confirmation that .Delete is guaranteed not to
 			// save the byteslice, then we can assume only a read-only copy is sufficient.
+			fmt.Println("Deleting from parent store: ", key) // TODO: remove
 			s.parentStore.Delete([]byte(key))
 			continue
 		}
 		if mvValue.Value() != nil {
+			fmt.Println("Writing to parent store: ", key, mvValue.Value()) // TODO: remove
 			s.parentStore.Set([]byte(key), mvValue.Value())
 		}
 	}

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -431,12 +431,16 @@ func (s *Store) WriteLatestToStore() {
 			// be sure if the underlying store might do a save with the byteslice or
 			// not. Once we get confirmation that .Delete is guaranteed not to
 			// save the byteslice, then we can assume only a read-only copy is sufficient.
-			s.logger.Info("Deleting from parent store: ", "key", hex.EncodeToString([]byte(key))) // TODO: remove
+			if s.logger != nil {
+				s.logger.Info("Deleting from parent store: ", "key", hex.EncodeToString([]byte(key))) // TODO: remove
+			}
 			s.parentStore.Delete([]byte(key))
 			continue
 		}
 		if mvValue.Value() != nil {
-			s.logger.Info("Writing to parent store: ", "key", hex.EncodeToString([]byte(key)), "value", hex.EncodeToString(mvValue.Value())) // TODO: remove
+			if s.logger != nil {
+				s.logger.Info("Writing to parent store: ", "key", hex.EncodeToString([]byte(key)), "value", hex.EncodeToString(mvValue.Value())) // TODO: remove
+			}
 			s.parentStore.Set([]byte(key), mvValue.Value())
 		}
 	}

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -126,7 +126,7 @@ func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context) {
 	mvs := make(map[sdk.StoreKey]multiversion.MultiVersionStore)
 	keys := ctx.MultiStore().StoreKeys()
 	for _, sk := range keys {
-		mvs[sk] = multiversion.NewMultiVersionStore(ctx.MultiStore().GetKVStore(sk))
+		mvs[sk] = multiversion.NewMultiVersionStore(ctx.MultiStore().GetKVStore(sk), ctx.Logger())
 	}
 	s.multiVersionStores = mvs
 }

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -126,7 +126,7 @@ func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context) {
 	mvs := make(map[sdk.StoreKey]multiversion.MultiVersionStore)
 	keys := ctx.MultiStore().StoreKeys()
 	for _, sk := range keys {
-		mvs[sk] = multiversion.NewMultiVersionStore(ctx.MultiStore().GetKVStore(sk), ctx.Logger())
+		mvs[sk] = multiversion.NewMultiVersionStoreWithLogger(ctx.MultiStore().GetKVStore(sk), ctx.Logger())
 	}
 	s.multiVersionStores = mvs
 }

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -192,7 +192,8 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 			t.Increment()
 		}
 	}
-	for _, mv := range s.multiVersionStores {
+	for k, mv := range s.multiVersionStores {
+		ctx.Logger().Info("Writing latest to store", "storeKey", k.Name()) // TODO: remove
 		mv.WriteLatestToStore()
 	}
 	return collectResponses(tasks), nil

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -276,7 +276,7 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 						task.Abort = &abt
 						continue
 					}
-					ctx.Logger().Info("Writing mvkv to multiversion store", "txIndex", task.Index) // TODO: remove
+					ctx.Logger().Info("Writing mvkv to multiversion store", "txIndex", task.Index, "taskReq", task.Request.Tx) // TODO: remove
 					// write from version store to multiversion stores
 					for _, v := range task.VersionStores {
 						v.WriteToMultiVersionStore()

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -126,6 +126,10 @@ func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context) {
 	mvs := make(map[sdk.StoreKey]multiversion.MultiVersionStore)
 	keys := ctx.MultiStore().StoreKeys()
 	for _, sk := range keys {
+		if sk.Name() == "dex_mem" { // TODO : remove
+			mvs[sk] = multiversion.NewMultiVersionStore(ctx.MultiStore().GetKVStore(sk))
+			continue
+		}
 		mvs[sk] = multiversion.NewMultiVersionStoreWithLogger(ctx.MultiStore().GetKVStore(sk), ctx.Logger())
 	}
 	s.multiVersionStores = mvs

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -126,7 +126,7 @@ func (s *scheduler) tryInitMultiVersionStore(ctx sdk.Context) {
 	mvs := make(map[sdk.StoreKey]multiversion.MultiVersionStore)
 	keys := ctx.MultiStore().StoreKeys()
 	for _, sk := range keys {
-		if sk.Name() == "dex_mem" { // TODO : remove
+		if sk.Name() == "mem_dex" { // TODO : remove
 			mvs[sk] = multiversion.NewMultiVersionStore(ctx.MultiStore().GetKVStore(sk))
 			continue
 		}

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -152,9 +152,12 @@ func allValidated(tasks []*deliverTxTask) bool {
 func (s *scheduler) PrefillEstimates(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) {
 	// iterate over TXs, update estimated writesets where applicable
 	for i, req := range reqs {
+		ctx.Logger().Info("Trying prefill for tx index", "index", i) // TODO: remove
 		mappedWritesets := req.EstimatedWritesets
 		// order shouldnt matter for storeKeys because each storeKey partitioned MVS is independent
 		for storeKey, writeset := range mappedWritesets {
+			// TODO: remove - log the mapped writesets
+			ctx.Logger().Info("Prefilling estimated writeset", "storeKey", storeKey.Name(), "writeset", writeset)
 			// we use `-1` to indicate a prefill incarnation
 			s.multiVersionStores[storeKey].SetEstimatedWriteset(i, -1, writeset)
 		}
@@ -273,7 +276,7 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 						task.Abort = &abt
 						continue
 					}
-
+					ctx.Logger().Info("Writing mvkv to multiversion store", "txIndex", task.Index) // TODO: remove
 					// write from version store to multiversion stores
 					for _, v := range task.VersionStores {
 						v.WriteToMultiVersionStore()

--- a/types/accesscontrol/validation.go
+++ b/types/accesscontrol/validation.go
@@ -10,6 +10,7 @@ var (
 )
 
 type StoreKeyToResourceTypePrefixMap map[string]map[ResourceType][]byte
+type ResourceTypeToStoreKeyMap map[ResourceType]string
 
 func DefaultStoreKeyToResourceTypePrefixMap() StoreKeyToResourceTypePrefixMap {
 	return StoreKeyToResourceTypePrefixMap{

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -506,7 +506,6 @@ func (k Keeper) GetStoreKeyMap(ctx sdk.Context) storeKeyMap {
 }
 
 func (k Keeper) UpdateWritesetsWithAccessOps(accessOps []acltypes.AccessOperation, mappedWritesets sdk.MappedWritesets, storeKeyMap storeKeyMap) sdk.MappedWritesets {
-	fmt.Println(accessOps)
 	for _, accessOp := range accessOps {
 		// we only want writes and unknowns (assumed writes)
 		if accessOp.AccessType != acltypes.AccessType_WRITE && accessOp.AccessType != acltypes.AccessType_UNKNOWN {

--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yourbasic/graph"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
@@ -40,6 +41,7 @@ type (
 		MessageDependencyGeneratorMapper DependencyGeneratorMap
 		AccountKeeper                    authkeeper.AccountKeeper
 		StakingKeeper                    stakingkeeper.Keeper
+		ResourceTypeStoreKeyMapping      acltypes.ResourceTypeToStoreKeyMap
 	}
 )
 
@@ -491,6 +493,68 @@ func (k Keeper) IterateWasmDependencies(ctx sdk.Context, handler func(wasmDepend
 			break
 		}
 	}
+}
+
+type storeKeyMap map[string]sdk.StoreKey
+
+func (k Keeper) GetStoreKeyMap(ctx sdk.Context) storeKeyMap {
+	storeKeyMap := make(storeKeyMap)
+	for _, storeKey := range ctx.MultiStore().StoreKeys() {
+		storeKeyMap[storeKey.Name()] = storeKey
+	}
+	return storeKeyMap
+}
+
+func (k Keeper) UpdateWritesetsWithAccessOps(accessOps []acltypes.AccessOperation, mappedWritesets sdk.MappedWritesets, storeKeyMap storeKeyMap) sdk.MappedWritesets {
+	fmt.Println(accessOps)
+	for _, accessOp := range accessOps {
+		// we only want writes and unknowns (assumed writes)
+		if accessOp.AccessType != acltypes.AccessType_WRITE && accessOp.AccessType != acltypes.AccessType_UNKNOWN {
+			continue
+		}
+		// the accessOps should only have SPECIFIC identifiers (we don't want wildcards)
+		if accessOp.IdentifierTemplate == "*" {
+			continue
+		}
+		// check the resource type to store key map for potential store key
+		if storeKeyStr, ok := k.ResourceTypeStoreKeyMapping[accessOp.ResourceType]; ok {
+			// check that we have a storekey corresponding to that string
+			if storeKey, ok2 := storeKeyMap[storeKeyStr]; ok2 {
+				// if we have a StoreKey, add it to the writeset - writing empty bytes is ok because it will be saved as EstimatedWriteset
+				if _, ok := mappedWritesets[storeKey]; !ok {
+					mappedWritesets[storeKey] = make(multiversion.WriteSet)
+				}
+				mappedWritesets[storeKey][accessOp.IdentifierTemplate] = []byte{}
+			}
+		}
+
+	}
+	return mappedWritesets
+}
+
+// GenerateEstimatedWritesets utilizes the existing patterns for access operation generation to estimate the writesets for a transaction
+func (k Keeper) GenerateEstimatedWritesets(ctx sdk.Context, txDecoder sdk.TxDecoder, anteDepGen sdk.AnteDepGenerator, txIndex int, txBytes []byte) (sdk.MappedWritesets, error) {
+	storeKeyMap := k.GetStoreKeyMap(ctx)
+	writesets := make(sdk.MappedWritesets)
+	tx, err := txDecoder(txBytes)
+	if err != nil {
+		return nil, err
+	}
+	// generate antedeps accessOps for tx
+	anteDeps, err := anteDepGen([]acltypes.AccessOperation{}, tx, txIndex)
+	if err != nil {
+		return nil, err
+	}
+	writesets = k.UpdateWritesetsWithAccessOps(anteDeps, writesets, storeKeyMap)
+
+	// generate accessOps for each message
+	msgs := tx.GetMsgs()
+	for _, msg := range msgs {
+		msgDependencies := k.GetMessageDependencies(ctx, msg)
+		// update estimated writeset for each message deps
+		writesets = k.UpdateWritesetsWithAccessOps(msgDependencies, writesets, storeKeyMap)
+	}
+	return writesets, nil
 }
 
 func (k Keeper) BuildDependencyDag(ctx sdk.Context, txDecoder sdk.TxDecoder, anteDepGen sdk.AnteDepGenerator, txs [][]byte) (*types.Dag, error) {

--- a/x/accesscontrol/keeper/keeper_test.go
+++ b/x/accesscontrol/keeper/keeper_test.go
@@ -20,6 +20,7 @@ import (
 	aclkeeper "github.com/cosmos/cosmos-sdk/x/accesscontrol/keeper"
 	acltestutil "github.com/cosmos/cosmos-sdk/x/accesscontrol/testutil"
 	"github.com/cosmos/cosmos-sdk/x/accesscontrol/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -2680,7 +2681,8 @@ func TestGenerateEstimatedDependencies(t *testing.T) {
 	}
 	// set up testing mapping
 	app.AccessControlKeeper.ResourceTypeStoreKeyMapping = map[acltypes.ResourceType]string{
-		acltypes.ResourceType_KV_BANK_BALANCES: banktypes.StoreKey,
+		acltypes.ResourceType_KV_BANK_BALANCES:      banktypes.StoreKey,
+		acltypes.ResourceType_KV_AUTH_ADDRESS_STORE: authtypes.StoreKey,
 	}
 
 	storeKeyMap := app.AccessControlKeeper.GetStoreKeyMap(ctx)
@@ -2695,11 +2697,12 @@ func TestGenerateEstimatedDependencies(t *testing.T) {
 	require.NoError(t, err)
 
 	// check writesets
-	require.Equal(t, 1, len(writesets))
+	require.Equal(t, 2, len(writesets))
 	bankWritesets := writesets[storeKeyMap[banktypes.StoreKey]]
-	fmt.Println(bankWritesets)
-	// due to how the default dep gen works (doesnt generate proper store key, but that's ok)
 	require.Equal(t, 3, len(bankWritesets))
+
+	authWritesets := writesets[storeKeyMap[authtypes.StoreKey]]
+	require.Equal(t, 1, len(authWritesets))
 
 }
 

--- a/x/accesscontrol/keeper/options.go
+++ b/x/accesscontrol/keeper/options.go
@@ -1,5 +1,7 @@
 package keeper
 
+import acltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+
 type optsFn func(*Keeper)
 
 func (f optsFn) Apply(keeper *Keeper) {
@@ -24,4 +26,10 @@ func (oldGenerator DependencyGeneratorMap) Merge(newGenerator DependencyGenerato
 		oldGenerator[messageKey] = dependencyGenerator
 	}
 	return oldGenerator
+}
+
+func WithResourceTypeToStoreKeyMap(resourceTypeStoreKeyMapping acltypes.ResourceTypeToStoreKeyMap) optsFn {
+	return optsFn(func(k *Keeper) {
+		k.ResourceTypeStoreKeyMapping = resourceTypeStoreKeyMapping
+	})
 }


### PR DESCRIPTION
## Describe your changes and provide context
This modifies the accesscontrol keeper to allow generation of estimated writesets based on an input transaction. It will generate all of the access operations for the transaction, and then map them to various store key writesets as appropriate specifically for WRITE and UNKNOWN access types where a granular identifier template is specified (given that the pattern of granular identifier template is to provide a key that will be accessed). The side effect of a malformed identifier template is fairly minimal, since then it would write an ESTIMATE on a key that will never be touched, and that ESTIMATE will be cleared out anyways upon transaction execution completion.

## Testing performed to validate your change
unit tests
