### PR TITLE
[OCC] Add trace spans to scheduler

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -238,7 +238,7 @@ func (app *BaseApp) CheckTx(ctx context.Context, req *abci.RequestCheckTx) (*abc
 
 // DeliverTxBatch executes multiple txs
 func (app *BaseApp) DeliverTxBatch(ctx sdk.Context, req sdk.DeliverTxBatchRequest) (res sdk.DeliverTxBatchResponse) {
-	scheduler := tasks.NewScheduler(app.concurrencyWorkers, app.DeliverTx)
+	scheduler := tasks.NewScheduler(app.concurrencyWorkers, app.TracingInfo, app.DeliverTx)
 	// This will basically no-op the actual prefill if the metadata for the txs is empty
 
 	// process all txs, this will also initializes the MVS if prefill estimates was disabled

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -308,6 +308,7 @@ func (s *scheduler) prepareTask(ctx sdk.Context, task *deliverTxTask) {
 	abortCh := make(chan occ.Abort, len(s.multiVersionStores))
 	spanCtx, span := s.tracingInfo.StartWithContext("SchedulerExecute", ctx.TraceSpanContext())
 	span.SetAttributes(attribute.String("txHash", fmt.Sprintf("%X", sha256.Sum256(task.Request.Tx))))
+	span.SetAttributes(attribute.Int("txIndex", task.Index))
 	span.SetAttributes(attribute.Int("incarnation", task.Incarnation))
 	ctx = ctx.WithTraceSpanContext(spanCtx)
 

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -309,7 +309,7 @@ func (s *scheduler) prepareTask(ctx sdk.Context, task *deliverTxTask) {
 	spanCtx, span := s.tracingInfo.StartWithContext("SchedulerExecute", ctx.TraceSpanContext())
 	span.SetAttributes(attribute.String("txHash", fmt.Sprintf("%X", sha256.Sum256(task.Request.Tx))))
 	span.SetAttributes(attribute.Int("txIndex", task.Index))
-	span.SetAttributes(attribute.Int("incarnation", task.Incarnation))
+	span.SetAttributes(attribute.Int("txIncarnation", task.Incarnation))
 	ctx = ctx.WithTraceSpanContext(spanCtx)
 
 	// if there are no stores, don't try to wrap, because there's nothing to wrap

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -3,18 +3,18 @@ package tasks
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/utils/tracing"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"sort"
 
 	"github.com/tendermint/tendermint/abci/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/occ"
+	"github.com/cosmos/cosmos-sdk/utils/tracing"
 )
 
 type status string

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -1,6 +1,11 @@
 package tasks
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/utils/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"sort"
 
 	"github.com/tendermint/tendermint/abci/types"
@@ -33,6 +38,7 @@ const (
 
 type deliverTxTask struct {
 	Ctx     sdk.Context
+	Span    trace.Span
 	AbortCh chan occ.Abort
 
 	Status        status
@@ -64,13 +70,15 @@ type scheduler struct {
 	deliverTx          func(ctx sdk.Context, req types.RequestDeliverTx) (res types.ResponseDeliverTx)
 	workers            int
 	multiVersionStores map[sdk.StoreKey]multiversion.MultiVersionStore
+	tracingInfo        *tracing.Info
 }
 
 // NewScheduler creates a new scheduler
-func NewScheduler(workers int, deliverTxFunc func(ctx sdk.Context, req types.RequestDeliverTx) (res types.ResponseDeliverTx)) Scheduler {
+func NewScheduler(workers int, tracingInfo *tracing.Info, deliverTxFunc func(ctx sdk.Context, req types.RequestDeliverTx) (res types.ResponseDeliverTx)) Scheduler {
 	return &scheduler{
-		workers:   workers,
-		deliverTx: deliverTxFunc,
+		workers:     workers,
+		deliverTx:   deliverTxFunc,
+		tracingInfo: tracingInfo,
 	}
 }
 
@@ -181,7 +189,7 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 
 		// validate returns any that should be re-executed
 		// note this processes ALL tasks, not just those recently executed
-		toExecute, err = s.validateAll(tasks)
+		toExecute, err = s.validateAll(ctx, tasks)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +203,11 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 	return collectResponses(tasks), nil
 }
 
-func (s *scheduler) validateAll(tasks []*deliverTxTask) ([]*deliverTxTask, error) {
+func (s *scheduler) validateAll(ctx sdk.Context, tasks []*deliverTxTask) ([]*deliverTxTask, error) {
+	spanCtx, span := s.tracingInfo.StartWithContext("SchedulerValidate", ctx.TraceSpanContext())
+	ctx = ctx.WithTraceSpanContext(spanCtx)
+	defer span.End()
+
 	var res []*deliverTxTask
 
 	// find first non-validated entry
@@ -263,24 +275,7 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 					if !ok {
 						return nil
 					}
-
-					resp := s.deliverTx(task.Ctx, task.Request)
-
-					close(task.AbortCh)
-
-					if abt, ok := <-task.AbortCh; ok {
-						task.Status = statusAborted
-						task.Abort = &abt
-						continue
-					}
-
-					// write from version store to multiversion stores
-					for _, v := range task.VersionStores {
-						v.WriteToMultiVersionStore()
-					}
-
-					task.Status = statusExecuted
-					task.Response = &resp
+					s.executeTask(task)
 				}
 			}
 		})
@@ -288,32 +283,7 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 	grp.Go(func() error {
 		defer close(ch)
 		for _, task := range tasks {
-			// initialize the context
-			ctx = ctx.WithTxIndex(task.Index)
-			abortCh := make(chan occ.Abort, len(s.multiVersionStores))
-
-			// if there are no stores, don't try to wrap, because there's nothing to wrap
-			if len(s.multiVersionStores) > 0 {
-				// non-blocking
-				cms := ctx.MultiStore().CacheMultiStore()
-
-				// init version stores by store key
-				vs := make(map[store.StoreKey]*multiversion.VersionIndexedStore)
-				for storeKey, mvs := range s.multiVersionStores {
-					vs[storeKey] = mvs.VersionedIndexedStore(task.Index, task.Incarnation, abortCh)
-				}
-
-				// save off version store so we can ask it things later
-				task.VersionStores = vs
-				ms := cms.SetKVStores(func(k store.StoreKey, kvs sdk.KVStore) store.CacheWrap {
-					return vs[k]
-				})
-
-				ctx = ctx.WithMultiStore(ms)
-			}
-
-			task.AbortCh = abortCh
-			task.Ctx = ctx
+			s.prepareTask(ctx, task)
 
 			select {
 			case <-gCtx.Done():
@@ -329,4 +299,63 @@ func (s *scheduler) executeAll(ctx sdk.Context, tasks []*deliverTxTask) error {
 	}
 
 	return nil
+}
+
+// prepareTask initializes the context and version stores for a task
+func (s *scheduler) prepareTask(ctx sdk.Context, task *deliverTxTask) {
+	// initialize the context
+	ctx = ctx.WithTxIndex(task.Index)
+	abortCh := make(chan occ.Abort, len(s.multiVersionStores))
+	spanCtx, span := s.tracingInfo.StartWithContext("SchedulerExecute", ctx.TraceSpanContext())
+	span.SetAttributes(attribute.String("txHash", fmt.Sprintf("%X", sha256.Sum256(task.Request.Tx))))
+	span.SetAttributes(attribute.Int("incarnation", task.Incarnation))
+	ctx = ctx.WithTraceSpanContext(spanCtx)
+
+	// if there are no stores, don't try to wrap, because there's nothing to wrap
+	if len(s.multiVersionStores) > 0 {
+		// non-blocking
+		cms := ctx.MultiStore().CacheMultiStore()
+
+		// init version stores by store key
+		vs := make(map[store.StoreKey]*multiversion.VersionIndexedStore)
+		for storeKey, mvs := range s.multiVersionStores {
+			vs[storeKey] = mvs.VersionedIndexedStore(task.Index, task.Incarnation, abortCh)
+		}
+
+		// save off version store so we can ask it things later
+		task.VersionStores = vs
+		ms := cms.SetKVStores(func(k store.StoreKey, kvs sdk.KVStore) store.CacheWrap {
+			return vs[k]
+		})
+
+		ctx = ctx.WithMultiStore(ms)
+	}
+
+	task.AbortCh = abortCh
+	task.Ctx = ctx
+	task.Span = span
+}
+
+// executeTask executes a single task
+func (s *scheduler) executeTask(task *deliverTxTask) {
+	if task.Span != nil {
+		defer task.Span.End()
+	}
+	resp := s.deliverTx(task.Ctx, task.Request)
+
+	close(task.AbortCh)
+
+	if abt, ok := <-task.AbortCh; ok {
+		task.Status = statusAborted
+		task.Abort = &abt
+		return
+	}
+
+	// write from version store to multiversion stores
+	for _, v := range task.VersionStores {
+		v.WriteToMultiVersionStore()
+	}
+
+	task.Status = statusExecuted
+	task.Response = &resp
 }

--- a/tasks/scheduler_test.go
+++ b/tasks/scheduler_test.go
@@ -4,20 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/utils/tracing"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"testing"
-
-	"github.com/cosmos/cosmos-sdk/store/cachemulti"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/abci/types"
 	dbm "github.com/tendermint/tm-db"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
+	"github.com/cosmos/cosmos-sdk/store/cachemulti"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/utils/tracing"
 )
 
 type mockDeliverTxFunc func(ctx sdk.Context, req types.RequestDeliverTx) types.ResponseDeliverTx


### PR DESCRIPTION
## Describe your changes and provide context
- Adds trace span for `SchedulerValidate` 
- Adds trace span for `SchedulerExecute`
- Mild refactor (extracted methods) to make it easier to defer span ending

## Testing performed to validate your change
Example trace (run locally)
![image](https://github.com/sei-protocol/sei-cosmos/assets/6051744/b8a032f1-71b1-4e95-b12e-357455ebcc6d)

Example attributes of SchedulerExecute operation
![image](https://github.com/sei-protocol/sei-cosmos/assets/6051744/68992e84-4000-44c1-8597-9d4c10583a66)
