### PR TITLE
[OCC] Use worker pool to limit number of goroutines

### DIFF
--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -267,8 +267,13 @@ func (s *scheduler) validateAll(ctx sdk.Context, tasks []*deliverTxTask) ([]*del
 	var mx sync.Mutex
 	var res []*deliverTxTask
 
+	startIndex, anyInvalid := s.findFirstNonValidated()
+	if !anyInvalid {
+		return nil, nil
+	}
+
 	wg := sync.WaitGroup{}
-	for i := 0; i < len(tasks); i++ {
+	for i := startIndex; i < len(tasks); i++ {
 		wg.Add(1)
 		go func(task *deliverTxTask) {
 			defer wg.Done()

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -97,6 +97,7 @@ func (s *scheduler) Start(ctx context.Context, workers int) {
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for {
 				select {
 				case <-ctx.Done():

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -93,11 +93,8 @@ func (s *scheduler) invalidateTask(task *deliverTxTask) {
 }
 
 func (s *scheduler) Start(ctx context.Context, workers int) {
-	wg := sync.WaitGroup{}
 	for i := 0; i < workers; i++ {
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			for {
 				select {
 				case <-ctx.Done():
@@ -108,7 +105,6 @@ func (s *scheduler) Start(ctx context.Context, workers int) {
 			}
 		}()
 	}
-	wg.Wait()
 }
 
 func (s *scheduler) Do(work func()) {
@@ -213,7 +209,7 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 
 	workerCtx, cancel := context.WithCancel(ctx.Context())
 	defer cancel()
-	go s.Start(workerCtx, workers)
+	s.Start(workerCtx, workers)
 
 	toExecute := tasks
 	for !allValidated(tasks) {

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -300,13 +300,8 @@ func (s *scheduler) validateAll(ctx sdk.Context, tasks []*deliverTxTask) ([]*del
 	var mx sync.Mutex
 	var res []*deliverTxTask
 
-	startIndex, anyInvalid := s.findFirstNonValidated()
-	if !anyInvalid {
-		return nil, nil
-	}
-
 	wg := sync.WaitGroup{}
-	for i := startIndex; i < len(tasks); i++ {
+	for i := 0; i < len(tasks); i++ {
 		t := tasks[i]
 		wg.Add(1)
 		s.Do(func() {


### PR DESCRIPTION
## Describe your changes and provide context
- limit number of workers to a shared worker pool (avoids one-off goroutines)

## Testing performed to validate your change
- Tests pass 

