### PR TITLE
Set TxIndex before generating dependencies

### DIFF
--- a/x/accesscontrol/keeper/keeper.go
+++ b/x/accesscontrol/keeper/keeper.go
@@ -525,6 +525,7 @@ func (k Keeper) BuildDependencyDag(ctx sdk.Context, txDecoder sdk.TxDecoder, ant
 		// add Access ops for msg for anteMsg
 		dependencyDag.AddAccessOpsForMsg(acltypes.ANTE_MSG_INDEX, txIndex, anteAccessOpsList)
 
+		ctx = ctx.WithTxIndex(txIndex)
 		msgs := tx.GetMsgs()
 		for messageIndex, msg := range msgs {
 			if types.IsGovMessage(msg) {


### PR DESCRIPTION
## Describe your changes and provide context
We need to make `TxIndex` available during dependency generation so that we can derive the corresponding temporary intermediate account and coinbase account for the message

## Testing performed to validate your change

