### PR TITLE
Add wei support in bank keeper

### DIFF
--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -76,6 +76,7 @@ func (suite *IntegrationTestSuite) initKeepersWithmAccPerms(blockedAddrs map[str
 	appCodec := simapp.MakeTestEncodingConfig().Marshaler
 
 	maccPerms[holder] = nil
+	maccPerms[types.WeiEscrowName] = nil
 	maccPerms[authtypes.Burner] = []string{authtypes.Burner}
 	maccPerms[authtypes.Minter] = []string{authtypes.Minter}
 	maccPerms[multiPerm] = []string{authtypes.Burner, authtypes.Minter, authtypes.Staking}
@@ -106,6 +107,55 @@ func (suite *IntegrationTestSuite) SetupTest() {
 	suite.app = app
 	suite.ctx = ctx
 	suite.queryClient = queryClient
+}
+
+func (suite *IntegrationTestSuite) TestSendCoinsAndWei() {
+	ctx := suite.ctx
+	require := suite.Require()
+	authKeeper, keeper := suite.initKeepersWithmAccPerms(make(map[string]bool))
+	amt := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)))
+	require.NoError(keeper.MintCoins(ctx, authtypes.Minter, amt))
+	addr1 := sdk.AccAddress([]byte("addr1_______________"))
+	addr2 := sdk.AccAddress([]byte("addr2_______________"))
+	addr3 := sdk.AccAddress([]byte("addr3_______________"))
+	require.NoError(keeper.SendCoinsFromModuleToAccount(ctx, authtypes.Minter, addr1, amt))
+	// should no-op if sending zero
+	require.NoError(keeper.SendCoinsAndWei(ctx, addr1, addr2, nil, sdk.DefaultBondDenom, sdk.ZeroInt(), sdk.ZeroInt()))
+	require.Equal(sdk.ZeroInt(), keeper.GetWeiBalance(ctx, addr1))
+	require.Equal(sdk.ZeroInt(), keeper.GetWeiBalance(ctx, addr2))
+	require.Equal(sdk.NewInt(100), keeper.GetBalance(ctx, addr1, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.ZeroInt(), keeper.GetBalance(ctx, addr2, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.ZeroInt(), keeper.GetBalance(ctx, authKeeper.GetModuleAddress(types.WeiEscrowName), sdk.DefaultBondDenom).Amount)
+	// should just do usei send if wei is zero
+	require.NoError(keeper.SendCoinsAndWei(ctx, addr1, addr3, nil, sdk.DefaultBondDenom, sdk.NewInt(50), sdk.ZeroInt()))
+	require.Equal(sdk.ZeroInt(), keeper.GetWeiBalance(ctx, addr1))
+	require.Equal(sdk.ZeroInt(), keeper.GetWeiBalance(ctx, addr3))
+	require.Equal(sdk.NewInt(50), keeper.GetBalance(ctx, addr1, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.NewInt(50), keeper.GetBalance(ctx, addr3, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.ZeroInt(), keeper.GetBalance(ctx, authKeeper.GetModuleAddress(types.WeiEscrowName), sdk.DefaultBondDenom).Amount)
+	// should return error if wei amount overflows
+	require.Error(keeper.SendCoinsAndWei(ctx, addr1, addr2, nil, sdk.DefaultBondDenom, sdk.ZeroInt(), sdk.NewInt(1_000_000_000_000)))
+	// sender gets escrowed one usei, recipient does not get redeemed
+	require.NoError(keeper.SendCoinsAndWei(ctx, addr1, addr2, nil, sdk.DefaultBondDenom, sdk.NewInt(1), sdk.NewInt(1)))
+	require.Equal(sdk.NewInt(999_999_999_999), keeper.GetWeiBalance(ctx, addr1))
+	require.Equal(sdk.OneInt(), keeper.GetWeiBalance(ctx, addr2))
+	require.Equal(sdk.NewInt(48), keeper.GetBalance(ctx, addr1, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.OneInt(), keeper.GetBalance(ctx, addr2, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.OneInt(), keeper.GetBalance(ctx, authKeeper.GetModuleAddress(types.WeiEscrowName), sdk.DefaultBondDenom).Amount)
+	// sender does not get escrowed due to sufficient wei balance, recipient does not get redeemed
+	require.NoError(keeper.SendCoinsAndWei(ctx, addr1, addr3, nil, sdk.DefaultBondDenom, sdk.NewInt(1), sdk.NewInt(999_999_999_999)))
+	require.Equal(sdk.ZeroInt(), keeper.GetWeiBalance(ctx, addr1))
+	require.Equal(sdk.NewInt(999_999_999_999), keeper.GetWeiBalance(ctx, addr3))
+	require.Equal(sdk.NewInt(47), keeper.GetBalance(ctx, addr1, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.NewInt(51), keeper.GetBalance(ctx, addr3, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.OneInt(), keeper.GetBalance(ctx, authKeeper.GetModuleAddress(types.WeiEscrowName), sdk.DefaultBondDenom).Amount)
+	// sender gets escrowed and recipient gets redeemed
+	require.NoError(keeper.SendCoinsAndWei(ctx, addr1, addr3, nil, sdk.DefaultBondDenom, sdk.NewInt(1), sdk.NewInt(2)))
+	require.Equal(sdk.NewInt(999_999_999_998), keeper.GetWeiBalance(ctx, addr1))
+	require.Equal(sdk.NewInt(1), keeper.GetWeiBalance(ctx, addr3))
+	require.Equal(sdk.NewInt(45), keeper.GetBalance(ctx, addr1, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.NewInt(53), keeper.GetBalance(ctx, addr3, sdk.DefaultBondDenom).Amount)
+	require.Equal(sdk.OneInt(), keeper.GetBalance(ctx, authKeeper.GetModuleAddress(types.WeiEscrowName), sdk.DefaultBondDenom).Amount)
 }
 
 func (suite *IntegrationTestSuite) TestSupply() {

--- a/x/bank/keeper/view.go
+++ b/x/bank/keeper/view.go
@@ -26,6 +26,7 @@ type ViewKeeper interface {
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	LockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	GetWeiBalance(ctx sdk.Context, addr sdk.AccAddress) sdk.Int
 
 	IterateAccountBalances(ctx sdk.Context, addr sdk.AccAddress, cb func(coin sdk.Coin) (stop bool))
 	IterateAllBalances(ctx sdk.Context, cb func(address sdk.AccAddress, coin sdk.Coin) (stop bool))
@@ -231,4 +232,18 @@ func (k BaseViewKeeper) getAccountStore(ctx sdk.Context, addr sdk.AccAddress) pr
 	store := ctx.KVStore(k.storeKey)
 
 	return prefix.NewStore(store, types.CreateAccountBalancesPrefix(addr))
+}
+
+func (k BaseViewKeeper) GetWeiBalance(ctx sdk.Context, addr sdk.AccAddress) sdk.Int {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.WeiBalancesPrefix)
+	val := store.Get(addr)
+	if val == nil {
+		return sdk.ZeroInt()
+	}
+	res := new(sdk.Int)
+	if err := res.Unmarshal(val); err != nil {
+		// should never happen
+		panic(err)
+	}
+	return *res
 }

--- a/x/bank/types/key.go
+++ b/x/bank/types/key.go
@@ -21,10 +21,13 @@ const (
 
 	// QuerierRoute defines the module's query routing key
 	QuerierRoute = ModuleName
+
+	WeiEscrowName = "weiescrow"
 )
 
 // KVStore keys
 var (
+	WeiBalancesPrefix = []byte{0x04}
 	// BalancesPrefix is the prefix for the account balances store. We use a byte
 	// (instead of `[]byte("balances")` to save some disk space).
 	DeferredCachePrefix = []byte{0x03}


### PR DESCRIPTION
## Describe your changes and provide context
Add two new bank keeper functions that allow sub-usei (i.e. wei) sending, where 1 usei = 10^12 wei:
```
SendCoinsAndWei(ctx sdk.Context, from sdk.AccAddress, to sdk.AccAddress, customEscrow sdk.AccAddress, denom string, amt sdk.Int, wei sdk.Int) error
GetWeiBalance(ctx sdk.Context, addr sdk.AccAddress) sdk.Int
```
Any usei that is split as a result of wei sending will be stored in an escrow account, which can either be one that's specified by the caller or a default global escrow module account.

## Testing performed to validate your change
unit test & local integration with sei-chain

