### PR TITLE
Improve cachekv write performance

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -68,7 +68,7 @@ func (store *Store) GetStoreType() types.StoreType {
 func (store *Store) getFromCache(key []byte) []byte {
 	if cv, ok := store.cache.Load(conv.UnsafeBytesToStr(key)); ok {
 		return cv.(*types.CValue).Value()
-	} 
+	}
 	return store.parent.Get(key)
 }
 
@@ -135,18 +135,9 @@ func (store *Store) Write() {
 	// Clear the cache using the map clearing idiom
 	// and not allocating fresh objects.
 	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
-	store.cache.Range(func(key, value any) bool {
-		store.cache.Delete(key)
-		return true
-	})
-	store.deleted.Range(func(key, value any) bool {
-		store.deleted.Delete(key)
-		return true
-	})
-	store.unsortedCache.Range(func(key, value any) bool {
-		store.deleted.Delete(key)
-		return true
-	})
+	store.cache = &sync.Map{}
+	store.deleted = &sync.Map{}
+	store.unsortedCache = &sync.Map{}
 	store.sortedCache = dbm.NewMemDB()
 }
 

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -132,9 +132,6 @@ func (store *Store) Write() {
 		}
 	}
 
-	// Clear the cache using the map clearing idiom
-	// and not allocating fresh objects.
-	// Please see https://bencher.orijtech.com/perfclinic/mapclearing/
 	store.cache = &sync.Map{}
 	store.deleted = &sync.Map{}
 	store.unsortedCache = &sync.Map{}


### PR DESCRIPTION
## Describe your changes and provide context
This PR avoid the several O(N) operations to clear up the maps. Instead of looping through each item and delete them, it will be much more efficient to just reset to a new map.

## Testing performed to validate your change
Tested in loadtest cluster and get performance improved (3ms -> 0.1ms)
