### PR TITLE
Add migration handler for disabling seqno

### DIFF
--- a/x/auth/keeper/migrations.go
+++ b/x/auth/keeper/migrations.go
@@ -41,3 +41,9 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 
 	return iterErr
 }
+
+func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+	defaultParams := types.DefaultParams()
+	m.keeper.SetParams(ctx, defaultParams)
+	return nil
+}

--- a/x/auth/keeper/v2_to_v3_test.go
+++ b/x/auth/keeper/v2_to_v3_test.go
@@ -1,0 +1,28 @@
+package keeper_test
+
+import (
+	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMigrate2to3(t *testing.T) {
+	app, ctx := createTestApp(true)
+
+	prevParams := types.Params{
+		MaxMemoCharacters:      types.DefaultMaxMemoCharacters,
+		TxSigLimit:             types.DefaultTxSigLimit,
+		TxSizeCostPerByte:      types.DefaultTxSizeCostPerByte,
+		SigVerifyCostED25519:   types.DefaultSigVerifyCostED25519,
+		SigVerifyCostSecp256k1: types.DefaultSigVerifyCostSecp256k1,
+	}
+
+	app.AccountKeeper.SetParams(ctx, prevParams)
+	// migrate to default params
+	m := keeper.NewMigrator(app.AccountKeeper, app.GRPCQueryRouter())
+	err := m.Migrate2to3(ctx)
+	require.NoError(t, err)
+	params := app.AccountKeeper.GetParams(ctx)
+	require.Equal(t, params.DisableSeqnoCheck, false)
+}

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -134,6 +134,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err != nil {
 		panic(err)
 	}
+	err = cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2to3)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // InitGenesis performs genesis initialization for the auth module. It returns
@@ -153,7 +157,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 2 }
+func (AppModule) ConsensusVersion() uint64 { return 3 }
 
 // AppModuleSimulation functions
 

--- a/x/params/types/subspace.go
+++ b/x/params/types/subspace.go
@@ -219,6 +219,7 @@ func (s Subspace) Update(ctx sdk.Context, key, value []byte) error {
 // in the ParamSetPair by calling Subspace#Get.
 func (s Subspace) GetParamSet(ctx sdk.Context, ps ParamSet) {
 	for _, pair := range ps.ParamSetPairs() {
+		fmt.Printf("PSUDEBUG - pairs: %s\n", pair)
 		s.Get(ctx, pair.Key, pair.Value)
 	}
 }

--- a/x/params/types/subspace.go
+++ b/x/params/types/subspace.go
@@ -219,7 +219,6 @@ func (s Subspace) Update(ctx sdk.Context, key, value []byte) error {
 // in the ParamSetPair by calling Subspace#Get.
 func (s Subspace) GetParamSet(ctx sdk.Context, ps ParamSet) {
 	for _, pair := range ps.ParamSetPairs() {
-		fmt.Printf("PSUDEBUG - pairs: %s\n", pair)
 		s.Get(ctx, pair.Key, pair.Value)
 	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
Add migration handler to add new disable seqno parameter to chain. Note that i verified that we already use default values so we can just set the params to default instead of maintaining authParamsV1 and V2
## Testing performed to validate your change
- unit tests
- upgraded local chain, ensure that bank sends work
