### PR TITLE
Occ enabled cfg

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -60,6 +60,7 @@ const (
 
 	FlagChainID            = "chain-id"
 	FlagConcurrencyWorkers = "concurrency-workers"
+	FlagOccEnabled         = "occ-enabled"
 )
 
 var (
@@ -167,6 +168,7 @@ type BaseApp struct { //nolint: maligned
 	TracingInfo *tracing.Info
 
 	concurrencyWorkers int
+	occEnabled         bool
 }
 
 type appStore struct {
@@ -316,6 +318,11 @@ func (app *BaseApp) AppVersion() uint64 {
 // ConcurrencyWorkers returns the number of concurrent workers for the BaseApp.
 func (app *BaseApp) ConcurrencyWorkers() int {
 	return app.concurrencyWorkers
+}
+
+// OccEnabled returns the whether OCC is enabled for the BaseApp.
+func (app *BaseApp) OccEnabled() bool {
+	return app.occEnabled
 }
 
 // Version returns the application's version string.

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -140,6 +140,11 @@ func TestSetMinGasPrices(t *testing.T) {
 	require.Equal(t, minGasPrices, app.minGasPrices)
 }
 
+func TestSetOccEnabled(t *testing.T) {
+	app := newBaseApp(t.Name(), SetOccEnabled(true))
+	require.True(t, app.OccEnabled())
+}
+
 // func TestGetMaximumBlockGas(t *testing.T) {
 // 	app := setupBaseApp(t)
 // 	app.InitChain(context.Background(), &abci.RequestInitChain{})

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -86,6 +86,10 @@ func SetConcurrencyWorkers(workers int) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetConcurrencyWorkers(workers) }
 }
 
+func SetOccEnabled(occEnabled bool) func(*BaseApp) {
+	return func(app *BaseApp) { app.SetOccEnabled(occEnabled) }
+}
+
 // SetSnapshotKeepRecent sets the recent snapshots to keep.
 func SetSnapshotKeepRecent(keepRecent uint32) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetSnapshotKeepRecent(keepRecent) }
@@ -299,6 +303,13 @@ func (app *BaseApp) SetConcurrencyWorkers(workers int) {
 		panic("SetConcurrencyWorkers() on sealed BaseApp")
 	}
 	app.concurrencyWorkers = workers
+}
+
+func (app *BaseApp) SetOccEnabled(occEnabled bool) {
+	if app.sealed {
+		panic("SetOccEnabled() on sealed BaseApp")
+	}
+	app.occEnabled = occEnabled
 }
 
 // SetSnapshotKeepRecent sets the number of recent snapshots to keep.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -24,6 +24,9 @@ const (
 
 	// DefaultConcurrencyWorkers defines the default workers to use for concurrent transactions
 	DefaultConcurrencyWorkers = 20
+
+	// DefaultOccEanbled defines whether to use OCC for tx processing
+	DefaultOccEnabled = true
 )
 
 // BaseConfig defines the server's basic configuration
@@ -95,6 +98,8 @@ type BaseConfig struct {
 	// ConcurrencyWorkers defines the number of workers to use for concurrent
 	// transaction execution. A value of -1 means unlimited workers.  Default value is 10.
 	ConcurrencyWorkers int `mapstructure:"concurrency-workers"`
+	// Whether to enable optimistic concurrency control for tx execution, default is true
+	OccEnabled bool `mapstructure:"occ-enabled"`
 }
 
 // APIConfig defines the API listener configuration.
@@ -246,6 +251,7 @@ func DefaultConfig() *Config {
 			CompactionInterval:  0,
 			NoVersioning:        false,
 			ConcurrencyWorkers:  DefaultConcurrencyWorkers,
+			OccEnabled:          DefaultOccEnabled,
 		},
 		Telemetry: telemetry.Config{
 			Enabled:      false,
@@ -323,6 +329,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			NumOrphanPerFile:             v.GetInt("num-orphan-per-file"),
 			OrphanDirectory:              v.GetString("orphan-dir"),
 			ConcurrencyWorkers:           v.GetInt("concurrency-workers"),
+			OccEnabled:                   v.GetBool("occ-enabled"),
 		},
 		Telemetry: telemetry.Config{
 			ServiceName:             v.GetString("telemetry.service-name"),

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -28,3 +28,8 @@ func TestSetConcurrencyWorkers(t *testing.T) {
 	cfg := DefaultConfig()
 	require.Equal(t, DefaultConcurrencyWorkers, cfg.ConcurrencyWorkers)
 }
+
+func TestOCCEnabled(t *testing.T) {
+	cfg := DefaultConfig()
+	require.Equal(t, true, cfg.OccEnabled)
+}

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -23,7 +23,7 @@ const DefaultConfigTemplate = `# This is a TOML config file.
 # specified in this config (e.g. 0.25token1;0.0001token2).
 minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 
-# Pruning Strategies: 
+# Pruning Strategies:
 # - default: Keep the recent 362880 blocks and prune is triggered every 10 blocks
 # - nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 # - everything: all saved states will be deleted, storing only the recent 2 blocks; pruning at every block
@@ -75,11 +75,11 @@ inter-block-cache = {{ .BaseConfig.InterBlockCache }}
 # ["message.sender", "message.recipient"]
 index-events = {{ .BaseConfig.IndexEvents }}
 
-# IavlCacheSize set the size of the iavl tree cache. 
+# IavlCacheSize set the size of the iavl tree cache.
 # Default cache size is 50mb.
 iavl-cache-size = {{ .BaseConfig.IAVLCacheSize }}
 
-# IAVLDisableFastNode enables or disables the fast node feature of IAVL. 
+# IAVLDisableFastNode enables or disables the fast node feature of IAVL.
 # Default is true.
 iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 
@@ -106,6 +106,9 @@ orphan-dir = "{{ .BaseConfig.OrphanDirectory }}"
 
 # concurrency-workers defines how many workers to run for concurrent transaction execution
 # concurrency-workers = {{ .BaseConfig.ConcurrencyWorkers }}
+
+# occ-enabled defines whether OCC is enabled or not for transaction execution
+occ-enabled = {{ .BaseConfig.OccEnabled }}
 
 ###############################################################################
 ###                         Telemetry Configuration                         ###

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -305,6 +305,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, t
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
 		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
 		baseapp.SetCompactionInterval(cast.ToUint64(appOpts.Get(server.FlagCompactionInterval))),
+		baseapp.SetOccEnabled(cast.ToBool(appOpts.Get(baseapp.FlagOccEnabled))),
 	)
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
This adds `occ-enabled` as a config for baseapp to control whether to execute transactions with OCC parallelism.

## Testing performed to validate your change
Tested on sei-chain

