### PR TITLE
[SeiDB] Fix concurrent map access

### DIFF
--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -237,6 +237,8 @@ func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStor
 	if version <= 0 || (rs.lastCommitInfo != nil && version == rs.lastCommitInfo.Version) {
 		return rs.CacheMultiStore(), nil
 	}
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 	// add the transient/mem stores registered in current app.
 	for k, store := range rs.ckvStores {


### PR DESCRIPTION
## Describe your changes and provide context
This should fix the concurrent map access for storeV2 root multistore over (rs.ckvStores). The problem is that it is currently not protected by a read lock so when other goroutine modify the map, it will throw panic

## Testing performed to validate your change

