### PR TITLE
Allow balance to go negative in SendCoinsAndWei

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -120,6 +120,14 @@ func (coin Coin) Sub(coinB Coin) Coin {
 	return res
 }
 
+func (coin Coin) SubUnsafe(coinB Coin) Coin {
+	if coin.Denom != coinB.Denom {
+		panic(fmt.Sprintf("invalid coin denominations; %s, %s", coin.Denom, coinB.Denom))
+	}
+
+	return Coin{coin.Denom, coin.Amount.Sub(coinB.Amount)}
+}
+
 // SubAmount subtracts an amount from the Coin.
 func (coin Coin) SubAmount(amount Int) Coin {
 	res := Coin{coin.Denom, coin.Amount.Sub(amount)}


### PR DESCRIPTION
## Describe your changes and provide context
Bypass negative check for sends involving Wei escrow accounts, since they may temporarily go negative during tx processing (but will be settled back to 0 in EndBlock)

## Testing performed to validate your change
tested with the corresponding sei change

