### PR TITLE
Add new error code for oracle spam broadcast failure

### DIFF
--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -147,6 +147,9 @@ var (
 	// ErrInvalidConcurrency defines an error occurred during concurrent execution
 	ErrInvalidConcurrencyExecution = Register(RootCodespace, 41, "error during concurrent execution")
 
+	// ErrAlreadyExists defines an error for which the tx is considered as a spam because the node has already seen it before
+	ErrAlreadyExists = Register(RootCodespace, 42, "error tx already exists")
+
 	// ErrPanic is only set when we recover from a panic, so we know to
 	// redact potentially sensitive system info
 	ErrPanic = Register(UndefinedCodespace, 111222, "panic")

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -147,7 +147,7 @@ var (
 	// ErrInvalidConcurrency defines an error occurred during concurrent execution
 	ErrInvalidConcurrencyExecution = Register(RootCodespace, 41, "error during concurrent execution")
 
-	// ErrAlreadyExists defines an error for which the tx is considered as a spam because the node has already seen it before
+	// ErrAlreadyExists defines an error for which the tx failed checkTx because the node has already seen it before
 	ErrAlreadyExists = Register(RootCodespace, 42, "error tx already exists")
 
 	// ErrPanic is only set when we recover from a panic, so we know to


### PR DESCRIPTION
## Describe your changes and provide context
This PR add a new error code to represent specific failure for oracle votes that already exist and seen by this validator node.
## Testing performed to validate your change

