### PR TITLE
[SeiDB] Fix SS apply changeset version off by 1

### DIFF
--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -141,7 +141,7 @@ func (rs *Store) StateStoreCommit() {
 // Flush all the pending changesets to commit store.
 func (rs *Store) flush() error {
 	var changeSets []*proto.NamedChangeSet
-	currentVersion := rs.lastCommitInfo.Version
+	currentVersion := rs.lastCommitInfo.Version + 1
 	for key := range rs.ckvStores {
 		// it'll unwrap the inter-block cache
 		store := rs.GetCommitKVStore(key)
@@ -161,7 +161,7 @@ func (rs *Store) flush() error {
 		})
 		if rs.ssStore != nil {
 			rs.pendingChanges <- VersionedChangesets{
-				Version:    currentVersion + 1,
+				Version:    currentVersion,
 				Changesets: changeSets,
 			}
 		}

--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -161,7 +161,7 @@ func (rs *Store) flush() error {
 		})
 		if rs.ssStore != nil {
 			rs.pendingChanges <- VersionedChangesets{
-				Version:    currentVersion,
+				Version:    currentVersion + 1,
 				Changesets: changeSets,
 			}
 		}


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
When apply changeset to SS store, currently we are using the lastCommitInfo version,  which is the previous block height. This means the version is off by 1. The correct way is to use the current block height for the changeset version
## Testing performed to validate your change
Will add integration test for this test case