### PR TITLE
Relax locking contention

### DIFF
--- a/store/cachekv/mergeiterator.go
+++ b/store/cachekv/mergeiterator.go
@@ -16,11 +16,10 @@ import (
 //
 // TODO: Optimize by memoizing.
 type cacheMergeIterator struct {
-	parent       types.Iterator
-	cache        types.Iterator
-	ascending    bool
-	storeKey     sdktypes.StoreKey
-	eventManager *sdktypes.EventManager
+	parent    types.Iterator
+	cache     types.Iterator
+	ascending bool
+	storeKey  sdktypes.StoreKey
 }
 
 var _ types.Iterator = (*cacheMergeIterator)(nil)
@@ -29,14 +28,12 @@ func NewCacheMergeIterator(
 	parent, cache types.Iterator,
 	ascending bool,
 	storeKey sdktypes.StoreKey,
-	eventManager *sdktypes.EventManager,
 ) *cacheMergeIterator {
 	iter := &cacheMergeIterator{
-		parent:       parent,
-		cache:        cache,
-		ascending:    ascending,
-		storeKey:     storeKey,
-		eventManager: eventManager,
+		parent:    parent,
+		cache:     cache,
+		ascending: ascending,
+		storeKey:  storeKey,
 	}
 
 	return iter
@@ -138,14 +135,12 @@ func (iter *cacheMergeIterator) Value() []byte {
 	// If parent is invalid, get the cache value.
 	if !iter.parent.Valid() {
 		value := iter.cache.Value()
-		iter.eventManager.EmitResourceAccessReadEvent("iterator", iter.storeKey, iter.cache.Key(), value)
 		return value
 	}
 
 	// If cache is invalid, get the parent value.
 	if !iter.cache.Valid() {
 		value := iter.parent.Value()
-		iter.eventManager.EmitResourceAccessReadEvent("iterator", iter.storeKey, iter.parent.Key(), value)
 		return value
 	}
 
@@ -156,11 +151,9 @@ func (iter *cacheMergeIterator) Value() []byte {
 	switch cmp {
 	case -1: // parent < cache
 		value := iter.parent.Value()
-		iter.eventManager.EmitResourceAccessReadEvent("iterator", iter.storeKey, keyP, value)
 		return value
 	case 0, 1: // parent >= cache
 		value := iter.cache.Value()
-		iter.eventManager.EmitResourceAccessReadEvent("iterator", iter.storeKey, keyC, value)
 		return value
 	default:
 		panic("invalid comparison result")

--- a/store/cachekv/mergeiterator_test.go
+++ b/store/cachekv/mergeiterator_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
 )
@@ -14,7 +13,6 @@ import (
 func TestMangerIterator(t *testing.T) {
 	// initiate mock kvstore
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	eventManager := sdktypes.NewEventManager()
 	kvstore := cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	value := randSlice(defaultValueSizeBz)
 	startKey := randSlice(32)
@@ -29,27 +27,13 @@ func TestMangerIterator(t *testing.T) {
 	cache := kvstore.Iterator(nil, nil)
 	for ; cache.Valid(); cache.Next() {
 	}
-	iter := cachekv.NewCacheMergeIterator(parent, cache, true, types.NewKVStoreKey("CacheKvTest"), eventManager)
+	iter := cachekv.NewCacheMergeIterator(parent, cache, true, types.NewKVStoreKey("CacheKvTest"))
+
+	// get the next value and it should not be nil
+	nextValue := iter.Value()
+	require.NotNil(t, nextValue)
 
 	// get the next value
-	iter.Value()
-
-	// assert the resource access is still emitted correctly when the cache store is unavailable
-	require.Equal(t, "access_type", string(eventManager.Events()[0].Attributes[0].Key))
-	require.Equal(t, "read", string(eventManager.Events()[0].Attributes[0].Value))
-	require.Equal(t, "store_key", string(eventManager.Events()[0].Attributes[1].Key))
-	require.Equal(t, "CacheKvTest", string(eventManager.Events()[0].Attributes[1].Value))
-
-	// assert event emission when cache is available
-	cache = kvstore.Iterator(keys[1], keys[2])
-	iter = cachekv.NewCacheMergeIterator(parent, cache, true, types.NewKVStoreKey("CacheKvTest"), eventManager)
-
-	// get the next value
-	iter.Value()
-
-	// assert the resource access is still emitted correctly when the cache store is available
-	require.Equal(t, "access_type", string(eventManager.Events()[0].Attributes[0].Key))
-	require.Equal(t, "read", string(eventManager.Events()[0].Attributes[0].Value))
-	require.Equal(t, "store_key", string(eventManager.Events()[0].Attributes[1].Key))
-	require.Equal(t, "CacheKvTest", string(eventManager.Events()[0].Attributes[1].Value))
+	nextValue = iter.Value()
+	require.NotNil(t, nextValue)
 }

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -56,8 +56,6 @@ func (store *Store) GetEvents() []abci.Event {
 
 // Implements Store
 func (store *Store) ResetEvents() {
-	store.mtx.Lock()
-	defer store.mtx.Unlock()
 	store.eventManager = sdktypes.NewEventManager()
 }
 
@@ -77,7 +75,6 @@ func (store *Store) getFromCache(key []byte) []byte {
 // Get implements types.KVStore.
 func (store *Store) Get(key []byte) (value []byte) {
 	types.AssertValidKey(key)
-	store.eventManager.EmitResourceAccessReadEvent("get", store.storeKey, key, value)
 	return store.getFromCache(key)
 }
 
@@ -86,13 +83,11 @@ func (store *Store) Set(key []byte, value []byte) {
 	types.AssertValidKey(key)
 	types.AssertValidValue(value)
 	store.setCacheValue(key, value, false, true)
-	store.eventManager.EmitResourceAccessWriteEvent("set", store.storeKey, key, value)
 }
 
 // Has implements types.KVStore.
 func (store *Store) Has(key []byte) bool {
 	value := store.Get(key)
-	store.eventManager.EmitResourceAccessReadEvent("has", store.storeKey, key, value)
 	return value != nil
 }
 
@@ -194,7 +189,7 @@ func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	}()
 	store.dirtyItems(start, end)
 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending, store.eventManager, store.storeKey)
-	return NewCacheMergeIterator(parent, cache, ascending, store.storeKey, store.eventManager)
+	return NewCacheMergeIterator(parent, cache, ascending, store.storeKey)
 }
 
 func findStartIndex(strL []string, startQ string) int {


### PR DESCRIPTION
## Describe your changes and provide context
This reduces some of the locking contention experienced when executing transactions with OCC. Additionally, undoes an earlier revert that reintroduced some locking for event emission

## Testing performed to validate your change

