### PR TITLE
[OCC] add metrics for scheduler

### DIFF
--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	"sort"
 	"sync"
 
 	"github.com/cosmos/cosmos-sdk/store/multiversion"
 	store "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/occ"
 	"github.com/cosmos/cosmos-sdk/utils/tracing"


### PR DESCRIPTION
## Describe your changes and provide context
- **retries** represents number of tx attempts beyond the first attempt
- **max_incarnation** is the highest incarnation seen in a given block

## Testing performed to validate your change
- lower environment
