### PR TITLE
Remove escrow account in wei logic

### DIFF
--- a/types/denom.go
+++ b/types/denom.go
@@ -53,6 +53,14 @@ func GetBaseDenom() (string, error) {
 	return baseDenom, nil
 }
 
+func MustGetBaseDenom() string {
+	bd, err := GetBaseDenom()
+	if err != nil {
+		panic(err)
+	}
+	return bd
+}
+
 // ConvertCoin attempts to convert a coin to a given denomination. If the given
 // denomination is invalid or if neither denomination is registered, an error
 // is returned.

--- a/x/bank/types/key.go
+++ b/x/bank/types/key.go
@@ -21,8 +21,6 @@ const (
 
 	// QuerierRoute defines the module's query routing key
 	QuerierRoute = ModuleName
-
-	WeiEscrowName = "weiescrow"
 )
 
 // KVStore keys


### PR DESCRIPTION
## Describe your changes and provide context
Since add and sub balance are now decoupled, we no longer need an explicit escrow account, and can implicitly represent "escrow" by direct crediting/debiting account's usei balances. This PR removes the explicit escrow account logic, and also added wei logic in invariant checks

## Testing performed to validate your change
unit tests
