### PR TITLE
Amplify cosmos tx priority

### DIFF
--- a/x/auth/ante/validator_tx_fee_test.go
+++ b/x/auth/ante/validator_tx_fee_test.go
@@ -79,3 +79,22 @@ func TestGetMinimumGasWanted(t *testing.T) {
 
 	require.True(t, expectedMinGasWanted.IsEqual(minGasWanted))
 }
+
+func TestGetTxPriority(t *testing.T) {
+	sdk.RegisterDenom("test", sdk.NewDecWithPrec(1, 6))
+	require.Equal(
+		t,
+		int64(0),
+		ante.GetTxPriority(sdk.NewCoins(), 1000),
+	)
+	require.Equal(
+		t,
+		int64(1_000_000_000),
+		ante.GetTxPriority(sdk.NewCoins(sdk.NewCoin("test", sdk.NewInt(1))), 1000),
+	)
+	require.Equal(
+		t,
+		int64(0),
+		ante.GetTxPriority(sdk.NewCoins(sdk.NewCoin("test", sdk.NewInt(1))), 10_000_000_000_000), // gas too large
+	)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Since EVM transactions specify gas price in unit of wei, we have started representing priority of EVM transactions in wei-per-gas. In order for cosmos transactions' priority to be comparable with EVM transactions', we would like to use the same unit for priority here as well. Hence in this PR we amplify cosmos transaction priority by 10^12 (if the original priority is based on the base denom aka usei)

## Testing performed to validate your change
unit test
