### PR TITLE
Refactor readset to handle potential race conditions

### DIFF
--- a/store/multiversion/mvkv_test.go
+++ b/store/multiversion/mvkv_test.go
@@ -389,3 +389,52 @@ func TestIterator(t *testing.T) {
 	require.Equal(t, 1, abort.DependentTxIdx)
 
 }
+
+func TestIteratorReadsetRace(t *testing.T) {
+	mem := dbadapter.Store{DB: dbm.NewMemDB()}
+	parentKVStore := cachekv.NewStore(mem, types.NewKVStoreKey("mock"), 1000)
+	mvs := multiversion.NewMultiVersionStore(parentKVStore)
+	// initialize a new VersionIndexedStore
+	abortC := make(chan scheduler.Abort)
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 2, 2, abortC)
+
+	// set some initial values
+	parentKVStore.Set([]byte("key4"), []byte("value4"))
+	parentKVStore.Set([]byte("key5"), []byte("value5"))
+	parentKVStore.Set([]byte("deletedKey"), []byte("foo"))
+	mvs.SetWriteset(0, 1, map[string][]byte{
+		"key1":       []byte("value1"),
+		"key2":       []byte("value2"),
+		"deletedKey": nil,
+	})
+
+	// iterate over the keys - exclusive on key5
+	iter := vis.Iterator([]byte("000"), []byte("key5"))
+
+	// verify domain is superset
+	start, end := iter.Domain()
+	require.Equal(t, []byte("000"), start)
+	require.Equal(t, []byte("key5"), end)
+
+	// add new writeset for txIndex 1 - writes to key4
+	mvs.SetWriteset(1, 1, map[string][]byte{
+		"key4": []byte("value4NEW"),
+	})
+
+	// perform a read on key4 from VIS and assert it is the new value
+	val := vis.Get([]byte("key4"))
+	require.Equal(t, []byte("value4NEW"), val)
+
+	vals := []string{}
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		vals = append(vals, string(iter.Value()))
+	}
+	// we still read the OLD value because key4 wasn't known to be in the MVS thus wasnt served
+	require.Equal(t, []string{"value1", "value2", "value4"}, vals)
+	iter.Close()
+
+	// verify that key4 has two elements in the readset
+	readset := vis.GetReadset()
+	require.Len(t, readset["key4"], 2)
+}

--- a/store/multiversion/mvkv_test.go
+++ b/store/multiversion/mvkv_test.go
@@ -32,7 +32,7 @@ func TestVersionIndexedStoreGetters(t *testing.T) {
 	require.Equal(t, []byte("value1"), val2)
 	require.True(t, vis.Has([]byte("key1")))
 	// verify value now in readset
-	require.Equal(t, []byte("value1"), vis.GetReadset()["key1"])
+	require.Equal(t, [][]byte{[]byte("value1")}, vis.GetReadset()["key1"])
 
 	// read the same key that should now be served from the readset (can be verified by setting a different value for the key in the parent store)
 	parentKVStore.Set([]byte("key1"), []byte("value2")) // realistically shouldn't happen, modifying to verify readset access

--- a/store/multiversion/store.go
+++ b/store/multiversion/store.go
@@ -32,7 +32,7 @@ type MultiVersionStore interface {
 }
 
 type WriteSet map[string][]byte
-type ReadSet map[string][]byte
+type ReadSet map[string][][]byte
 type Iterateset []iterationTracker
 
 var _ MultiVersionStore = (*Store)(nil)
@@ -341,7 +341,12 @@ func (s *Store) checkReadsetAtIndex(index int) (bool, []int) {
 	}
 	readset := readSetAny.(ReadSet)
 	// iterate over readset and check if the value is the same as the latest value relateive to txIndex in the multiversion store
-	for key, value := range readset {
+	for key, valueArr := range readset {
+		if len(valueArr) != 1 {
+			valid = false
+			continue
+		}
+		value := valueArr[0]
 		// get the latest value from the multiversion store
 		latestValue := s.GetLatestBeforeIndex(index, []byte(key))
 		if latestValue == nil {

--- a/store/multiversion/store_test.go
+++ b/store/multiversion/store_test.go
@@ -185,11 +185,11 @@ func TestMultiVersionStoreValidateState(t *testing.T) {
 	mvs.SetWriteset(1, 2, writeset)
 
 	readset := make(multiversion.ReadSet)
-	readset["key1"] = []byte("value1")
-	readset["key2"] = []byte("value2")
-	readset["key3"] = nil
-	readset["key4"] = []byte("value4")
-	readset["key5"] = []byte("value5")
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
+	readset["key5"] = [][]byte{[]byte("value5")}
 	mvs.SetReadset(5, readset)
 
 	// assert no readset is valid
@@ -249,11 +249,11 @@ func TestMultiVersionStoreParentValidationMismatch(t *testing.T) {
 	mvs.SetWriteset(1, 2, writeset)
 
 	readset := make(multiversion.ReadSet)
-	readset["key1"] = []byte("value1")
-	readset["key2"] = []byte("value2")
-	readset["key3"] = nil
-	readset["key4"] = []byte("value4")
-	readset["key5"] = []byte("value5")
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
+	readset["key5"] = [][]byte{[]byte("value5")}
 	mvs.SetReadset(5, readset)
 
 	// assert no readset is valid
@@ -294,11 +294,11 @@ func TestMVSValidationWithOnlyEstimate(t *testing.T) {
 	mvs.SetWriteset(1, 2, writeset)
 
 	readset := make(multiversion.ReadSet)
-	readset["key1"] = []byte("value1")
-	readset["key2"] = []byte("value2")
-	readset["key3"] = nil
-	readset["key4"] = []byte("value4")
-	readset["key5"] = []byte("value5")
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
+	readset["key5"] = [][]byte{[]byte("value5")}
 	mvs.SetReadset(5, readset)
 
 	// add a conflict due to estimate
@@ -496,11 +496,11 @@ func TestMVSIteratorValidationWithWritesetValuesSetAfterIteration(t *testing.T) 
 	mvs.SetWriteset(1, 2, writeset)
 
 	readset := make(multiversion.ReadSet)
-	readset["key1"] = []byte("value1")
-	readset["key2"] = []byte("value2")
-	readset["key3"] = nil
-	readset["key4"] = []byte("value4")
-	readset["key5"] = []byte("value5")
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
+	readset["key5"] = [][]byte{[]byte("value5")}
 	mvs.SetReadset(5, readset)
 
 	// no key6 because the iteration was performed BEFORE the write
@@ -536,11 +536,11 @@ func TestMVSIteratorValidationReverse(t *testing.T) {
 	mvs.SetWriteset(1, 2, writeset)
 
 	readset := make(multiversion.ReadSet)
-	readset["key1"] = []byte("value1")
-	readset["key2"] = []byte("value2")
-	readset["key3"] = nil
-	readset["key4"] = []byte("value4")
-	readset["key5"] = []byte("value5")
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
+	readset["key5"] = [][]byte{[]byte("value5")}
 	mvs.SetReadset(5, readset)
 
 	// set a key BEFORE iteration occurred
@@ -575,10 +575,10 @@ func TestMVSIteratorValidationEarlyStop(t *testing.T) {
 	mvs.SetWriteset(1, 2, writeset)
 
 	readset := make(multiversion.ReadSet)
-	readset["key1"] = []byte("value1")
-	readset["key2"] = []byte("value2")
-	readset["key3"] = nil
-	readset["key4"] = []byte("value4")
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
 	mvs.SetReadset(5, readset)
 
 	iter := vis.Iterator([]byte("key1"), []byte("key7"))

--- a/store/multiversion/store_test.go
+++ b/store/multiversion/store_test.go
@@ -278,6 +278,35 @@ func TestMultiVersionStoreParentValidationMismatch(t *testing.T) {
 	require.Empty(t, conflicts)
 }
 
+func TestMultiVersionStoreMultipleReadsetValueValidationFailure(t *testing.T) {
+	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
+	mvs := multiversion.NewMultiVersionStore(parentKVStore)
+
+	parentKVStore.Set([]byte("key2"), []byte("value0"))
+	parentKVStore.Set([]byte("key3"), []byte("value3"))
+	parentKVStore.Set([]byte("key4"), []byte("value4"))
+	parentKVStore.Set([]byte("key5"), []byte("value5"))
+
+	writeset := make(multiversion.WriteSet)
+	writeset["key1"] = []byte("value1")
+	writeset["key2"] = []byte("value2")
+	writeset["key3"] = nil
+	mvs.SetWriteset(1, 2, writeset)
+
+	readset := make(multiversion.ReadSet)
+	readset["key1"] = [][]byte{[]byte("value1")}
+	readset["key2"] = [][]byte{[]byte("value2")}
+	readset["key3"] = [][]byte{nil}
+	readset["key4"] = [][]byte{[]byte("value4")}
+	readset["key5"] = [][]byte{[]byte("value5"), []byte("value5b")}
+	mvs.SetReadset(5, readset)
+
+	// assert readset index 5 is invalid due to multiple values in readset
+	valid, conflicts := mvs.ValidateTransactionState(5)
+	require.False(t, valid)
+	require.Empty(t, conflicts)
+}
+
 func TestMVSValidationWithOnlyEstimate(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)


### PR DESCRIPTION
## Describe your changes and provide context
In some rare situations, it is possible that the race between iterators and other potential reads interleaved with writes to the same key by earlier transactions may result in stale values being used by a transaction but not being caught during validation. This refactor of readset behavior rigorously requires that ALL attempts to update the readset must either ADD to the readset if the value is different from that previously encountered, or no-op only if that value is already existing in the readset. As a result, if we encounter a situation where a race condition caused different values to be read for a key, this will catch it in validation and result in the transaction failing validation and requiring re-execution.

## Testing performed to validate your change
Unit tests