### PR TITLE
Fix iterator behavior for edge case validation failures

### DIFF
--- a/store/multiversion/data_structures.go
+++ b/store/multiversion/data_structures.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	// The approximate number of items and children per B-tree node. Tuned with benchmarks.
-	multiVersionBTreeDegree = 2 // should be equivalent to a binary search tree TODO: benchmark this
+	multiVersionBTreeDegree = 2
 )
 
 type MultiVersionValue interface {

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -23,7 +23,7 @@ func (NoOpHandler) UpdateReadSet(key []byte, value []byte) {}
 
 // exposes a handler for adding items to iterateset, to be called upon iterator close
 type IterateSetHandler interface {
-	UpdateIterateSet(iterationTracker)
+	UpdateIterateSet(*iterationTracker)
 }
 
 type iterationTracker struct {
@@ -100,7 +100,7 @@ func NewVersionIndexedStore(parent types.KVStore, multiVersionStore MultiVersion
 	return &VersionIndexedStore{
 		readset:           make(map[string][][]byte),
 		writeset:          make(map[string][]byte),
-		iterateset:        []iterationTracker{},
+		iterateset:        []*iterationTracker{},
 		sortedStore:       dbm.NewMemDB(),
 		parent:            parent,
 		multiVersionStore: multiVersionStore,
@@ -265,7 +265,6 @@ func (v *VersionIndexedStore) ReverseIterator(start []byte, end []byte) dbm.Iter
 	return v.iterator(start, end, false)
 }
 
-// TODO: still needs iterateset tracking
 // Iterator implements types.KVStore.
 func (store *VersionIndexedStore) iterator(start []byte, end []byte, ascending bool) dbm.Iterator {
 	// TODO: remove?
@@ -301,7 +300,8 @@ func (store *VersionIndexedStore) iterator(start []byte, end []byte, ascending b
 	mergeIterator := NewMVSMergeIterator(parent, memIterator, ascending, store)
 
 	iterationTracker := NewIterationTracker(start, end, ascending, store.writeset)
-	trackedIterator := NewTrackedIterator(mergeIterator, iterationTracker, store, store)
+	store.UpdateIterateSet(&iterationTracker)
+	trackedIterator := NewTrackedIterator(mergeIterator, &iterationTracker, store)
 
 	// mergeIterator
 	return trackedIterator
@@ -394,7 +394,8 @@ func (store *VersionIndexedStore) ResetEvents() {
 	panic("not implemented")
 }
 
-func (store *VersionIndexedStore) UpdateIterateSet(iterationTracker iterationTracker) {
+func (store *VersionIndexedStore) UpdateIterateSet(iterationTracker *iterationTracker) {
+	// TODO: refactor such that the iterateset is added to the store at the time of iterator creation and updated continuously instead of at Close
 	// append to iterateset
 	store.iterateset = append(store.iterateset, iterationTracker)
 }

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -301,7 +301,7 @@ func (store *VersionIndexedStore) iterator(start []byte, end []byte, ascending b
 
 	iterationTracker := NewIterationTracker(start, end, ascending, store.writeset)
 	store.UpdateIterateSet(&iterationTracker)
-	trackedIterator := NewTrackedIterator(mergeIterator, &iterationTracker, store)
+	trackedIterator := NewTrackedIterator(mergeIterator, &iterationTracker)
 
 	// mergeIterator
 	return trackedIterator

--- a/store/multiversion/trackediterator.go
+++ b/store/multiversion/trackediterator.go
@@ -1,24 +1,22 @@
 package multiversion
 
-import "github.com/cosmos/cosmos-sdk/store/types"
+import (
+	"github.com/cosmos/cosmos-sdk/store/types"
+)
 
 // tracked iterator is a wrapper around an existing iterator to track the iterator progress and monitor which keys are iterated.
 type trackedIterator struct {
 	types.Iterator
 
-	iterateset iterationTracker
+	iterateset *iterationTracker
 	ReadsetHandler
-	IterateSetHandler
 }
 
-// TODO: test
-
-func NewTrackedIterator(iter types.Iterator, iterationTracker iterationTracker, iterateSetHandler IterateSetHandler, readSetHandler ReadsetHandler) *trackedIterator {
+func NewTrackedIterator(iter types.Iterator, iterationTracker *iterationTracker, readSetHandler ReadsetHandler) *trackedIterator {
 	return &trackedIterator{
-		Iterator:          iter,
-		iterateset:        iterationTracker,
-		IterateSetHandler: iterateSetHandler,
-		ReadsetHandler:    readSetHandler,
+		Iterator:       iter,
+		iterateset:     iterationTracker,
+		ReadsetHandler: readSetHandler,
 	}
 }
 
@@ -26,11 +24,11 @@ func NewTrackedIterator(iter types.Iterator, iterationTracker iterationTracker, 
 func (ti *trackedIterator) Close() error {
 	// TODO: if there are more keys to the iterator, then we consider it early stopped?
 	if ti.Iterator.Valid() {
+		key := ti.Iterator.Key()
 		// TODO: test whether reaching end of iteration range means valid is true or false
-		ti.iterateset.SetEarlyStopKey(ti.Iterator.Key())
+		ti.iterateset.AddKey(key)
+		ti.iterateset.SetEarlyStopKey(key)
 	}
-	// Update iterate set
-	ti.IterateSetHandler.UpdateIterateSet(ti.iterateset)
 	return ti.Iterator.Close()
 }
 
@@ -48,6 +46,7 @@ func (ti *trackedIterator) Value() []byte {
 	val := ti.Iterator.Value()
 	// add key to the tracker
 	ti.iterateset.AddKey(key)
+	ti.ReadsetHandler.UpdateReadSet(key, val)
 	return val
 }
 

--- a/store/multiversion/trackediterator.go
+++ b/store/multiversion/trackediterator.go
@@ -9,14 +9,12 @@ type trackedIterator struct {
 	types.Iterator
 
 	iterateset *iterationTracker
-	ReadsetHandler
 }
 
-func NewTrackedIterator(iter types.Iterator, iterationTracker *iterationTracker, readSetHandler ReadsetHandler) *trackedIterator {
+func NewTrackedIterator(iter types.Iterator, iterationTracker *iterationTracker) *trackedIterator {
 	return &trackedIterator{
-		Iterator:       iter,
-		iterateset:     iterationTracker,
-		ReadsetHandler: readSetHandler,
+		Iterator:   iter,
+		iterateset: iterationTracker,
 	}
 }
 
@@ -46,7 +44,6 @@ func (ti *trackedIterator) Value() []byte {
 	val := ti.Iterator.Value()
 	// add key to the tracker
 	ti.iterateset.AddKey(key)
-	ti.ReadsetHandler.UpdateReadSet(key, val)
 	return val
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
This fixes certain edge cases where the iteration tracker isn't included into the store if the iterator is never closed, and another case where keys that are deleted within iterator range with early stop cause incorrect validation results

## Testing performed to validate your change
Unit tests