### PR TITLE
Refactor abort handlers and iterator early stops to allow for aborting via panic

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -866,6 +866,7 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, txBytes []byte) (gInf
 		if r := recover(); r != nil {
 			acltypes.SendAllSignalsForTx(ctx.TxCompletionChannels())
 			recoveryMW := newOutOfGasRecoveryMiddleware(gasWanted, ctx, app.runTxRecoveryMiddleware)
+			recoveryMW = newOCCAbortRecoveryMiddleware(recoveryMW) // TODO: do we have to wrap with occ enabled check?
 			err, result = processRecovery(r, recoveryMW), nil
 			if mode != runTxModeDeliver {
 				ctx.MultiStore().ResetEvents()

--- a/store/multiversion/store_test.go
+++ b/store/multiversion/store_test.go
@@ -344,7 +344,7 @@ func TestMVSValidationWithOnlyEstimate(t *testing.T) {
 func TestMVSIteratorValidation(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -375,7 +375,7 @@ func TestMVSIteratorValidation(t *testing.T) {
 func TestMVSIteratorValidationWithEstimate(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -409,7 +409,7 @@ func TestMVSIteratorValidationWithEstimate(t *testing.T) {
 func TestMVSIteratorValidationWithKeySwitch(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -445,7 +445,7 @@ func TestMVSIteratorValidationWithKeySwitch(t *testing.T) {
 func TestMVSIteratorValidationWithKeyAdded(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -480,7 +480,7 @@ func TestMVSIteratorValidationWithKeyAdded(t *testing.T) {
 func TestMVSIteratorValidationWithWritesetValues(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -511,7 +511,7 @@ func TestMVSIteratorValidationWithWritesetValues(t *testing.T) {
 func TestMVSIteratorValidationWithWritesetValuesSetAfterIteration(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -551,7 +551,7 @@ func TestMVSIteratorValidationWithWritesetValuesSetAfterIteration(t *testing.T) 
 func TestMVSIteratorValidationReverse(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -590,7 +590,7 @@ func TestMVSIteratorValidationReverse(t *testing.T) {
 func TestMVSIteratorValidationEarlyStop(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -634,7 +634,7 @@ func TestMVSIteratorValidationEarlyStop(t *testing.T) {
 func TestMVSIteratorValidationEarlyStopEarlierKeyRemoved(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -679,7 +679,7 @@ func TestMVSIteratorValidationEarlyStopEarlierKeyRemoved(t *testing.T) {
 func TestMVSIteratorValidationEarlyStopEarlierKeyRemovedAndOtherReplaced(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -726,7 +726,7 @@ func TestMVSIteratorValidationEarlyStopEarlierKeyRemovedAndOtherReplaced(t *test
 func TestMVSIteratorValidationEarlyStopAtEndOfRange(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -764,7 +764,7 @@ func TestMVSIteratorValidationEarlyStopAtEndOfRange(t *testing.T) {
 func TestMVSIteratorValidationWithKeyAddedForgetToClose(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 5, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key2"), []byte("value0"))
 	parentKVStore.Set([]byte("key3"), []byte("value3"))
@@ -799,7 +799,7 @@ func TestMVSIteratorValidationWithKeyAddedForgetToClose(t *testing.T) {
 func TestMVSIteratorValidationEarlyStopIncludedInIterateset(t *testing.T) {
 	parentKVStore := dbadapter.Store{DB: dbm.NewMemDB()}
 	mvs := multiversion.NewMultiVersionStore(parentKVStore)
-	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 2, 1, make(chan occ.Abort))
+	vis := multiversion.NewVersionIndexedStore(parentKVStore, mvs, 2, 1, make(chan occ.Abort, 1))
 
 	parentKVStore.Set([]byte("key1"), []byte("value1"))
 	parentKVStore.Set([]byte("key2"), []byte("value2"))
@@ -809,11 +809,11 @@ func TestMVSIteratorValidationEarlyStopIncludedInIterateset(t *testing.T) {
 	i := 0
 	iter := vis.Iterator([]byte("key1"), []byte("key5"))
 	for ; iter.Valid(); iter.Next() {
-		i++
 		// break after iterating 2 items
 		if i == 2 {
 			break
 		}
+		i++
 	}
 	iter.Close()
 	vis.WriteToMultiVersionStore()

--- a/store/multiversion/trackediterator.go
+++ b/store/multiversion/trackediterator.go
@@ -18,16 +18,13 @@ func NewTrackedIterator(iter types.Iterator, iterationTracker *iterationTracker)
 	}
 }
 
-// Close calls first updates the iterateset from the iterator, and then calls iterator.Close()
-func (ti *trackedIterator) Close() error {
-	// TODO: if there are more keys to the iterator, then we consider it early stopped?
-	if ti.Iterator.Valid() {
-		key := ti.Iterator.Key()
-		// TODO: test whether reaching end of iteration range means valid is true or false
-		ti.iterateset.AddKey(key)
-		ti.iterateset.SetEarlyStopKey(key)
+func (ti *trackedIterator) Valid() bool {
+	valid := ti.Iterator.Valid()
+	// if no longer valid, remove the early stop key since we reached end of range
+	if !valid {
+		ti.iterateset.SetEarlyStopKey(nil)
 	}
-	return ti.Iterator.Close()
+	return valid
 }
 
 // Key calls the iterator.Key() and adds the key to the iterateset, then returns the key from the iterator

--- a/store/multiversion/trackediterator.go
+++ b/store/multiversion/trackediterator.go
@@ -23,6 +23,9 @@ func (ti *trackedIterator) Valid() bool {
 	// if no longer valid, remove the early stop key since we reached end of range
 	if !valid {
 		ti.iterateset.SetEarlyStopKey(nil)
+	} else {
+		key := ti.Iterator.Key()
+		ti.iterateset.AddKey(key)
 	}
 	return valid
 }

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -150,6 +150,9 @@ var (
 	// ErrAlreadyExists defines an error for which the tx failed checkTx because the node has already seen it before
 	ErrAlreadyExists = Register(RootCodespace, 42, "error tx already exists")
 
+	// ErrOCCAbort defines an error exncountered by a transaction when it encounters an OCC conflict resulting in an Abort
+	ErrOCCAbort = Register(RootCodespace, 43, "occ abort")
+
 	// ErrPanic is only set when we recover from a panic, so we know to
 	// redact potentially sensitive system info
 	ErrPanic = Register(UndefinedCodespace, 111222, "panic")


### PR DESCRIPTION
## Describe your changes and provide context
This allows for aborting more immediately via handled panics when encountering ESTIMATE values during execution. This also refactors the way early stop keys are tracked in iterators to handle an edge case where an ESTIMATE related panic caused a hang due to channels with insufficient buffer size

## Testing performed to validate your change
Unit test modifications and will test with sei-chain
