### PR TITLE
Fix DeleteAll for CacheKV/MultiVersionKV so that all keys are properly deleted

### DIFF
--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -234,6 +234,10 @@ func (kv kvStore) DeleteAll(start, end []byte) error {
 	panic("not implemented")
 }
 
+func (kv kvStore) GetAllKeyStrsInRange(start, end []byte) []string {
+	panic("not implemented")
+}
+
 func NewCommitMultiStore() sdk.CommitMultiStore {
 	return multiStore{kv: make(map[sdk.StoreKey]kvStore)}
 }

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -369,16 +369,28 @@ func (store *Store) GetParent() types.KVStore {
 }
 
 func (store *Store) DeleteAll(start, end []byte) error {
-	store.dirtyItems(start, end)
-	// memdb iterator
-	cachedIter, err := store.sortedCache.Iterator(start, end)
-	if err != nil {
-		return err
-	}
-	defer cachedIter.Close()
-	for ; cachedIter.Valid(); cachedIter.Next() {
-		// `Delete` would not touch sortedCache so it's okay to perform inside iterator
-		store.Delete(cachedIter.Key())
+	for _, k := range store.GetAllKeyStrsInRange(start, end) {
+		store.Delete([]byte(k))
 	}
 	return nil
+}
+
+func (store *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
+	keyStrs := map[string]struct{}{}
+	for _, pk := range store.parent.GetAllKeyStrsInRange(start, end) {
+		keyStrs[pk] = struct{}{}
+	}
+	store.cache.Range(func(key, value any) bool {
+		cv := value.(*types.CValue)
+		if cv.Value() == nil {
+			delete(keyStrs, key.(string))
+		} else {
+			keyStrs[key.(string)] = struct{}{}
+		}
+		return true
+	})
+	for k := range keyStrs {
+		res = append(res, k)
+	}
+	return res
 }

--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -67,14 +67,17 @@ func TestCacheKVStore(t *testing.T) {
 	require.NotNil(t, st.GetParent())
 
 	// DeleteAll deletes all entries in cache but not affect mem
-	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	mem.Set(keyFmt(1), valFmt(1))
+	mem.Set(keyFmt(3), valFmt(4))
+	st = cachekv.NewStore(mem, types.NewKVStoreKey("CacheKvTest"), types.DefaultCacheSizeLimit)
 	st.Set(keyFmt(1), valFmt(2))
 	st.Set(keyFmt(2), valFmt(3))
 	require.Nil(t, st.DeleteAll(nil, nil))
 	require.Nil(t, st.Get(keyFmt(1)))
 	require.Nil(t, st.Get(keyFmt(2)))
+	require.Nil(t, st.Get(keyFmt(3)))
 	require.Equal(t, valFmt(1), mem.Get(keyFmt(1)))
+	require.Equal(t, valFmt(4), mem.Get(keyFmt(3)))
 }
 
 func TestCacheKVStoreNoNilSet(t *testing.T) {

--- a/store/dbadapter/store.go
+++ b/store/dbadapter/store.go
@@ -112,5 +112,14 @@ func (dsa Store) DeleteAll(start, end []byte) error {
 	return nil
 }
 
+func (dsa Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
+	iter := dsa.Iterator(start, end)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		res = append(res, string(iter.Key()))
+	}
+	return
+}
+
 // dbm.DB implements KVStore so we can CacheKVStore it.
 var _ types.KVStore = Store{}

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -134,6 +134,10 @@ func (gs *Store) DeleteAll(start, end []byte) error {
 	return gs.parent.DeleteAll(start, end)
 }
 
+func (gs *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
+	return gs.parent.GetAllKeyStrsInRange(start, end)
+}
+
 type gasIterator struct {
 	gasMeter  types.GasMeter
 	gasConfig types.GasConfig

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -436,6 +436,15 @@ func (st *Store) DeleteAll(start, end []byte) error {
 	return nil
 }
 
+func (st *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
+	iter := st.Iterator(start, end)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		res = append(res, string(iter.Key()))
+	}
+	return
+}
+
 // Takes a MutableTree, a key, and a flag for creating existence or absence proof and returns the
 // appropriate merkle.Proof. Since this must be called after querying for the value, this function should never error
 // Thus, it will panic on error rather than returning it

--- a/store/listenkv/store.go
+++ b/store/listenkv/store.go
@@ -165,3 +165,7 @@ func (s *Store) onWrite(delete bool, key, value []byte) {
 func (s *Store) DeleteAll(start, end []byte) error {
 	return s.parent.DeleteAll(start, end)
 }
+
+func (s *Store) GetAllKeyStrsInRange(start, end []byte) []string {
+	return s.parent.GetAllKeyStrsInRange(start, end)
+}

--- a/store/multiversion/mvkv.go
+++ b/store/multiversion/mvkv.go
@@ -323,21 +323,12 @@ func (v *VersionIndexedStore) DeleteAll(start, end []byte) error {
 }
 
 func (v *VersionIndexedStore) GetAllKeyStrsInRange(start, end []byte) (res []string) {
-	keyStrs := map[string]struct{}{}
-	for _, pk := range v.parent.GetAllKeyStrsInRange(start, end) {
-		keyStrs[pk] = struct{}{}
+	iter := v.Iterator(start, end)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		res = append(res, string(iter.Key()))
 	}
-	for k, val := range v.writeset {
-		if val == nil {
-			delete(keyStrs, string(k))
-		} else {
-			keyStrs[string(k)] = struct{}{}
-		}
-	}
-	for k := range keyStrs {
-		res = append(res, k)
-	}
-	return res
+	return
 }
 
 // GetStoreType implements types.KVStore.

--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -102,6 +102,18 @@ func (s Store) DeleteAll(start, end []byte) error {
 	return s.parent.DeleteAll(newstart, newend)
 }
 
+func (s Store) GetAllKeyStrsInRange(start, end []byte) []string {
+	newstart := cloneAppend(s.prefix, start)
+
+	var newend []byte
+	if end == nil {
+		newend = cpIncr(s.prefix)
+	} else {
+		newend = cloneAppend(s.prefix, end)
+	}
+	return s.parent.GetAllKeyStrsInRange(newstart, newend)
+}
+
 // Implements KVStore
 // Check https://github.com/tendermint/tendermint/blob/master/libs/db/prefix_db.go#L106
 func (s Store) Iterator(start, end []byte) types.Iterator {

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -190,6 +190,10 @@ func (tkv *Store) DeleteAll(start, end []byte) error {
 	return tkv.parent.DeleteAll(start, end)
 }
 
+func (tkv *Store) GetAllKeyStrsInRange(start, end []byte) []string {
+	return tkv.parent.GetAllKeyStrsInRange(start, end)
+}
+
 // writeOperation writes a KVStore operation to the underlying io.Writer as
 // JSON-encoded data where the key/value pair is base64 encoded.
 func writeOperation(w io.Writer, op operation, tc types.TraceContext, key, value []byte) {

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -257,6 +257,8 @@ type KVStore interface {
 	VersionExists(version int64) bool
 
 	DeleteAll(start, end []byte) error
+
+	GetAllKeyStrsInRange(start, end []byte) []string
 }
 
 // Iterator is an alias db's Iterator for convenience.

--- a/storev2/commitment/store.go
+++ b/storev2/commitment/store.go
@@ -195,3 +195,12 @@ func (st *Store) DeleteAll(start, end []byte) error {
 	}
 	return nil
 }
+
+func (st *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
+	iter := st.Iterator(start, end)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		res = append(res, string(iter.Key()))
+	}
+	return
+}

--- a/storev2/state/store.go
+++ b/storev2/state/store.go
@@ -147,3 +147,12 @@ func (st *Store) DeleteAll(start, end []byte) error {
 	}
 	return nil
 }
+
+func (st *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
+	iter := st.Iterator(start, end)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		res = append(res, string(iter.Key()))
+	}
+	return
+}


### PR DESCRIPTION
## Describe your changes and provide context
If we have a cacheKV that has a dirty cache of 1->a and a parent with an entry 2->b, the previous implementation of `DeleteAll` would only call cacheKV.Delete on key 1 but not affecting 2 at all (i.e. if someone queries key 2 on the cacheKV they would still get `b`, but the expectation is for 2 to be deleted as appearing on the cacheKV level). This PR fixes that by first getting all the keys to be (marked as) deleted recursively and then delete all those keys one-by-one; note that this recursion should be fairly efficient since it's not subject to the exponential latency that merge iterators have.

This PR also fixed DeleteAll for `mvkv` so that it doesn't actually touch parent store's value but only change the writeset (as a single `Delete` would have done).

## Testing performed to validate your change
unit test
