### PR TITLE
[OCC] if no txs, avoid scheduler overhead, limit tasks

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -12,8 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/tasks"
-
 	"github.com/armon/go-metrics"
 	"github.com/gogo/protobuf/proto"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -23,6 +21,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	snapshottypes "github.com/cosmos/cosmos-sdk/snapshots/types"
+	"github.com/cosmos/cosmos-sdk/tasks"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -252,18 +251,18 @@ func (app *BaseApp) CheckTx(ctx context.Context, req *abci.RequestCheckTx) (*abc
 
 // DeliverTxBatch executes multiple txs
 func (app *BaseApp) DeliverTxBatch(ctx sdk.Context, req sdk.DeliverTxBatchRequest) (res sdk.DeliverTxBatchResponse) {
-	scheduler := tasks.NewScheduler(app.concurrencyWorkers, app.TracingInfo, app.DeliverTx)
-	// This will basically no-op the actual prefill if the metadata for the txs is empty
-
-	// process all txs, this will also initializes the MVS if prefill estimates was disabled
-	txRes, err := scheduler.ProcessAll(ctx, req.TxEntries)
-	if err != nil {
-		// TODO: handle error
-	}
-
 	responses := make([]*sdk.DeliverTxResult, 0, len(req.TxEntries))
-	for _, tx := range txRes {
-		responses = append(responses, &sdk.DeliverTxResult{Response: tx})
+	// avoid overhead for empty batches
+	if len(req.TxEntries) > 0 {
+		scheduler := tasks.NewScheduler(app.concurrencyWorkers, app.TracingInfo, app.DeliverTx)
+		txRes, err := scheduler.ProcessAll(ctx, req.TxEntries)
+		if err != nil {
+			ctx.Logger().Error("error while processing scheduler", "err", err)
+			panic(err)
+		}
+		for _, tx := range txRes {
+			responses = append(responses, &sdk.DeliverTxResult{Response: tx})
+		}
 	}
 	return sdk.DeliverTxBatchResponse{Results: responses}
 }

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -286,7 +286,7 @@ func (s *scheduler) ProcessAll(ctx sdk.Context, reqs []*sdk.DeliverTxEntry) ([]t
 
 	// default to number of tasks if workers is negative or 0 by this point
 	workers := s.workers
-	if s.workers < 1 {
+	if s.workers < 1 || len(tasks) < s.workers {
 		workers = len(tasks)
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
- avoids scheduler if no txs (mainly for gassless situations)
- limits tasks to the min(task count, workers)

## Testing performed to validate your change
- unit tests and load testing
