### PR TITLE
Added `TxTracer` to `DeliverTxEntry` which is the first step to support tracing when using OCC

### DIFF
--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -54,6 +54,7 @@ type deliverTxTask struct {
 	AbsoluteIndex int
 	Response      *types.ResponseDeliverTx
 	VersionStores map[sdk.StoreKey]*multiversion.VersionIndexedStore
+	TxTracer      sdk.TxTracer
 }
 
 // AppendDependencies appends the given indexes to the task's dependencies
@@ -83,6 +84,10 @@ func (dt *deliverTxTask) Reset() {
 	dt.Abort = nil
 	dt.AbortCh = nil
 	dt.VersionStores = nil
+
+	if dt.TxTracer != nil {
+		dt.TxTracer.Reset()
+	}
 }
 
 func (dt *deliverTxTask) Increment() {
@@ -187,7 +192,9 @@ func toTasks(reqs []*sdk.DeliverTxEntry) ([]*deliverTxTask, map[int]*deliverTxTa
 			AbsoluteIndex: r.AbsoluteIndex,
 			Status:        statusPending,
 			Dependencies:  map[int]struct{}{},
+			TxTracer:      r.TxTracer,
 		}
+
 		tasksMap[r.AbsoluteIndex] = task
 		allTasks = append(allTasks, task)
 	}
@@ -198,6 +205,10 @@ func (s *scheduler) collectResponses(tasks []*deliverTxTask) []types.ResponseDel
 	res := make([]types.ResponseDeliverTx, 0, len(tasks))
 	for _, t := range tasks {
 		res = append(res, *t.Response)
+
+		if t.TxTracer != nil {
+			t.TxTracer.Commit()
+		}
 	}
 	return res
 }
@@ -506,6 +517,10 @@ func (s *scheduler) prepareTask(task *deliverTxTask) {
 		})
 
 		ctx = ctx.WithMultiStore(ms)
+	}
+
+	if task.TxTracer != nil {
+		ctx = task.TxTracer.InjectInContext(ctx)
 	}
 
 	task.AbortCh = abortCh

--- a/tasks/scheduler.go
+++ b/tasks/scheduler.go
@@ -533,14 +533,21 @@ func (s *scheduler) executeTask(task *deliverTxTask) {
 	task.Ctx = dCtx
 
 	// in the synchronous case, we only want to re-execute tasks that need re-executing
-	// if already validated, then this does another validation
-	if s.synchronous && task.IsStatus(statusValidated) {
-		s.shouldRerun(task)
+	if s.synchronous {
+		// if already validated, then this does another validation
 		if task.IsStatus(statusValidated) {
-			return
+			s.shouldRerun(task)
+			if task.IsStatus(statusValidated) {
+				return
+			}
 		}
-		task.Reset()
-		task.Increment()
+
+		// waiting transactions may not yet have been reset
+		// this ensures a task has been reset and incremented
+		if !task.IsStatus(statusPending) {
+			task.Reset()
+			task.Increment()
+		}
 	}
 
 	s.prepareTask(task)

--- a/types/tx_batch.go
+++ b/types/tx_batch.go
@@ -6,13 +6,14 @@ import (
 )
 
 // DeliverTxEntry represents an individual transaction's request within a batch.
-// This can be extended to include tx-level tracing or metadata
+// This can be extended to include tx-level metadata
 type DeliverTxEntry struct {
 	Request            abci.RequestDeliverTx
 	SdkTx              Tx
 	Checksum           [32]byte
 	AbsoluteIndex      int
 	EstimatedWritesets MappedWritesets
+	TxTracer           TxTracer
 }
 
 // EstimatedWritesets represents an estimated writeset for a transaction mapped by storekey to the writeset estimate.

--- a/types/tx_tracer.go
+++ b/types/tx_tracer.go
@@ -1,0 +1,44 @@
+package types
+
+// TxTracer is an interface for tracing transactions generic
+// enough to be used by any transaction processing engine be it
+// CoWasm or EVM.
+//
+// The TxTracer responsibility is to inject itself in the context
+// that will be used to process the transaction. How the context
+// will be used afterward is up to the transaction processing engine.
+//
+// Today, only EVM transaction processing engine do something with the
+// TxTracer (it inject itself into the EVM execution context for
+// go-ethereum level tracing).
+//
+// The TxTracer receives signals from the scheduler when the tracer
+// should be reset because the transaction is being re-executed and
+// when the transaction is committed.
+type TxTracer interface {
+	// InjectInContext injects the transaction specific tracer in the context
+	// that will be used to process the transaction.
+	//
+	// For now only the EVM transaction processing engine uses the tracer
+	// so it only make sense to inject an EVM tracer. Future updates might
+	// add the possibility to inject a tracer for other transaction kind.
+	//
+	// Which tracer implementation to provied and how will be retrieved later on
+	// from the context is dependent on the transaction processing engine.
+	InjectInContext(ctx Context) Context
+
+	// Reset is called when the transaction is being re-executed and the tracer
+	// should be reset. A transaction executed by the OCC parallel engine might
+	// be re-executed multiple times before being committed, each time `Reset`
+	// will be called.
+	//
+	// When Reset is received, it means everything that was traced before should
+	// be discarded.
+	Reset()
+
+	// Commit is called when the transaction is committed. This is the last signal
+	// the tracer will receive for a given transaction. After this call, the tracer
+	// should do whatever it needs to forward the tracing information to the
+	// appropriate place/collector.
+	Commit()
+}


### PR DESCRIPTION
## Describe your changes and provide context

This brings in an interface that can be set on `DeliverTxEntry` and hooks into the `scheduler` so it call's the necessary tracer callbacks when required.

Refer to `types/tx_tracer.go` for extra details about the patch.

## Testing performed to validate your change

