### PR TITLE
Fix Panic: Check For Error Before Defer

### DIFF
--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -507,10 +507,10 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 	} else {
 		// Serve abci query from historical sc store if proofs needed
 		scStore, err := rs.scStore.LoadVersion(version, true)
-		defer scStore.Close()
 		if err != nil {
 			return sdkerrors.QueryResult(err)
 		}
+		defer scStore.Close()
 		store = types.Queryable(commitment.NewStore(scStore.GetTreeByName(storeName), rs.logger))
 		commitInfo = convertCommitInfo(scStore.LastCommitInfo())
 		commitInfo = amendCommitInfo(commitInfo, rs.storesParams)


### PR DESCRIPTION
## Describe your changes and provide context
- Checks for err before `defer`
- Without this, if there is a err, the node will panic on the `defer` because `scStore` is `nil`

## Testing performed to validate your change
- Verified on node
