### PR TITLE
Remove Non-Multiplier Gas Meter

### DIFF
--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -490,7 +490,7 @@ func TestSimulateTx(t *testing.T) {
 
 	anteOpt := func(bapp *BaseApp) {
 		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
-			newCtx = ctx.WithGasMeter(sdk.NewGasMeter(gasConsumed))
+			newCtx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, gasConsumed))
 			return
 		})
 	}
@@ -665,7 +665,7 @@ func TestTxGasLimits(t *testing.T) {
 	gasGranted := uint64(10)
 	anteOpt := func(bapp *BaseApp) {
 		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
-			newCtx = ctx.WithGasMeter(sdk.NewGasMeter(gasGranted))
+			newCtx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, gasGranted))
 
 			// AnteHandlers must have their own defer/recover in order for the BaseApp
 			// to know how much gas was used! This is because the GasMeter is created in
@@ -754,7 +754,7 @@ func TestTxGasLimits(t *testing.T) {
 // 	gasGranted := uint64(10)
 // 	anteOpt := func(bapp *BaseApp) {
 // 		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
-// 			newCtx = ctx.WithGasMeter(sdk.NewGasMeter(gasGranted))
+// 			newCtx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, gasGranted))
 
 // 			defer func() {
 // 				if r := recover(); r != nil {
@@ -817,7 +817,7 @@ func TestTxGasLimits(t *testing.T) {
 // 		// reset the block gas
 // 		header := tmproto.Header{Height: app.LastBlockHeight() + 1}
 // 		app.setDeliverState(header)
-// 		app.deliverState.ctx = app.deliverState.ctx.WithBlockGasMeter(sdk.NewGasMeter(app.getMaximumBlockGas(app.deliverState.ctx)))
+// 		app.deliverState.ctx = app.deliverState.ctx.WithBlockGasMeter(sdk.NewGasMeter(app.getMaximumBlockGas(app.deliverState.ctx), 1, 1))
 // 		app.BeginBlock(app.deliverState.ctx, abci.RequestBeginBlock{Header: header})
 
 // 		// execute the transaction multiple times
@@ -982,7 +982,7 @@ func TestGasConsumptionBadTx(t *testing.T) {
 	gasWanted := uint64(5)
 	anteOpt := func(bapp *BaseApp) {
 		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
-			newCtx = ctx.WithGasMeter(sdk.NewGasMeter(gasWanted))
+			newCtx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, gasWanted))
 
 			defer func() {
 				if r := recover(); r != nil {

--- a/store/gaskv/store_test.go
+++ b/store/gaskv/store_test.go
@@ -19,7 +19,7 @@ func valFmt(i int) []byte { return bz(fmt.Sprintf("value%0.8d", i)) }
 
 func TestGasKVStoreBasic(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	meter := types.NewGasMeter(10000)
+	meter := types.NewMultiplierGasMeter(10000, 1, 1)
 	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
 
 	require.Equal(t, types.StoreTypeDB, st.GetStoreType())
@@ -40,7 +40,7 @@ func TestGasKVStoreBasic(t *testing.T) {
 
 func TestGasKVStoreIterator(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	meter := types.NewGasMeter(100000)
+	meter := types.NewMultiplierGasMeter(100000, 1, 1)
 	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
 	require.False(t, st.Has(keyFmt(1)))
 	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
@@ -108,14 +108,14 @@ func TestGasKVStoreIterator(t *testing.T) {
 
 func TestGasKVStoreOutOfGasSet(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	meter := types.NewGasMeter(0)
+	meter := types.NewMultiplierGasMeter(0, 1, 1)
 	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
 	require.Panics(t, func() { st.Set(keyFmt(1), valFmt(1)) }, "Expected out-of-gas")
 }
 
 func TestGasKVStoreOutOfGasIterator(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
-	meter := types.NewGasMeter(20000)
+	meter := types.NewMultiplierGasMeter(20000, 1, 1)
 	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
 	st.Set(keyFmt(1), valFmt(1))
 	iterator := st.Iterator(nil, nil)

--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -98,7 +98,7 @@ func TestIAVLStorePrefix(t *testing.T) {
 }
 
 func TestPrefixKVStoreNoNilSet(t *testing.T) {
-	meter := types.NewGasMeter(100000000)
+	meter := types.NewMultiplierGasMeter(100000000, 1, 1)
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
 	gasStore := gaskv.NewStore(mem, meter, types.KVGasConfig())
 	require.Panics(t, func() { gasStore.Set([]byte("key"), nil) }, "setting a nil value should panic")

--- a/store/types/gas.go
+++ b/store/types/gas.go
@@ -60,15 +60,6 @@ type basicGasMeter struct {
 	lock     *sync.Mutex
 }
 
-// NewGasMeter returns a reference to a new basicGasMeter.
-func NewGasMeter(limit Gas) GasMeter {
-	return &basicGasMeter{
-		limit:    limit,
-		consumed: 0,
-		lock:     &sync.Mutex{},
-	}
-}
-
 func (g *basicGasMeter) GasConsumed() Gas {
 	g.lock.Lock()
 	defer g.lock.Unlock()
@@ -206,14 +197,6 @@ func (g *multiplierGasMeter) Multiplier() (numerator uint64, denominator uint64)
 type infiniteGasMeter struct {
 	consumed Gas
 	lock     *sync.Mutex
-}
-
-// NewInfiniteGasMeter returns a reference to a new infiniteGasMeter.
-func NewInfiniteGasMeter() GasMeter {
-	return &infiniteGasMeter{
-		consumed: 0,
-		lock:     &sync.Mutex{},
-	}
 }
 
 func (g *infiniteGasMeter) GasConsumed() Gas {

--- a/store/types/gas_test.go
+++ b/store/types/gas_test.go
@@ -43,7 +43,7 @@ func TestGasMeter(t *testing.T) {
 	}
 
 	for tcnum, tc := range cases {
-		meter := NewGasMeter(tc.limit)
+		meter := NewMultiplierGasMeter(tc.limit, 1, 1)
 		used := uint64(0)
 
 		for unum, usage := range tc.usage {
@@ -68,7 +68,7 @@ func TestGasMeter(t *testing.T) {
 		require.Equal(t, meter.GasConsumed(), meter.Limit(), "Gas consumption not match limit+1")
 		require.Panics(t, func() { meter.RefundGas(meter.GasConsumed()+1, "refund greater than consumed") })
 
-		meter2 := NewGasMeter(math.MaxUint64)
+		meter2 := NewMultiplierGasMeter(math.MaxUint64, 1, 1)
 		meter2.ConsumeGas(Gas(math.MaxUint64/2), "consume half max uint64")
 		require.Panics(t, func() { meter2.ConsumeGas(Gas(math.MaxUint64/2)+2, "panic") })
 		n, d := meter.Multiplier()

--- a/store/types/gas_test.go
+++ b/store/types/gas_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInfiniteGasMeter(t *testing.T) {
 	t.Parallel()
-	meter := NewInfiniteGasMeter()
+	meter := NewInfiniteMultiplierGasMeter(1, 1)
 	require.Equal(t, uint64(0), meter.Limit())
 	require.Equal(t, uint64(0), meter.GasConsumed())
 	require.Equal(t, uint64(0), meter.GasConsumedToLimit())

--- a/types/context.go
+++ b/types/context.go
@@ -216,7 +216,7 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 		chainID:      header.ChainID,
 		checkTx:      isCheckTx,
 		logger:       logger,
-		gasMeter:     stypes.NewInfiniteGasMeter(),
+		gasMeter:     NewInfiniteGasMeter(1, 1),
 		minGasPrice:  DecCoins{},
 		eventManager: NewEventManager(),
 

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -91,7 +91,7 @@ func (s *contextTestSuite) TestContextWithCustom() {
 	txbytes := []byte("txbytes")
 	logger := mocks.NewMockLogger(ctrl)
 	voteinfos := []abci.VoteInfo{{}}
-	meter := types.NewGasMeter(10000)
+	meter := types.NewGasMeterWithMultiplier(ctx, 10000)
 	minGasPrices := types.DecCoins{types.NewInt64DecCoin("feetoken", 1)}
 	headerHash := []byte("headerHash")
 

--- a/types/store.go
+++ b/types/store.go
@@ -181,8 +181,8 @@ type (
 	GasConfig = types.GasConfig
 )
 
-func NewGasMeter(limit Gas) GasMeter {
-	return types.NewGasMeter(limit)
+func NewGasMeter(limit Gas, multiplierNumerator uint64, multiplierDenominator uint64) GasMeter {
+	return types.NewMultiplierGasMeter(limit, multiplierNumerator, multiplierDenominator)
 }
 
 type (
@@ -190,6 +190,23 @@ type (
 	ErrorGasOverflow = types.ErrorGasOverflow
 )
 
-func NewInfiniteGasMeter() GasMeter {
-	return types.NewInfiniteGasMeter()
+func NewInfiniteGasMeter(multiplierNumerator uint64, multiplierDenominator uint64) GasMeter {
+	return types.NewInfiniteMultiplierGasMeter(multiplierNumerator, multiplierDenominator)
+}
+
+// Helpers for setting gas meter with parent ctx multiplier
+func NewGasMeterWithMultiplier(ctx Context, limit uint64) GasMeter {
+	if ctx.GasMeter() == nil {
+		return NewGasMeter(limit, 1, 1)
+	}
+	n, d := ctx.GasMeter().Multiplier()
+	return types.NewMultiplierGasMeter(limit, n, d)
+}
+
+func NewInfiniteGasMeterWithMultiplier(ctx Context) GasMeter {
+	if ctx.GasMeter() == nil {
+		return NewInfiniteGasMeter(1, 1)
+	}
+	n, d := ctx.GasMeter().Multiplier()
+	return types.NewInfiniteMultiplierGasMeter(n, d)
 }

--- a/types/store_test.go
+++ b/types/store_test.go
@@ -61,10 +61,32 @@ func (s *storeTestSuite) TestNewTransientStoreKeys() {
 }
 
 func (s *storeTestSuite) TestNewInfiniteGasMeter() {
-	gm := sdk.NewInfiniteGasMeter()
+	gm := sdk.NewInfiniteGasMeter(1, 1)
 	s.Require().NotNil(gm)
 	_, ok := gm.(types.GasMeter)
 	s.Require().True(ok)
+}
+
+func (s *storeTestSuite) TestNewGasMeterWithMultiplier() {
+	ctx := sdk.Context{}
+	n, d := sdk.NewGasMeterWithMultiplier(ctx, 10).Multiplier()
+	s.Require().Equal(uint64(1), n)
+	s.Require().Equal(uint64(1), d)
+	ctx = ctx.WithGasMeter(sdk.NewGasMeter(10, 3, 4))
+	n, d = sdk.NewGasMeterWithMultiplier(ctx, 10).Multiplier()
+	s.Require().Equal(uint64(3), n)
+	s.Require().Equal(uint64(4), d)
+}
+
+func (s *storeTestSuite) TestNewInfiniteGasMeterWithMultiplier() {
+	ctx := sdk.Context{}
+	n, d := sdk.NewInfiniteGasMeterWithMultiplier(ctx).Multiplier()
+	s.Require().Equal(uint64(1), n)
+	s.Require().Equal(uint64(1), d)
+	ctx = ctx.WithGasMeter(sdk.NewGasMeter(10, 3, 4))
+	n, d = sdk.NewInfiniteGasMeterWithMultiplier(ctx).Multiplier()
+	s.Require().Equal(uint64(3), n)
+	s.Require().Equal(uint64(4), d)
 }
 
 func (s *storeTestSuite) TestStoreTypes() {

--- a/x/auth/ante/setup.go
+++ b/x/auth/ante/setup.go
@@ -78,9 +78,10 @@ func (sud SetUpContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 func SetGasMeter(simulate bool, ctx sdk.Context, gasLimit uint64, _ sdk.Tx) sdk.Context {
 	// In various cases such as simulation and during the genesis block, we do not
 	// meter any gas utilization.
+
 	if simulate || ctx.BlockHeight() == 0 {
-		return ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+		return ctx.WithGasMeter(sdk.NewInfiniteGasMeterWithMultiplier(ctx))
 	}
 
-	return ctx.WithGasMeter(sdk.NewGasMeter(gasLimit))
+	return ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, gasLimit))
 }

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -95,11 +95,11 @@ func (suite *AnteTestSuite) TestConsumeSignatureVerificationGas() {
 		gasConsumed uint64
 		shouldErr   bool
 	}{
-		{"PubKeyEd25519", args{sdk.NewInfiniteGasMeter(), nil, ed25519.GenPrivKey().PubKey(), params}, p.SigVerifyCostED25519, true},
-		{"PubKeySecp256k1", args{sdk.NewInfiniteGasMeter(), nil, secp256k1.GenPrivKey().PubKey(), params}, p.SigVerifyCostSecp256k1, false},
-		{"PubKeySecp256r1", args{sdk.NewInfiniteGasMeter(), nil, skR1.PubKey(), params}, p.SigVerifyCostSecp256r1(), false},
-		{"Multisig", args{sdk.NewInfiniteGasMeter(), multisignature1, multisigKey1, params}, expectedCost1, false},
-		{"unknown key", args{sdk.NewInfiniteGasMeter(), nil, nil, params}, 0, true},
+		{"PubKeyEd25519", args{sdk.NewInfiniteGasMeter(1, 1), nil, ed25519.GenPrivKey().PubKey(), params}, p.SigVerifyCostED25519, true},
+		{"PubKeySecp256k1", args{sdk.NewInfiniteGasMeter(1, 1), nil, secp256k1.GenPrivKey().PubKey(), params}, p.SigVerifyCostSecp256k1, false},
+		{"PubKeySecp256r1", args{sdk.NewInfiniteGasMeter(1, 1), nil, skR1.PubKey(), params}, p.SigVerifyCostSecp256r1(), false},
+		{"Multisig", args{sdk.NewInfiniteGasMeter(1, 1), multisignature1, multisigKey1, params}, expectedCost1, false},
+		{"unknown key", args{sdk.NewInfiniteGasMeter(1, 1), nil, nil, params}, 0, true},
 	}
 	for _, tt := range tests {
 		sigV2 := signing.SignatureV2{


### PR DESCRIPTION
## Describe your changes and provide context
- Removes non-multiplier gas meter => forces to always use one with multiplier
- Adds in default gas meter creator which takes in parent context and uses in multiplier from there

## Testing performed to validate your change
- Unit testing
- Verifying on chain
