### PR TITLE
Serve versioned data from SC instead of SS if possible

### DIFF
--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	tmcfg "github.com/tendermint/tendermint/config"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -22,6 +23,23 @@ func TestSetMinimumFees(t *testing.T) {
 func TestSetSnapshotDirectory(t *testing.T) {
 	cfg := DefaultConfig()
 	require.Equal(t, "", cfg.StateSync.SnapshotDirectory)
+}
+
+func TestValidateStatesync(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SetMinGasPrices(sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)})
+	// test statesync enabled
+	cfg.StateSync.SnapshotInterval = 2000
+	err := cfg.ValidateBasic(tmcfg.DefaultConfig())
+	require.NoError(t, err)
+	// test invalid snapshot interval but noerror because SC not enabled
+	cfg.StateCommit.SnapshotInterval = 1000
+	err = cfg.ValidateBasic(tmcfg.DefaultConfig())
+	require.NoError(t, err)
+	// test invalid snapshot interval with err
+	cfg.StateCommit.Enable = true
+	err = cfg.ValidateBasic(tmcfg.DefaultConfig())
+	require.Error(t, err)
 }
 
 func TestSetConcurrencyWorkers(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
This modifies the storev2 CacheMultiStoreWithVersion to first try to access state in the state commit layer if the version is present, and serve from state store only if the version isn't present in state commit store. Additionally, to guarantee statesync is served from state commit always, added a config change that requires the statesync snapshot interval to be less than or equal to the state commit snapshot interval.

## Testing performed to validate your change
Tested with statesync functionality, and also added unit tests for config validation.
