### PR TITLE
Add validation to prevent data corruption due to SS store misoperation

### DIFF
--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -77,6 +77,12 @@ func NewStore(
 		if err != nil {
 			panic(err)
 		}
+		// Check whether SC was enabled before but SS was not
+		ssVersion, _ := ssStore.GetLatestVersion()
+		scVersion, _ := scStore.GetLatestVersion()
+		if ssVersion <= 0 && scVersion > 0 {
+			panic("Enabling SS store without state sync could cause data corruption")
+		}
 		if err = ss.RecoverStateStore(homeDir, logger, ssStore); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
Currently if a node did state sync with SS disabled, and then we turn on SS, it will behave wrong due to SS not having initial version for most keys and cause data corruption. And if that node tries to create a snapshot, it will produce a bad snapshot which could cause other nodes to app hash.

Solution:
In this PR, we simply add a validation check to make sure if SS is suddenly enabled, and SS doesn't have any data yet, SC must also not have any data, otherwise, we will panic during startup.

## Testing performed to validate your change
Tested on arctic-1:
<img width="887" alt="image" src="https://github.com/sei-protocol/sei-cosmos/assets/50607998/9bc1a67b-7b11-4254-96a2-9e155239bb85">

Enabled SS first, hit panic, and then disable SS again, node was running fine.