### PR TITLE
Allow reading pairs in changeset before flush

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -324,8 +324,12 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTx, tx sdk
 	return
 }
 
-func (app *BaseApp) WriteStateToCommitAndGetWorkingHash() []byte {
+func (app *BaseApp) WriteState() sdk.CommitMultiStore {
 	app.stateToCommit.ms.Write()
+	return app.cms
+}
+
+func (app *BaseApp) GetWorkingHash() []byte {
 	hash, err := app.cms.GetWorkingHash()
 	if err != nil {
 		// this should never happen
@@ -360,7 +364,8 @@ func (app *BaseApp) Commit(ctx context.Context) (res *abci.ResponseCommit, err e
 	header := app.stateToCommit.ctx.BlockHeader()
 	retainHeight := app.GetBlockRetentionHeight(header.Height)
 
-	app.WriteStateToCommitAndGetWorkingHash()
+	app.WriteState()
+	app.GetWorkingHash()
 	app.cms.Commit(true)
 
 	// Reset the Check state to the latest committed.

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -540,7 +540,8 @@ func (app *SimApp) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlo
 	events = append(events, endBlockResp.Events...)
 
 	app.SetDeliverStateToCommit()
-	appHash := app.WriteStateToCommitAndGetWorkingHash()
+	app.WriteState()
+	appHash := app.GetWorkingHash()
 	return &abci.ResponseFinalizeBlock{
 		Events:    events,
 		TxResults: txResults,

--- a/storev2/commitment/store.go
+++ b/storev2/commitment/store.go
@@ -1,6 +1,7 @@
 package commitment
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -201,6 +202,17 @@ func (st *Store) GetAllKeyStrsInRange(start, end []byte) (res []string) {
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		res = append(res, string(iter.Key()))
+	}
+	return
+}
+
+func (st *Store) GetChangedPairs(prefix []byte) (res []*iavl.KVPair) {
+	// not sure if we can assume pairs are sorted or not, so be conservative
+	// here and iterate through everything
+	for _, p := range st.changeSet.Pairs {
+		if bytes.HasPrefix(p.Key, prefix) {
+			res = append(res, p)
+		}
 	}
 	return
 }


### PR DESCRIPTION
## Describe your changes and provide context
After `Set` is called, we want to be able to read all changed pairs for a given prefix, before the changes are flushed into sc.

## Testing performed to validate your change
light invariance check in sei-chain

