### PR TITLE
Add cosmos events for sending/receiving wei

### DIFF
--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -813,6 +813,83 @@ func (suite *IntegrationTestSuite) TestMsgSendEvents() {
 	suite.Require().Equal(abci.Event(event2), events[9])
 }
 
+func (suite *IntegrationTestSuite) TestMsgSendCoinsAndWeiEvents() {
+	app, ctx := suite.app, suite.ctx
+	addr := sdk.AccAddress([]byte("addr1_______________"))
+	addr2 := sdk.AccAddress([]byte("addr2_______________"))
+	acc := app.AccountKeeper.NewAccountWithAddress(ctx, addr)
+
+	app.AccountKeeper.SetAccount(ctx, acc)
+	newCoins := sdk.NewCoins(sdk.NewInt64Coin(sdk.MustGetBaseDenom(), 50))
+	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(sdk.MustGetBaseDenom(), 40))
+	suite.Require().NoError(simapp.FundAccount(app.BankKeeper, ctx, addr, newCoins))
+
+	ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+	suite.Require().NoError(app.BankKeeper.SendCoinsAndWei(ctx, addr, addr2, sendCoins.AmountOf(sdk.MustGetBaseDenom()), sdk.NewInt(100)))
+	event1 := sdk.Event{
+		Type:       types.EventTypeTransfer,
+		Attributes: []abci.EventAttribute{},
+	}
+	event1.Attributes = append(
+		event1.Attributes,
+		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr2.String())},
+	)
+	event1.Attributes = append(
+		event1.Attributes,
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
+	)
+	event1.Attributes = append(
+		event1.Attributes,
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(sendCoins.String())},
+	)
+
+	event2 := sdk.Event{
+		Type:       sdk.EventTypeMessage,
+		Attributes: []abci.EventAttribute{},
+	}
+	event2.Attributes = append(
+		event2.Attributes,
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
+	)
+
+	weiEvent := sdk.Event{
+		Type:       types.EventTypeWeiSpent,
+		Attributes: []abci.EventAttribute{},
+	}
+
+	weiEvent.Attributes = append(
+		weiEvent.Attributes,
+		abci.EventAttribute{Key: []byte(types.AttributeKeySpender), Value: []byte(addr.String())},
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte("100")},
+	)
+
+	weiEvent2 := sdk.Event{
+		Type:       types.EventTypeWeiReceived,
+		Attributes: []abci.EventAttribute{},
+	}
+
+	weiEvent2.Attributes = append(
+		weiEvent2.Attributes,
+		abci.EventAttribute{Key: []byte(types.AttributeKeyReceiver), Value: []byte(addr2.String())},
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte("100")},
+	)
+
+	// events are shifted due to the funding account events
+	events := ctx.EventManager().ABCIEvents()
+	suite.Require().Equal(6, len(events))
+	suite.Require().Equal(abci.Event(event1), events[4])
+	suite.Require().Equal(abci.Event(event2), events[5])
+	suite.Require().Equal(abci.Event(weiEvent), events[0])
+	suite.Require().Equal(abci.Event(weiEvent2), events[1])
+
+	// verify no wei events are emitted when the amount is zero
+	ctx = ctx.WithEventManager(sdk.NewEventManager())
+	suite.Require().NoError(app.BankKeeper.SendCoinsAndWei(ctx, addr2, addr, sendCoins.AmountOf(sdk.MustGetBaseDenom()), sdk.ZeroInt()))
+	events = ctx.EventManager().ABCIEvents()
+	suite.Require().Equal(4, len(events))
+}
+
 func (suite *IntegrationTestSuite) TestMsgMultiSendEvents() {
 	app, ctx := suite.app, suite.ctx
 

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -875,19 +875,32 @@ func (suite *IntegrationTestSuite) TestMsgSendCoinsAndWeiEvents() {
 		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte("100")},
 	)
 
+	weiTransfer := sdk.Event{
+		Type:       types.EventTypeWeiTransfer,
+		Attributes: []abci.EventAttribute{},
+	}
+
+	weiTransfer.Attributes = append(
+		weiTransfer.Attributes,
+		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr2.String())},
+		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
+		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte("100")},
+	)
+
 	// events are shifted due to the funding account events
 	events := ctx.EventManager().ABCIEvents()
-	suite.Require().Equal(6, len(events))
-	suite.Require().Equal(abci.Event(event1), events[4])
-	suite.Require().Equal(abci.Event(event2), events[5])
+	suite.Require().Equal(7, len(events))
+	suite.Require().Equal(abci.Event(weiTransfer), events[2])
+	suite.Require().Equal(abci.Event(event1), events[5])
+	suite.Require().Equal(abci.Event(event2), events[6])
 	suite.Require().Equal(abci.Event(weiEvent), events[0])
 	suite.Require().Equal(abci.Event(weiEvent2), events[1])
 
-	// verify no wei events are emitted when the amount is zero
+	// verify no wei add and sub events are emitted when the amount is zero
 	ctx = ctx.WithEventManager(sdk.NewEventManager())
 	suite.Require().NoError(app.BankKeeper.SendCoinsAndWei(ctx, addr2, addr, sendCoins.AmountOf(sdk.MustGetBaseDenom()), sdk.ZeroInt()))
 	events = ctx.EventManager().ABCIEvents()
-	suite.Require().Equal(4, len(events))
+	suite.Require().Equal(5, len(events))
 }
 
 func (suite *IntegrationTestSuite) TestMsgMultiSendEvents() {

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -330,10 +330,17 @@ func (k BaseSendKeeper) BlockedAddr(addr sdk.AccAddress) bool {
 	return k.blockedAddrs[addr.String()]
 }
 
-func (k BaseSendKeeper) SubWei(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Int) error {
+func (k BaseSendKeeper) SubWei(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Int) (err error) {
 	if amt.Equal(sdk.ZeroInt()) {
 		return nil
 	}
+	defer func() {
+		if err == nil {
+			ctx.EventManager().EmitEvent(
+				types.NewWeiSpentEvent(addr, amt),
+			)
+		}
+	}()
 	currentWeiBalance := k.GetWeiBalance(ctx, addr)
 	if amt.LTE(currentWeiBalance) {
 		// no need to change usei balance
@@ -352,10 +359,17 @@ func (k BaseSendKeeper) SubWei(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Int
 	return k.setWeiBalance(ctx, addr, weiBalance)
 }
 
-func (k BaseSendKeeper) AddWei(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Int) error {
+func (k BaseSendKeeper) AddWei(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Int) (err error) {
 	if amt.Equal(sdk.ZeroInt()) {
 		return nil
 	}
+	defer func() {
+		if err == nil {
+			ctx.EventManager().EmitEvent(
+				types.NewWeiReceivedEvent(addr, amt),
+			)
+		}
+	}()
 	currentWeiBalance := k.GetWeiBalance(ctx, addr)
 	postWeiBalance := currentWeiBalance.Add(amt)
 	if postWeiBalance.LT(OneUseiInWei) {

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -391,6 +391,14 @@ func (k BaseSendKeeper) SendCoinsAndWei(ctx sdk.Context, from sdk.AccAddress, to
 	if err := k.AddWei(ctx, to, wei); err != nil {
 		return err
 	}
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeWeiTransfer,
+			sdk.NewAttribute(types.AttributeKeyRecipient, to.String()),
+			sdk.NewAttribute(types.AttributeKeySender, from.String()),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, wei.String()),
+		),
+	})
 	if amt.GT(sdk.ZeroInt()) {
 		return k.SendCoinsWithoutAccCreation(ctx, from, to, sdk.NewCoins(sdk.NewCoin(sdk.MustGetBaseDenom(), amt)))
 	}

--- a/x/bank/types/events.go
+++ b/x/bank/types/events.go
@@ -6,7 +6,8 @@ import (
 
 // bank module event types
 const (
-	EventTypeTransfer = "transfer"
+	EventTypeTransfer    = "transfer"
+	EventTypeWeiTransfer = "wei_transfer"
 
 	AttributeKeyRecipient = "recipient"
 	AttributeKeySender    = "sender"

--- a/x/bank/types/events.go
+++ b/x/bank/types/events.go
@@ -16,6 +16,8 @@ const (
 	// supply and balance tracking events name and attributes
 	EventTypeCoinSpent    = "coin_spent"
 	EventTypeCoinReceived = "coin_received"
+	EventTypeWeiSpent     = "wei_spent"
+	EventTypeWeiReceived  = "wei_received"
 	EventTypeCoinMint     = "coinbase" // NOTE(fdymylja): using mint clashes with mint module event
 	EventTypeCoinBurn     = "burn"
 
@@ -40,6 +42,26 @@ func NewCoinSpentEvent(spender sdk.AccAddress, amount sdk.Coins) sdk.Event {
 func NewCoinReceivedEvent(receiver sdk.AccAddress, amount sdk.Coins) sdk.Event {
 	return sdk.NewEvent(
 		EventTypeCoinReceived,
+		sdk.NewAttribute(AttributeKeyReceiver, receiver.String()),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
+	)
+}
+
+// NewWeiSpentEvent constructs a new wei spent sdk.Event
+// nolint: interfacer
+func NewWeiSpentEvent(spender sdk.AccAddress, amount sdk.Int) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeWeiSpent,
+		sdk.NewAttribute(AttributeKeySpender, spender.String()),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
+	)
+}
+
+// NewWeiReceivedEvent constructs a new wei received sdk.Event
+// nolint: interfacer
+func NewWeiReceivedEvent(receiver sdk.AccAddress, amount sdk.Int) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeWeiReceived,
 		sdk.NewAttribute(AttributeKeyReceiver, receiver.String()),
 		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
 	)


### PR DESCRIPTION
## Describe your changes and provide context
This adds events to AddWei and SubWei so that they are also emitted during tx execution so that there doesnt appear to be a disparity between usei spent and received due to wei accounting that occurs during evm transactions

## Testing performed to validate your change
Unit tests, will test on a local chain
