### PR TITLE
Add error for evm revert

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -320,6 +320,12 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTx, tx sdk
 			TxHash:        resCtx.EVMTxHash(),
 			VmError:       result.EvmError,
 		}
+		// TODO: populate error data for EVM err
+		if result.EvmError != "" {
+			evmErr := sdkerrors.Wrap(sdkerrors.ErrEVMVMError, result.EvmError)
+			res.Codespace, res.Code, res.Log = sdkerrors.ABCIInfo(evmErr, app.trace)
+			resultStr = "failed"
+		}
 	}
 	return
 }

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -156,6 +156,9 @@ var (
 	// ErrUnsupportedTxType defines an error for an unsupported transaction type (e.g., EIP-4844 transactions)
 	ErrUnsupportedTxType = Register(RootCodespace, 44, "unsupported transaction type")
 
+	// ErrEVMVMError defines an error for an evm vm error (eg. revert)
+	ErrEVMVMError = Register(RootCodespace, 45, "evm vm error")
+
 	// ErrPanic is only set when we recover from a panic, so we know to
 	// redact potentially sensitive system info
 	ErrPanic = Register(UndefinedCodespace, 111222, "panic")


### PR DESCRIPTION
## Describe your changes and provide context
This adds an error code for evm revert, and updates the tx result with it in the case of evm response containing a VM Error

## Testing performed to validate your change
Tested on local chain