### PR TITLE
Enable swagger endpoint by default

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -259,7 +259,7 @@ func DefaultConfig() *Config {
 		},
 		API: APIConfig{
 			Enable:             false,
-			Swagger:            false,
+			Swagger:            true,
 			Address:            "tcp://0.0.0.0:1317",
 			MaxOpenConnections: 1000,
 			RPCReadTimeout:     10,

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -36,3 +36,8 @@ func TestOCCEnabled(t *testing.T) {
 	cfg.BaseConfig.OccEnabled = true
 	require.True(t, cfg.OccEnabled)
 }
+
+func TestDefaultSwaggerConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	require.True(t, cfg.API.Swagger)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Update default value for `api.swagger` to be `true`. This way new nodes by default will expose `/swagger/` endpoint.

## Testing performed to validate your change
- unit test
- imported the change to `sei-chain` and ran `seid init` to verify `app.toml`

