### PR TITLE
Add public interface for multistore to return earlist version

### DIFF
--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -257,3 +257,8 @@ func (ms multiStore) SetKVStores(handler func(key store.StoreKey, s sdk.KVStore)
 func (ms multiStore) StoreKeys() []sdk.StoreKey {
 	panic("not implemented")
 }
+
+func (ms multiStore) GetEarliestVersion() int64 {
+	//TODO implement me
+	panic("not implemented")
+}

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -241,3 +241,7 @@ func (cms Store) Close() {
 		closer.Close()
 	}
 }
+
+func (cms Store) GetEarliestVersion() int64 {
+	panic("not implemented")
+}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -61,6 +61,7 @@ type Store struct {
 	pruneHeights        []int64
 	initialVersion      int64
 	archivalVersion     int64
+	earliestVersion     int64
 	orphanOpts          *iavltree.Options
 
 	traceWriter       io.Writer
@@ -525,6 +526,9 @@ func (rs *Store) PruneStores(clearStorePruningHeights bool, pruningHeights []int
 				}
 			}
 		}
+	}
+	if len(pruningHeights) > 0 {
+		rs.earliestVersion = pruningHeights[len(pruningHeights)-1]
 	}
 
 	if clearStorePruningHeights {
@@ -1216,4 +1220,8 @@ func (rs *Store) StoreKeys() []types.StoreKey {
 		res = append(res, sk)
 	}
 	return res
+}
+
+func (rs *Store) GetEarliestVersion() int64 {
+	return rs.earliestVersion
 }

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -121,6 +121,9 @@ type MultiStore interface {
 	GetStore(StoreKey) Store
 	GetKVStore(StoreKey) KVStore
 
+	// Get the earliest available version for state store
+	GetEarliestVersion() int64
+
 	// TracingEnabled returns if tracing is enabled for the MultiStore.
 	TracingEnabled() bool
 

--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -854,10 +854,22 @@ func (*Store) SetKVStores(handler func(key types.StoreKey, s types.KVStore) type
 }
 
 // StoreKeys implements types.CommitMultiStore.
-func (s *Store) StoreKeys() []types.StoreKey {
-	res := make([]types.StoreKey, len(s.storeKeys))
-	for _, sk := range s.storeKeys {
+func (rs *Store) StoreKeys() []types.StoreKey {
+	res := make([]types.StoreKey, len(rs.storeKeys))
+	for _, sk := range rs.storeKeys {
 		res = append(res, sk)
 	}
 	return res
+}
+
+func (rs *Store) GetEarliestVersion() int64 {
+	latestVersion := rs.lastCommitInfo.Version
+	if rs.ssStore != nil {
+		version, err := rs.ssStore.GetEarliestVersion()
+		if err != nil {
+			return latestVersion
+		}
+		return version
+	}
+	return latestVersion
 }

--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -862,6 +862,7 @@ func (rs *Store) StoreKeys() []types.StoreKey {
 	return res
 }
 
+// GetEarliestVersion return earliest version for SS or latestVersion if only SC is enabled
 func (rs *Store) GetEarliestVersion() int64 {
 	latestVersion := rs.lastCommitInfo.Version
 	if rs.ssStore != nil {


### PR DESCRIPTION
## Describe your changes and provide context
This PR add a public interface for Multistore to return the earlist available version for state store (historical state). For seidb, if only SC is enabled, then it will assume only latest state is available.

## Testing performed to validate your change

