### PR TITLE
Add recipient checker logics to bank send

### DIFF
--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -159,6 +159,9 @@ var (
 	// ErrEVMVMError defines an error for an evm vm error (eg. revert)
 	ErrEVMVMError = Register(RootCodespace, 45, "evm reverted")
 
+	// ErrInvalidRecipient defines an error for sending to disallowed recipients in bank
+	ErrInvalidRecipient = Register(RootCodespace, 46, "invalid bank recipient")
+
 	// ErrPanic is only set when we recover from a panic, so we know to
 	// redact potentially sensitive system info
 	ErrPanic = Register(UndefinedCodespace, 111222, "panic")


### PR DESCRIPTION
## Describe your changes and provide context
Allow checkers to be registered with bank send keeper so that certain recipients can be blocked. For example, to block a temp address (created by EVM module before address association) from receiving after its main address is associated, one would register a checker as follows:
```
app.BankKeeper.RegisterRecipientChecker(func(ctx sdk.Context, recipient sdk.AccAddress) bool {
    castEvmAddress := common.BytesToAddress(recipient)
    _, isAssociated := app.EvmKeeper.GetSeiAddress(ctx, castEvmAddress)
    return !isAssociated
})
```

## Testing performed to validate your change
unit test
