### PR TITLE
fix: init app earliest version correctly after state sync

### DIFF
--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -765,6 +765,10 @@ loop:
 	if ssImporter != nil {
 		close(ssImporter)
 	}
+	// initialize the earliest version for SS store
+	if rs.ssStore != nil {
+		rs.ssStore.SetEarliestVersion(height)
+	}
 
 	return snapshotItem, restoreErr
 }


### PR DESCRIPTION
## Describe your changes and provide context
init app earliest version correctly after state sync to avoid app earliest version < block earliest version 
## Testing performed to validate your change

