### PR TITLE
return prior to delivertx hooks upon evm err

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -325,6 +325,7 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTx, tx sdk
 			evmErr := sdkerrors.Wrap(sdkerrors.ErrEVMVMError, result.EvmError)
 			res.Codespace, res.Code, res.Log = sdkerrors.ABCIInfo(evmErr, app.trace)
 			resultStr = "failed"
+			return
 		}
 	}
 	for _, hook := range app.deliverTxHooks {


### PR DESCRIPTION
## Describe your changes and provide context
Do we prefer to return early prior to running deliverTx hooks upon encountering an evm tx error?

## Testing performed to validate your change

