### PR TITLE
Refactor DeliverTx hook so that panics can be handled

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -305,7 +305,29 @@ func (app *BaseApp) DeliverTx(ctx sdk.Context, req abci.RequestDeliverTx, tx sdk
 		}
 		return sdkerrors.ResponseDeliverTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, sdk.MarkEventsToIndex(anteEvents, app.indexEvents), app.trace)
 	}
-	res = app.getDeliverTxResponse(resCtx, gInfo, result, &resultStr)
+
+	res = abci.ResponseDeliverTx{
+		GasWanted: int64(gInfo.GasWanted), // TODO: Should type accept unsigned ints?
+		GasUsed:   int64(gInfo.GasUsed),   // TODO: Should type accept unsigned ints?
+		Log:       result.Log,
+		Data:      result.Data,
+		Events:    sdk.MarkEventsToIndex(result.Events, app.indexEvents),
+	}
+	if resCtx.IsEVM() {
+		res.EvmTxInfo = &abci.EvmTxInfo{
+			SenderAddress: resCtx.EVMSenderAddress(),
+			Nonce:         resCtx.EVMNonce(),
+			TxHash:        resCtx.EVMTxHash(),
+			VmError:       result.EvmError,
+		}
+		// TODO: populate error data for EVM err
+		if result.EvmError != "" {
+			evmErr := sdkerrors.Wrap(sdkerrors.ErrEVMVMError, result.EvmError)
+			res.Codespace, res.Code, res.Log = sdkerrors.ABCIInfo(evmErr, app.trace)
+			resultStr = "failed"
+			return
+		}
+	}
 	return
 }
 

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -1676,12 +1676,12 @@ func TestDeliverTxHooks(t *testing.T) {
 	ctx := app.deliverState.ctx
 
 	// register noop hook
-	app.RegisterDeliverTxHook(func(ctx sdk.Context, tx sdk.Tx, b [32]byte, rdt abci.ResponseDeliverTx) {})
+	app.RegisterDeliverTxHook(func(ctx sdk.Context, tx sdk.Tx, b [32]byte, rdt sdk.DeliverTxHookInput) {})
 	res := app.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txBytes}, decoded, sha256.Sum256(txBytes))
 	require.True(t, res.IsOK(), fmt.Sprintf("%v", res))
 
 	// register panic hook (should be captured by recover() middleware)
-	app.RegisterDeliverTxHook(func(ctx sdk.Context, tx sdk.Tx, b [32]byte, rdt abci.ResponseDeliverTx) { panic(1) })
+	app.RegisterDeliverTxHook(func(ctx sdk.Context, tx sdk.Tx, b [32]byte, rdt sdk.DeliverTxHookInput) { panic(1) })
 	require.NotPanics(t, func() {
 		res = app.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txBytes}, decoded, sha256.Sum256(txBytes))
 	})

--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -1646,6 +1646,48 @@ func TestDeliverTx(t *testing.T) {
 	}
 }
 
+func TestDeliverTxHooks(t *testing.T) {
+	anteOpt := func(*BaseApp) {}
+	routerOpt := func(bapp *BaseApp) {
+		r := sdk.NewRoute(routeMsgCounter, func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) { return &sdk.Result{}, nil })
+		bapp.Router().AddRoute(r)
+	}
+
+	app := setupBaseApp(t, anteOpt, routerOpt)
+	app.InitChain(context.Background(), &abci.RequestInitChain{})
+
+	// Create same codec used in txDecoder
+	codec := codec.NewLegacyAmino()
+	registerTestCodec(codec)
+
+	header := tmproto.Header{Height: 1}
+	app.setDeliverState(header)
+	app.BeginBlock(app.deliverState.ctx, abci.RequestBeginBlock{Header: header})
+
+	// every even i is an evm tx
+	counter := int64(1)
+	tx := newTxCounter(counter, counter)
+
+	txBytes, err := codec.Marshal(tx)
+	require.NoError(t, err)
+
+	decoded, _ := app.txDecoder(txBytes)
+
+	ctx := app.deliverState.ctx
+
+	// register noop hook
+	app.RegisterDeliverTxHook(func(ctx sdk.Context, tx sdk.Tx, b [32]byte, rdt abci.ResponseDeliverTx) {})
+	res := app.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txBytes}, decoded, sha256.Sum256(txBytes))
+	require.True(t, res.IsOK(), fmt.Sprintf("%v", res))
+
+	// register panic hook (should be captured by recover() middleware)
+	app.RegisterDeliverTxHook(func(ctx sdk.Context, tx sdk.Tx, b [32]byte, rdt abci.ResponseDeliverTx) { panic(1) })
+	require.NotPanics(t, func() {
+		res = app.DeliverTx(ctx, abci.RequestDeliverTx{Tx: txBytes}, decoded, sha256.Sum256(txBytes))
+	})
+	require.False(t, res.IsOK(), fmt.Sprintf("%v", res))
+}
+
 func TestOptionFunction(t *testing.T) {
 	logger := defaultLogger()
 	db := dbm.NewMemDB()

--- a/types/result.go
+++ b/types/result.go
@@ -263,3 +263,8 @@ func WrapServiceResult(ctx Context, res proto.Message, err error) (*Result, erro
 	}
 	return sdkRes, nil
 }
+
+type DeliverTxHookInput struct {
+	EvmTxInfo *abci.EvmTxInfo
+	Events    []abci.Event
+}


### PR DESCRIPTION
## Describe your changes and provide context
Panics in tx handler is usually handled by a defer statement containing a `recover()` clause. Previously the call stack looks like:
```
func DeliverTx:
    func runTx:
        deferred recover
        (actual processing)
    DeliverTx hook
```
In the above structure, DeliverTx hooks are run on `DeliverTx` level, so they are outside the deferred recover clause which is within `runTx` level.

This PR changes it to be:
```
func DeliverTx:
    func runTx:
        deferred recover
        (actual processing)
        DeliverTx hook
```
so that the hook can be recovered as well

## Testing performed to validate your change
unit test
