### PR TITLE
Flush receipt with the correct state

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -372,7 +372,7 @@ func (app *BaseApp) Commit(ctx context.Context) (res *abci.ResponseCommit, err e
 	retainHeight := app.GetBlockRetentionHeight(header.Height)
 
 	if app.preCommitHandler != nil {
-		if err := app.preCommitHandler(app.deliverState.ctx); err != nil {
+		if err := app.preCommitHandler(app.stateToCommit.ctx); err != nil {
 			panic(fmt.Errorf("error when executing commit handler: %s", err))
 		}
 	}


### PR DESCRIPTION
## Describe your changes and provide context
`stateToCommit` could be either `processProposalState` or `deliverState`, so we should flush to the correct one. This might not be causing issue yet though, since before receipt flush, we'd first write `stateToCommit` to the parent state, so that `deliverState` would fall through to parent which is already updated by `stateToCommit`

## Testing performed to validate your change
existing test

