### PR TITLE
SS Only Write Leaf Nodes

### DIFF
--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -763,7 +763,7 @@ loop:
 			scImporter.AddNode(node)
 
 			// Check if we should also import to SS store
-			if rs.ssStore != nil && ssImporter != nil {
+			if rs.ssStore != nil && node.Height == 0 && ssImporter != nil {
 				ssImporter <- sstypes.SnapshotNode{
 					StoreKey: storeKey,
 					Key:      node.Key,


### PR DESCRIPTION
## Describe your changes and provide context
- Only write iavl leaf nodes to ss during initial sc migration
- This was removed previously incorrectly

## Testing performed to validate your change
- Testing on rpc migration node
