### PR TITLE
Fix Seid Rollback state mismatch error

### DIFF
--- a/server/rollback.go
+++ b/server/rollback.go
@@ -22,7 +22,7 @@ when Tendermint has persisted an incorrect app hash and is thus unable to make
 progress. Rollback overwrites a state at height n with the state at height n - 1.
 The application also roll back to height n - 1. No blocks are removed, so upon
 restarting Tendermint the transactions in block n will be re-executed against the
-application.
+application. If you wanna rollback multiple blocks, please add --hard option.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := GetServerContextFromCmd(cmd)
@@ -54,7 +54,7 @@ application.
 
 			// rollback the app state
 			lastCommit = app.CommitMultiStore().LastCommitID()
-			fmt.Printf("App state height %d and hash %X\n", lastCommit.GetVersion(), lastCommit.GetHash())
+			fmt.Printf("CMS app state height %d and hash %X\n", lastCommit.GetVersion(), lastCommit.GetHash())
 			fmt.Printf("Attempting to rollback app state to height=%d\n", tmHeight)
 			if err := app.CommitMultiStore().RollbackToVersion(tmHeight); err != nil {
 				return fmt.Errorf("failed to rollback to version: %w", err)

--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -519,7 +519,17 @@ func (rs *Store) RollbackToVersion(target int64) error {
 	if target > math.MaxUint32 {
 		return fmt.Errorf("rollback height target %d exceeds max uint32", target)
 	}
-	return rs.scStore.Rollback(target)
+	err := rs.scStore.Rollback(target)
+	if err != nil {
+		return err
+	}
+	// to keep the root hash compatible with cosmos-sdk 0.46
+	if rs.scStore.Version() != 0 {
+		fmt.Printf("Rolled back CMS to version %d\n", rs.scStore.Version())
+		rs.lastCommitInfo = convertCommitInfo(rs.scStore.LastCommitInfo())
+		rs.lastCommitInfo = amendCommitInfo(rs.lastCommitInfo, rs.storesParams)
+	}
+	return nil
 }
 
 // getStoreByName performs a lookup of a StoreKey given a store name typically

--- a/storev2/rootmulti/store.go
+++ b/storev2/rootmulti/store.go
@@ -523,7 +523,7 @@ func (rs *Store) RollbackToVersion(target int64) error {
 	if err != nil {
 		return err
 	}
-	// to keep the root hash compatible with cosmos-sdk 0.46
+	// We need to update the lastCommitInfo after rollback
 	if rs.scStore.Version() != 0 {
 		fmt.Printf("Rolled back CMS to version %d\n", rs.scStore.Version())
 		rs.lastCommitInfo = convertCommitInfo(rs.scStore.LastCommitInfo())


### PR DESCRIPTION
## Describe your changes and provide context
This PR will fix a bug where SeiDB rollback will report errors or failure due to it was using a wrong commitInfo after rollback.

## Testing performed to validate your change
Will fix the errors like this:
```
Rolled back app state to height 118546578 and hash 2338A536D9EA0FAF1D80ADE8569D5340BCF2665C12137974E45B85D32D6F073D
panic: Application state height does not match the tendermint state height

goroutine 1 [running]:
github.com/cosmos/cosmos-sdk/server.NewRollbackCmd.func1(0xc00089fa00?, {0xc000620e20?, 0x0?, 0x1?})
	/root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.3.44/server/rollback.go:68 +0x5ce
github.com/spf13/cobra.(*Command).execute(0xc0001e0000, {0xc000620e00, 0x1, 0x1})
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x87c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000005500)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:961
github.com/cosmos/cosmos-sdk/server/cmd.Execute(0x4d0b068?, {0xc00021c5d0, 0xa})
	/root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.3.44/server/cmd/execute.go:35 +0x145
main.main()
	/home/ubuntu/sei-chain/cmd/seid/main.go:16 +0x2b
```