### PR TITLE
blacklist evm coinbase address from receiving

### DIFF
--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -15,6 +16,8 @@ import (
 const (
 	TokenFactoryPrefix = "factory"
 )
+
+var CoinbaseAddressPrefix = []byte("evm_coinbase")
 
 // SendKeeper defines a module interface that facilitates the transfer of coins
 // between accounts without the possibility of creating coins.
@@ -343,6 +346,11 @@ func (k BaseSendKeeper) IsSendEnabledCoin(ctx sdk.Context, coin sdk.Coin) bool {
 // BlockedAddr checks if a given address is restricted from
 // receiving funds.
 func (k BaseSendKeeper) BlockedAddr(addr sdk.AccAddress) bool {
+	if len(addr) == len(CoinbaseAddressPrefix)+8 {
+		if bytes.Equal(CoinbaseAddressPrefix, addr[:len(CoinbaseAddressPrefix)]) {
+			return true
+		}
+	}
 	return k.blockedAddrs[addr.String()]
 }
 

--- a/x/bank/keeper/send_test.go
+++ b/x/bank/keeper/send_test.go
@@ -1,0 +1,21 @@
+package keeper_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockedAddr(t *testing.T) {
+	k := keeper.NewBaseSendKeeper(nil, nil, nil, paramtypes.Subspace{}, map[string]bool{})
+	txIndexBz := make([]byte, 8)
+	binary.BigEndian.PutUint64(txIndexBz, uint64(5))
+	addr := sdk.AccAddress(append(keeper.CoinbaseAddressPrefix, txIndexBz...))
+	require.True(t, k.BlockedAddr(addr))
+	addr[0] = 'q'
+	require.False(t, k.BlockedAddr(addr))
+}


### PR DESCRIPTION
## Describe your changes and provide context
Disallow EVM transient coinbase addresses (used to enable parallelization) from receiving funds from module account or having vesting accounts.

## Testing performed to validate your change
unit test
