### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/baseapp/deliver_tx_test.go
+++ b/baseapp/deliver_tx_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -1850,13 +1849,9 @@ func setupBaseAppWithSnapshots(t *testing.T, blocks uint, blockTxs int, options 
 
 	snapshotInterval := uint64(2)
 	snapshotTimeout := 1 * time.Minute
-	snapshotDir, err := os.MkdirTemp("", "baseapp")
-	require.NoError(t, err)
+	snapshotDir := t.TempDir()
 	snapshotStore, err := snapshots.NewStore(dbm.NewMemDB(), snapshotDir)
 	require.NoError(t, err)
-	teardown := func() {
-		os.RemoveAll(snapshotDir)
-	}
 
 	app := setupBaseApp(t, append(options,
 		SetSnapshotStore(snapshotStore),
@@ -1909,7 +1904,7 @@ func setupBaseAppWithSnapshots(t *testing.T, blocks uint, blockTxs int, options 
 		}
 	}
 
-	return app, teardown
+	return app, func() {}
 }
 
 func TestMountStores(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir
## Testing performed to validate your change

