### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/gogo/protobuf/jsonpb"


### PR DESCRIPTION
## Describe your changes and provide context

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library

## Testing performed to validate your change

