### PR TITLE
fix: Fix OperationMsg route assignment for non-legacy messages

### DIFF
--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -83,7 +83,7 @@ func NewOperationMsg(msg sdk.Msg, ok bool, comment string, cdc *codec.ProtoCodec
 
 	bz := cdc.MustMarshalJSON(msg)
 
-	return NewOperationMsgBasic(sdk.MsgTypeURL(msg), sdk.MsgTypeURL(msg), comment, ok, bz)
+	return NewOperationMsgBasic("", sdk.MsgTypeURL(msg), comment, ok, bz)
 
 }
 


### PR DESCRIPTION
## Describe your changes and provide context

This commit corrects the parameter assignment in NewOperationMsg when handling non-legacy messages. Previously both Route and Name fields were populated with the message type URL, which might lead to confusion. Now Route is explicitly set to empty string for non-legacy messages while Name retains the message type URL, better reflecting their intended purposes:

- Route: Only populated for legacy messages (via LegacyMsg interface)
- Name: Always uses the message type URL regardless of message type

This maintains backward compatibility with legacy messages while establishing clearer field semantics for new message types.



## Testing performed to validate your change

