### PR TITLE
Fix quadratic balance query

### DIFF
--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -1939,6 +1939,21 @@ func (suite *IntegrationTestSuite) TestMintCoinRestrictions() {
 	}
 }
 
+func (suite *IntegrationTestSuite) TestKeeperGetAllBalances(t *testing.T) {
+	app, ctx := suite.app, suite.ctx
+	addr := sdk.AccAddress([]byte("addr1_______________"))
+	for i := 0; i < 1000000; i++ {
+		app.BankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.Coin{
+			Denom: fmt.Sprintf("d%d", i), Amount: sdk.OneInt(),
+		}}, false)
+	}
+	balances := app.BankKeeper.GetAllBalances(ctx, addr)
+	for i := 0; i < 1000000; i++ {
+		suite.Require().Equal(t, fmt.Sprintf("d%d", i), balances[i].Denom)
+		suite.Require().Equal(t, sdk.OneInt(), balances[i].Amount)
+	}
+}
+
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
 }

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -1939,18 +1939,24 @@ func (suite *IntegrationTestSuite) TestMintCoinRestrictions() {
 	}
 }
 
-func (suite *IntegrationTestSuite) TestKeeperGetAllBalances(t *testing.T) {
+func (suite *IntegrationTestSuite) TestKeeperGetAllBalances() {
 	app, ctx := suite.app, suite.ctx
 	addr := sdk.AccAddress([]byte("addr1_______________"))
-	for i := 0; i < 1000000; i++ {
+	cnt := 1000000
+	allDenoms := make(sdk.Coins, cnt)
+	for i := 0; i < cnt; i++ {
+		d := fmt.Sprintf("d%d", i+10) // denom must be at least 3 chars.
 		app.BankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.Coin{
-			Denom: fmt.Sprintf("d%d", i), Amount: sdk.OneInt(),
+			Denom: d, Amount: sdk.OneInt(),
 		}}, false)
+		allDenoms[i] = sdk.Coin{Denom: d}
 	}
+	allDenoms = allDenoms.Sort()
 	balances := app.BankKeeper.GetAllBalances(ctx, addr)
-	for i := 0; i < 1000000; i++ {
-		suite.Require().Equal(t, fmt.Sprintf("d%d", i), balances[i].Denom)
-		suite.Require().Equal(t, sdk.OneInt(), balances[i].Amount)
+	suite.Require().Len(balances, cnt)
+	for i := 0; i < cnt; i++ {
+		suite.Require().Equal(allDenoms[i].Denom, balances[i].Denom)
+		suite.Require().Equal(sdk.OneInt(), balances[i].Amount)
 	}
 }
 

--- a/x/bank/keeper/view.go
+++ b/x/bank/keeper/view.go
@@ -64,7 +64,7 @@ func (k BaseViewKeeper) HasBalance(ctx sdk.Context, addr sdk.AccAddress, amt sdk
 func (k BaseViewKeeper) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
 	balances := sdk.NewCoins()
 	k.IterateAccountBalances(ctx, addr, func(balance sdk.Coin) bool {
-		balances = balances.Add(balance)
+		balances = append(balances, balance)
 		return false
 	})
 


### PR DESCRIPTION
## Describe your changes and provide context
Previously `GetAllBalances` would perform slice copy operation for each iterator `Next` call due to how `Coin::Add` is implemented. The reason for the copy is because `Coin:Add` needs to sort the resulting slice. However this is unnecessary because at the end of `GetAllBalances` the slice would sorted again anyway. This PR changes the iterator operation to be a simple append, so that the total time complexity would be O(n) instead of O(n^2)

## Testing performed to validate your change
unit test

