### PR TITLE
do not set ginfo if antehandler returns an error

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -968,12 +968,12 @@ func (app *BaseApp) runTx(ctx sdk.Context, mode runTxMode, tx sdk.Tx, checksum [
 
 		events := ctx.EventManager().Events()
 
-		// GasMeter expected to be set in AnteHandler
-		gasWanted = ctx.GasMeter().Limit()
-		gasEstimate = ctx.GasEstimate()
 		if err != nil {
 			return gInfo, nil, nil, 0, nil, nil, ctx, err
 		}
+		// GasMeter expected to be set in AnteHandler
+		gasWanted = ctx.GasMeter().Limit()
+		gasEstimate = ctx.GasEstimate()
 
 		// Dont need to validate in checkTx mode
 		if ctx.MsgValidator() != nil && mode == runTxModeDeliver {


### PR DESCRIPTION
## Describe your changes and provide context
There is no guarantee that gasLimit/gasUsed would be set correctly in the case of an antehandler error (e.g. gasless txs would have its gas limit set to 0 if antehandler runs without error, but not if antehandler errors out before the overwrite)
## Testing performed to validate your change
local sei
