### PR TITLE
skip upgrade BeginBlock for EVM tracer

### DIFF
--- a/x/upgrade/abci.go
+++ b/x/upgrade/abci.go
@@ -21,6 +21,9 @@ import (
 // a migration to be executed if needed upon this switch (migration defined in the new binary)
 // skipUpgradeHeightArray is a set of block heights for which the upgrade must be skipped
 func BeginBlocker(k keeper.Keeper, ctx sdk.Context, _ abci.RequestBeginBlock) {
+	if ctx.IsTracing() {
+		return
+	}
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 
 	plan, planFound := k.GetUpgradePlan(ctx)


### PR DESCRIPTION
## Describe your changes and provide context
We do not need to/cannot/ change binary during a tracer call

## Testing performed to validate your change
patched on archive node
