### PR TITLE
refactor: use strings.builder

### DIFF
--- a/client/cmd.go
+++ b/client/cmd.go
@@ -62,16 +62,17 @@ func ValidateCmd(cmd *cobra.Command, args []string) error {
 
 	// return the help screen if no unknown command is found
 	if unknownCmd != "" {
-		err := fmt.Sprintf("unknown command \"%s\" for \"%s\"", unknownCmd, cmd.CalledAs())
+		var err strings.Builder
+		err.WriteString(fmt.Sprintf("unknown command \"%s\" for \"%s\"", unknownCmd, cmd.CalledAs()))
 
 		// build suggestions for unknown argument
 		if suggestions := cmd.SuggestionsFor(unknownCmd); len(suggestions) > 0 {
-			err += "\n\nDid you mean this?\n"
+			err.WriteString("\n\nDid you mean this?\n")
 			for _, s := range suggestions {
-				err += fmt.Sprintf("\t%v\n", s)
+				err.WriteString(fmt.Sprintf("\t%v\n", s))
 			}
 		}
-		return errors.New(err)
+		return errors.New(err.String())
 	}
 
 	return cmd.Help()

--- a/crypto/types/compact_bit_array.go
+++ b/crypto/types/compact_bit_array.go
@@ -180,19 +180,20 @@ func (bA *CompactBitArray) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	bits := `"`
+	var bits strings.Builder
+	bits.WriteString(`"`)
 	size := bA.Count()
 	for i := 0; i < size; i++ {
 		if bA.GetIndex(i) {
-			bits += `x`
+			bits.WriteString(`x`)
 		} else {
-			bits += `_`
+			bits.WriteString(`_`)
 		}
 	}
 
-	bits += `"`
+	bits.WriteString(`"`)
 
-	return []byte(bits), nil
+	return []byte(bits.String()), nil
 }
 
 var bitArrayJSONRegexp = regexp.MustCompile(`\A"([_x]*)"\z`)

--- a/x/distribution/types/query.go
+++ b/x/distribution/types/query.go
@@ -21,18 +21,20 @@ func NewQueryDelegatorTotalRewardsResponse(rewards []DelegationDelegatorReward,
 }
 
 func (res QueryDelegatorTotalRewardsResponse) String() string {
-	out := "Delegator Total Rewards:\n"
-	out += "  Rewards:"
+	var out strings.Builder
+	out.WriteString("Delegator Total Rewards:\n")
+	out.WriteString("  Rewards:")
 	for _, reward := range res.Rewards {
-		out += fmt.Sprintf(`  
+		out.WriteString(fmt.Sprintf(`  
 	ValidatorAddress: %s
-	Reward: %s`, reward.ValidatorAddress, reward.Reward)
+	Reward: %s`, reward.ValidatorAddress, reward.Reward))
 	}
-	out += fmt.Sprintf("\n  Total: %s\n", res.Total)
-	return strings.TrimSpace(out)
+	out.WriteString(fmt.Sprintf("\n  Total: %s\n", res.Total))
+	return strings.TrimSpace(out.String())
 }
 
 // NewDelegationDelegatorReward constructs a DelegationDelegatorReward.
+//
 //nolint:interfacer
 func NewDelegationDelegatorReward(valAddr sdk.ValAddress,
 	reward sdk.DecCoins) DelegationDelegatorReward {

--- a/x/distribution/types/validator.go
+++ b/x/distribution/types/validator.go
@@ -37,12 +37,13 @@ func NewValidatorSlashEvent(validatorPeriod uint64, fraction sdk.Dec) ValidatorS
 }
 
 func (vs ValidatorSlashEvents) String() string {
-	out := "Validator Slash Events:\n"
+	var out strings.Builder
+	out.WriteString("Validator Slash Events:\n")
 	for i, sl := range vs.ValidatorSlashEvents {
-		out += fmt.Sprintf(`  Slash %d:
+		out.WriteString(fmt.Sprintf(`  Slash %d:
     Period:   %d
     Fraction: %s
-`, i, sl.ValidatorPeriod, sl.Fraction)
+`, i, sl.ValidatorPeriod, sl.Fraction))
 	}
-	return strings.TrimSpace(out)
+	return strings.TrimSpace(out.String())
 }

--- a/x/gov/types/deposit.go
+++ b/x/gov/types/deposit.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -9,6 +10,7 @@ import (
 )
 
 // NewDeposit creates a new Deposit instance
+//
 //nolint:interfacer
 func NewDeposit(proposalID uint64, depositor sdk.AccAddress, amount sdk.Coins) Deposit {
 	return Deposit{proposalID, depositor.String(), amount}
@@ -41,11 +43,12 @@ func (d Deposits) String() string {
 	if len(d) == 0 {
 		return "[]"
 	}
-	out := fmt.Sprintf("Deposits for Proposal %d:", d[0].ProposalId)
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("Deposits for Proposal %d:", d[0].ProposalId))
 	for _, dep := range d {
-		out += fmt.Sprintf("\n  %s: %s", dep.Depositor, dep.Amount)
+		out.WriteString(fmt.Sprintf("\n  %s: %s", dep.Depositor, dep.Amount))
 	}
-	return out
+	return out.String()
 }
 
 // Empty returns whether a deposit is empty.

--- a/x/gov/types/proposal.go
+++ b/x/gov/types/proposal.go
@@ -109,13 +109,14 @@ func (p Proposals) Equal(other Proposals) bool {
 
 // String implements stringer interface
 func (p Proposals) String() string {
-	out := "ID - (Status) [Type] Title\n"
+	var out strings.Builder
+	out.WriteString("ID - (Status) [Type] Title\n")
 	for _, prop := range p {
-		out += fmt.Sprintf("%d - (%s) [%s] %s\n",
+		out.WriteString(fmt.Sprintf("%d - (%s) [%s] %s\n",
 			prop.ProposalId, prop.Status,
-			prop.ProposalType(), prop.GetTitle())
+			prop.ProposalType(), prop.GetTitle()))
 	}
-	return strings.TrimSpace(out)
+	return strings.TrimSpace(out.String())
 }
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces

--- a/x/gov/types/vote.go
+++ b/x/gov/types/vote.go
@@ -11,6 +11,7 @@ import (
 )
 
 // NewVote creates a new Vote instance
+//
 //nolint:interfacer
 func NewVote(proposalID uint64, voter sdk.AccAddress, options WeightedVoteOptions) Vote {
 	return Vote{ProposalId: proposalID, Voter: voter.String(), Options: options}
@@ -43,11 +44,12 @@ func (v Votes) String() string {
 	if len(v) == 0 {
 		return "[]"
 	}
-	out := fmt.Sprintf("Votes for Proposal %d:", v[0].ProposalId)
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("Votes for Proposal %d:", v[0].ProposalId))
 	for _, vot := range v {
-		out += fmt.Sprintf("\n  %s: %s", vot.Voter, vot.Options)
+		out.WriteString(fmt.Sprintf("\n  %s: %s", vot.Voter, vot.Options))
 	}
-	return out
+	return out.String()
 }
 
 // Empty returns whether a vote is empty.

--- a/x/staking/keeper/invariants.go
+++ b/x/staking/keeper/invariants.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -94,7 +95,7 @@ func ModuleAccountInvariants(k Keeper) sdk.Invariant {
 func NonNegativePowerInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var (
-			msg    string
+			msg    strings.Builder
 			broken bool
 		)
 
@@ -110,18 +111,18 @@ func NonNegativePowerInvariant(k Keeper) sdk.Invariant {
 
 			if !bytes.Equal(iterator.Key(), powerKey) {
 				broken = true
-				msg += fmt.Sprintf("power store invariance:\n\tvalidator.Power: %v"+
+				msg.WriteString(fmt.Sprintf("power store invariance:\n\tvalidator.Power: %v"+
 					"\n\tkey should be: %v\n\tkey in store: %v\n",
-					validator.GetConsensusPower(k.PowerReduction(ctx)), powerKey, iterator.Key())
+					validator.GetConsensusPower(k.PowerReduction(ctx)), powerKey, iterator.Key()))
 			}
 
 			if validator.Tokens.IsNegative() {
 				broken = true
-				msg += fmt.Sprintf("\tnegative tokens for validator: %v\n", validator)
+				msg.WriteString(fmt.Sprintf("\tnegative tokens for validator: %v\n", validator))
 			}
 		}
 
-		return sdk.FormatInvariant(types.ModuleName, "nonnegative power", fmt.Sprintf("found invalid validator powers\n%s", msg)), broken
+		return sdk.FormatInvariant(types.ModuleName, "nonnegative power", fmt.Sprintf("found invalid validator powers\n%s", msg.String())), broken
 	}
 }
 
@@ -129,7 +130,7 @@ func NonNegativePowerInvariant(k Keeper) sdk.Invariant {
 func PositiveDelegationInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var (
-			msg   string
+			msg   strings.Builder
 			count int
 		)
 
@@ -138,20 +139,20 @@ func PositiveDelegationInvariant(k Keeper) sdk.Invariant {
 			if delegation.Shares.IsNegative() {
 				count++
 
-				msg += fmt.Sprintf("\tdelegation with negative shares: %+v\n", delegation)
+				msg.WriteString(fmt.Sprintf("\tdelegation with negative shares: %+v\n", delegation))
 			}
 
 			if delegation.Shares.IsZero() {
 				count++
 
-				msg += fmt.Sprintf("\tdelegation with zero shares: %+v\n", delegation)
+				msg.WriteString(fmt.Sprintf("\tdelegation with zero shares: %+v\n", delegation))
 			}
 		}
 
 		broken := count != 0
 
 		return sdk.FormatInvariant(types.ModuleName, "positive delegations", fmt.Sprintf(
-			"%d invalid delegations found\n%s", count, msg)), broken
+			"%d invalid delegations found\n%s", count, msg.String())), broken
 	}
 }
 
@@ -161,7 +162,7 @@ func PositiveDelegationInvariant(k Keeper) sdk.Invariant {
 func DelegatorSharesInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var (
-			msg    string
+			msg    strings.Builder
 			broken bool
 		)
 
@@ -187,12 +188,12 @@ func DelegatorSharesInvariant(k Keeper) sdk.Invariant {
 			calculatedValTotalDelShares := validatorsDelegationShares[validator.GetOperator().String()]
 			if !calculatedValTotalDelShares.Equal(expValTotalDelShares) {
 				broken = true
-				msg += fmt.Sprintf("broken delegator shares invariance:\n"+
+				msg.WriteString(fmt.Sprintf("broken delegator shares invariance:\n"+
 					"\tvalidator.DelegatorShares: %v\n"+
-					"\tsum of Delegator.Shares: %v\n", expValTotalDelShares, calculatedValTotalDelShares)
+					"\tsum of Delegator.Shares: %v\n", expValTotalDelShares, calculatedValTotalDelShares))
 			}
 		}
 
-		return sdk.FormatInvariant(types.ModuleName, "delegator shares", msg), broken
+		return sdk.FormatInvariant(types.ModuleName, "delegator shares", msg.String()), broken
 	}
 }

--- a/x/staking/legacy/v040/types.go
+++ b/x/staking/legacy/v040/types.go
@@ -105,19 +105,20 @@ func (e UnbondingDelegationEntry) String() string {
 
 // String returns a human readable string representation of an UnbondingDelegation.
 func (ubd UnbondingDelegation) String() string {
-	out := fmt.Sprintf(`Unbonding Delegations between:
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(`Unbonding Delegations between:
   Delegator:                 %s
   Validator:                 %s
-	Entries:`, ubd.DelegatorAddress, ubd.ValidatorAddress)
+	Entries:`, ubd.DelegatorAddress, ubd.ValidatorAddress))
 	for i, entry := range ubd.Entries {
-		out += fmt.Sprintf(`    Unbonding Delegation %d:
+		out.WriteString(fmt.Sprintf(`    Unbonding Delegation %d:
       Creation Height:           %v
       Min time to unbond (unix): %v
       Expected balance:          %s`, i, entry.CreationHeight,
-			entry.CompletionTime, entry.Balance)
+			entry.CompletionTime, entry.Balance))
 	}
 
-	return out
+	return out.String()
 }
 
 // UnbondingDelegations is a collection of UnbondingDelegation
@@ -139,26 +140,27 @@ func (e RedelegationEntry) String() string {
 
 // String returns a human readable string representation of a Redelegation.
 func (red Redelegation) String() string {
-	out := fmt.Sprintf(`Redelegations between:
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(`Redelegations between:
   Delegator:                 %s
   Source Validator:          %s
   Destination Validator:     %s
   Entries:
 `,
 		red.DelegatorAddress, red.ValidatorSrcAddress, red.ValidatorDstAddress,
-	)
+	))
 
 	for i, entry := range red.Entries {
-		out += fmt.Sprintf(`    Redelegation Entry #%d:
+		out.WriteString(fmt.Sprintf(`    Redelegation Entry #%d:
       Creation height:           %v
       Min time to unbond (unix): %v
       Dest Shares:               %s
 `,
 			i, entry.CreationHeight, entry.CompletionTime, entry.SharesDst,
-		)
+		))
 	}
 
-	return strings.TrimRight(out, "\n")
+	return strings.TrimRight(out.String(), "\n")
 }
 
 // Redelegations are a collection of Redelegation

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -28,6 +28,7 @@ func (dvv DVVTriplet) String() string {
 }
 
 // NewDelegation creates a new delegation object
+//
 //nolint:interfacer
 func NewDelegation(delegatorAddr sdk.AccAddress, validatorAddr sdk.ValAddress, shares sdk.Dec) Delegation {
 	return Delegation{
@@ -111,6 +112,7 @@ func (e UnbondingDelegationEntry) IsMature(currentTime time.Time) bool {
 }
 
 // NewUnbondingDelegation - create a new unbonding delegation object
+//
 //nolint:interfacer
 func NewUnbondingDelegation(
 	delegatorAddr sdk.AccAddress, validatorAddr sdk.ValAddress,
@@ -159,19 +161,20 @@ func UnmarshalUBD(cdc codec.BinaryCodec, value []byte) (ubd UnbondingDelegation,
 
 // String returns a human readable string representation of an UnbondingDelegation.
 func (ubd UnbondingDelegation) String() string {
-	out := fmt.Sprintf(`Unbonding Delegations between:
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(`Unbonding Delegations between:
   Delegator:                 %s
   Validator:                 %s
-	Entries:`, ubd.DelegatorAddress, ubd.ValidatorAddress)
+	Entries:`, ubd.DelegatorAddress, ubd.ValidatorAddress))
 	for i, entry := range ubd.Entries {
-		out += fmt.Sprintf(`    Unbonding Delegation %d:
+		out.WriteString(fmt.Sprintf(`    Unbonding Delegation %d:
       Creation Height:           %v
       Min time to unbond (unix): %v
       Expected balance:          %s`, i, entry.CreationHeight,
-			entry.CompletionTime, entry.Balance)
+			entry.CompletionTime, entry.Balance))
 	}
 
-	return out
+	return out.String()
 }
 
 // UnbondingDelegations is a collection of UnbondingDelegation
@@ -254,26 +257,27 @@ func UnmarshalRED(cdc codec.BinaryCodec, value []byte) (red Redelegation, err er
 
 // String returns a human readable string representation of a Redelegation.
 func (red Redelegation) String() string {
-	out := fmt.Sprintf(`Redelegations between:
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(`Redelegations between:
   Delegator:                 %s
   Source Validator:          %s
   Destination Validator:     %s
   Entries:
 `,
 		red.DelegatorAddress, red.ValidatorSrcAddress, red.ValidatorDstAddress,
-	)
+	))
 
 	for i, entry := range red.Entries {
-		out += fmt.Sprintf(`    Redelegation Entry #%d:
+		out.WriteString(fmt.Sprintf(`    Redelegation Entry #%d:
       Creation height:           %v
       Min time to unbond (unix): %v
       Dest Shares:               %s
 `,
 			i, entry.CreationHeight, entry.CompletionTime, entry.SharesDst,
-		)
+		))
 	}
 
-	return strings.TrimRight(out, "\n")
+	return strings.TrimRight(out.String(), "\n")
 }
 
 // Redelegations are a collection of Redelegation
@@ -332,6 +336,7 @@ func (d DelegationResponses) String() (out string) {
 }
 
 // NewRedelegationResponse crates a new RedelegationEntryResponse instance.
+//
 //nolint:interfacer
 func NewRedelegationResponse(
 	delegatorAddr sdk.AccAddress, validatorSrc, validatorDst sdk.ValAddress, entries []RedelegationEntryResponse,


### PR DESCRIPTION
## Describe your changes and provide context

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)


## Testing performed to validate your change

