### PR TITLE
Manually replace file versions in stack trace wrapping

### DIFF
--- a/types/errors/stacktrace.go
+++ b/types/errors/stacktrace.go
@@ -73,14 +73,26 @@ func writeSimpleFrame(s io.Writer, f errors.Frame) {
 	if len(chunks) == 2 {
 		file = chunks[1]
 	}
+	// replace specific file versions in stack trace
+	file = replaceWasmdVersionStr(file)
+	file = replaceSeiCosmosVersionStr(file)
 	fmt.Fprintf(s, " [%s:%d]", file, line)
+}
+
+func replaceWasmdVersionStr(err string) string {
+	return strings.Replace(err, "sei-wasmd@v0.3.11", "sei-wasmd@v0.3.10", 1)
+}
+
+func replaceSeiCosmosVersionStr(err string) string {
+	return strings.Replace(err, "sei-cosmos@v0.3.67", "sei-cosmos@v0.3.66", 1)
 }
 
 // Format works like pkg/errors, with additions.
 // %s is just the error message
 // %+v is the full stack trace
 // %v appends a compressed [filename:line] where the error
-//    was created
+//
+//	was created
 //
 // Inspired by https://github.com/pkg/errors/blob/v0.8.1/errors.go#L162-L176
 func (e *wrappedError) Format(s fmt.State, verb rune) {

--- a/types/errors/stacktrace.go
+++ b/types/errors/stacktrace.go
@@ -74,17 +74,16 @@ func writeSimpleFrame(s io.Writer, f errors.Frame) {
 		file = chunks[1]
 	}
 	// replace specific file versions in stack trace
-	file = replaceWasmdVersionStr(file)
-	file = replaceSeiCosmosVersionStr(file)
+	file = replacePackageVersionStr(file)
 	fmt.Fprintf(s, " [%s:%d]", file, line)
 }
 
-func replaceWasmdVersionStr(err string) string {
-	return strings.Replace(err, "sei-wasmd@v0.3.11", "sei-wasmd@v0.3.10", 1)
-}
-
-func replaceSeiCosmosVersionStr(err string) string {
-	return strings.Replace(err, "sei-cosmos@v0.3.67", "sei-cosmos@v0.3.66", 1)
+func replacePackageVersionStr(err string) string {
+	err = strings.Replace(err, "sei-wasmd@v0.3.11", "sei-wasmd@v0.3.10", 1)
+	err = strings.Replace(err, "CosmWasm/wasmd@v0.27.0", "sei-protocol/sei-wasmd@v0.3.10", 1)
+	err = strings.Replace(err, "sei-cosmos@v0.3.67", "sei-cosmos@v0.3.66", 1)
+	err = strings.Replace(err, "sei-cosmos@v0.3.68", "sei-cosmos@v0.3.66", 1)
+	return err
 }
 
 // Format works like pkg/errors, with additions.

--- a/types/errors/stacktrace_test.go
+++ b/types/errors/stacktrace_test.go
@@ -64,13 +64,23 @@ func (s *errorsTestSuite) TestStackTrace() {
 func (s *errorsTestSuite) TestReplaceWasmdVersionStr() {
 	input := "sei-wasmd@v0.3.11/some/path/file.go"
 	expected := "sei-wasmd@v0.3.10/some/path/file.go"
-	result := replaceWasmdVersionStr(input)
+	result := replacePackageVersionStr(input)
+	s.Require().Equal(expected, result)
+
+	input = "CosmWasm/wasmd@v0.27.0/some/path/file.go"
+	expected = "sei-protocol/sei-wasmd@v0.3.10/some/path/file.go"
+	result = replacePackageVersionStr(input)
 	s.Require().Equal(expected, result)
 }
 
 func (s *errorsTestSuite) TestReplaceSeiCosmosVersionStr() {
 	input := "sei-cosmos@v0.3.67/some/path/file.go"
 	expected := "sei-cosmos@v0.3.66/some/path/file.go"
-	result := replaceSeiCosmosVersionStr(input)
+	result := replacePackageVersionStr(input)
+	s.Require().Equal(expected, result)
+
+	input = "sei-cosmos@v0.3.68/some/path/file.go"
+	expected = "sei-cosmos@v0.3.66/some/path/file.go"
+	result = replacePackageVersionStr(input)
 	s.Require().Equal(expected, result)
 }

--- a/types/errors/stacktrace_test.go
+++ b/types/errors/stacktrace_test.go
@@ -39,7 +39,7 @@ func (s *errorsTestSuite) TestStackTrace() {
 	const thisTestSrc = "types/errors/stacktrace_test.go"
 
 	for _, tc := range cases {
-		s.Require().True(reflect.DeepEqual(tc.err.Error(), tc.wantError), tc.err.Error(), tc.wantError)
+		s.Require().True(reflect.DeepEqual(tc.err.Error(), tc.wantError))
 		s.Require().NotNil(stackTrace(tc.err))
 		fullStack := fmt.Sprintf("%+v", tc.err)
 		s.Require().True(strings.Contains(fullStack, thisTestSrc))

--- a/types/errors/stacktrace_test.go
+++ b/types/errors/stacktrace_test.go
@@ -39,7 +39,7 @@ func (s *errorsTestSuite) TestStackTrace() {
 	const thisTestSrc = "types/errors/stacktrace_test.go"
 
 	for _, tc := range cases {
-		s.Require().True(reflect.DeepEqual(tc.err.Error(), tc.wantError))
+		s.Require().True(reflect.DeepEqual(tc.err.Error(), tc.wantError), tc.err.Error(), tc.wantError)
 		s.Require().NotNil(stackTrace(tc.err))
 		fullStack := fmt.Sprintf("%+v", tc.err)
 		s.Require().True(strings.Contains(fullStack, thisTestSrc))
@@ -59,4 +59,18 @@ func (s *errorsTestSuite) TestStackTrace() {
 		// be here, not the Wrap() function
 		s.Require().True(strings.Contains(tinyStack, thisTestSrc))
 	}
+}
+
+func (s *errorsTestSuite) TestReplaceWasmdVersionStr() {
+	input := "sei-wasmd@v0.3.11/some/path/file.go"
+	expected := "sei-wasmd@v0.3.10/some/path/file.go"
+	result := replaceWasmdVersionStr(input)
+	s.Require().Equal(expected, result)
+}
+
+func (s *errorsTestSuite) TestReplaceSeiCosmosVersionStr() {
+	input := "sei-cosmos@v0.3.67/some/path/file.go"
+	expected := "sei-cosmos@v0.3.66/some/path/file.go"
+	result := replaceSeiCosmosVersionStr(input)
+	s.Require().Equal(expected, result)
 }


### PR DESCRIPTION
## Describe your changes and provide context
Replaces specific package versions when wrapping stack trace for errors

## Testing performed to validate your change
Unit tests

